### PR TITLE
Expand SQL coverage: WHERE operators, CASE, window functions, CTEs, derived tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,25 +513,43 @@ this.**
 | Trailing semicolon | `select id from users;` |
 | Typed parameters | `where id = $1` → `query(sql, id: number)` |
 | Strict mode | `{ strict: true }` → unknown column becomes a `QueryTypeError` |
+| `WHERE` operators | `=`, `<>`, comparisons, `LIKE`/`ILIKE`, `IN (...)`, `BETWEEN ... AND ...`, `IS [NOT] NULL`, `AND`/`OR` |
+| `GROUP BY` / `HAVING` / `ORDER BY` / `LIMIT` / `OFFSET` | parsed and skipped; output shape follows the `SELECT` list, `HAVING`/`LIMIT`/`OFFSET` placeholders are typed |
+| `UNION` / `UNION ALL` | result shape is inferred from the first branch |
+| `CASE WHEN ... THEN ... [ELSE ...] END` | branch types are unioned (`\| null` added when there is no `ELSE`) |
+| Window functions | `row_number() over (partition by ... order by ...)`, `rank()`, `dense_rank()`, etc. |
+| CTEs (`WITH ... AS (...)`) | later CTEs may reference earlier ones; works with strict mode |
+| Derived tables | `from (select ...) x`, including subqueries with their own `WHERE`/`JOIN` |
 
 ## Limitations
 
 This is a focused tool for the common read path, not a full SQL grammar:
 
-- **No subqueries or CTEs yet.** Derived tables (`from (select ...) x`) and
-  `WITH ... AS (...)` are not parsed.
+- **Scalar subqueries are not typed.** A subquery used as a value inside the
+  `SELECT` list or `WHERE` (`select (select count(*) from posts) from users`)
+  resolves to `unknown`. Only `WITH` CTEs and derived tables in `FROM` are
+  parsed.
+- **`CASE` does not support nested `CASE`.** The parser looks for the first
+  top-level `END`; a `CASE` nested inside another `CASE`'s branch is not
+  supported.
+- **Window `OVER (...)` clauses are only used as a boundary**, not parsed for
+  their own typing — `PARTITION BY`/`ORDER BY` content inside `OVER (...)` is
+  discarded, not validated.
 - **Function arguments must not contain spaces.** `count(*)`, `lower(name)`,
   `sum(price)` work; `count(distinct id)` and `concat(a, b)` (space after the
   comma) do not.
 - **Aggregates assume numeric output.** `min`/`max` resolve to `number` even
-  over a text column; unrecognized functions resolve to `unknown`.
+  over a text column; unrecognized functions resolve to `unknown`. `lag`,
+  `lead`, `first_value`, `last_value`, `nth_value` resolve to `unknown` (their
+  real type depends on the argument, which isn't inspected).
 - **`select *` across a join merges columns by name.** When two tables share a
   column name (e.g. both have `id`), the types are intersected rather than kept
   separate. Alias the columns to keep them distinct.
 - **Typed parameters need spaced operators.** `where id = $1` is typed;
-  `where id=$1` is not. `IN (...)` lists and parameters inside `INSERT ...
-  VALUES` are not typed (they fall back to a flexible `unknown[]`). Numbered
-  placeholders are assumed to appear in ascending order (`$1`, `$2`, ...).
+  `where id=$1` is not. Parameters inside `INSERT ... VALUES` are not typed
+  (they fall back to a flexible `unknown[]`), and parameters inside a `WITH`
+  query's own CTE bodies are not typed either. Numbered placeholders are
+  assumed to appear in ascending order (`$1`, `$2`, ...).
 - **Quoted identifiers** use `"..."` (standard) or `[...]` (SQL Server);
   MySQL backticks are not supported. Schema-qualified tables (`public.users`)
   resolve by their final segment (`users`).
@@ -553,10 +571,9 @@ your normal type check. Nothing is generated and nothing is written to disk.
 variable instead of a string literal, or it selects a column/table not in your
 schema. Inline the literal and check the schema.
 
-**How do I handle a `JOIN` today?** Write the SQL as usual and annotate the
-result type yourself with `Query<...>` for the parts that are inferable, or fall
-back to a hand-written row type for that one query. JOIN inference is on the
-roadmap.
+**How do I handle a `JOIN`?** `JOIN` is inferred natively — see
+[section 9](#9-joins). `INNER`/`LEFT`/`RIGHT`/`FULL`/`CROSS` are all
+supported, including nullability of the outer-joined side.
 
 **Why a `Result` instead of throwing?** Database calls are expected to fail
 sometimes; modelling that as a value (rather than an exception) forces callers

--- a/src/case.ts
+++ b/src/case.ts
@@ -1,0 +1,96 @@
+import type { Trim, FirstWord, DropFirstWord, IsKeyword, Unquote } from './string.js';
+import type { SchemaLike, Source, ResolveColumnType } from './parse.js';
+
+export type IsCaseExpression<Expr extends string> = IsKeyword<FirstWord<Trim<Expr>>, 'case'>;
+
+type FindEnd<S extends string, Accumulated extends string = ''> = S extends `${infer Head} ${infer Tail}`
+  ? IsKeyword<Head, 'end'> extends true
+    ? { body: Trim<Accumulated>; rest: Trim<Tail> }
+    : FindEnd<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+  : IsKeyword<S, 'end'> extends true
+    ? { body: Trim<Accumulated>; rest: '' }
+    : never;
+
+export type SplitCaseExpression<Expr extends string> = DropFirstWord<Trim<Expr>> extends infer AfterCase extends string
+  ? FindEnd<AfterCase> extends { body: infer Body extends string; rest: infer Rest extends string }
+    ? Rest extends ''
+      ? { body: Body; alias: 'case' }
+      : IsKeyword<FirstWord<Rest>, 'as'> extends true
+        ? { body: Body; alias: Unquote<Trim<DropFirstWord<Rest>>> }
+        : { body: Body; alias: Unquote<Trim<Rest>> }
+    : never
+  : never;
+
+interface CaseSegment {
+  kind: 'when' | 'then' | 'else';
+  text: string;
+}
+
+type ScanCaseSegments<
+  S extends string,
+  CurrentKind extends 'when' | 'then' | 'else',
+  CurrentText extends string,
+  Accumulated extends CaseSegment[],
+> = S extends `${infer Head} ${infer Tail}`
+  ? IsKeyword<Head, 'when'> extends true
+    ? ScanCaseSegments<Tail, 'when', '', [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText> }]>
+    : IsKeyword<Head, 'then'> extends true
+      ? ScanCaseSegments<Tail, 'then', '', [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText> }]>
+      : IsKeyword<Head, 'else'> extends true
+        ? ScanCaseSegments<Tail, 'else', '', [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText> }]>
+        : ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated>
+  : [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText extends '' ? S : `${CurrentText} ${S}`> }];
+
+type HasElseBranch<Segments extends CaseSegment[]> = Segments extends [
+  infer Head extends CaseSegment,
+  ...infer Tail extends CaseSegment[],
+]
+  ? Head['kind'] extends 'else'
+    ? true
+    : HasElseBranch<Tail>
+  : false;
+
+type LiteralType<Expr extends string> = Trim<Expr> extends `'${string}'`
+  ? string
+  : Trim<Expr> extends `${number}`
+    ? number
+    : Lowercase<Trim<Expr>> extends 'true' | 'false'
+      ? boolean
+      : Lowercase<Trim<Expr>> extends 'null'
+        ? null
+        : never;
+
+type BranchValueType<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Expr extends string,
+  Strict extends boolean,
+> = LiteralType<Expr> extends infer Literal
+  ? [Literal] extends [never]
+    ? ResolveColumnType<DB, Sources, Trim<Expr>, Strict>
+    : Literal
+  : never;
+
+type BranchUnion<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Segments extends CaseSegment[],
+  Strict extends boolean,
+> = Segments extends [infer Head extends CaseSegment, ...infer Tail extends CaseSegment[]]
+  ? Head['kind'] extends 'then' | 'else'
+    ? BranchValueType<DB, Sources, Head['text'], Strict> | BranchUnion<DB, Sources, Tail, Strict>
+    : BranchUnion<DB, Sources, Tail, Strict>
+  : never;
+
+export type CaseExpressionType<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Body extends string,
+  Strict extends boolean,
+> = ScanCaseSegments<DropFirstWord<Trim<Body>>, 'when', '', []> extends infer Segments extends CaseSegment[]
+  ? BranchUnion<DB, Sources, Segments, Strict> extends infer Union
+    ? HasElseBranch<Segments> extends true
+      ? Union
+      : Union | null
+    : never
+  : never;

--- a/src/cte.ts
+++ b/src/cte.ts
@@ -1,0 +1,49 @@
+import type { Trim, FirstWord, DropFirstWord, IsKeyword, ExtractParenGroup } from './string.js';
+import type { SchemaLike, Flatten } from './parse.js';
+import type { InferRowWith } from './parse.js';
+
+type CteEntry = [name: string, query: string];
+
+type ParseCteEntry<S extends string> = Trim<S> extends `${infer NameWord} ${infer AfterName}`
+  ? IsKeyword<FirstWord<Trim<AfterName>>, 'as'> extends true
+    ? Trim<DropFirstWord<Trim<AfterName>>> extends `(${infer AfterOpen}`
+      ? ExtractParenGroup<AfterOpen> extends { inner: infer SubQuery extends string; rest: infer Rest extends string }
+        ? { name: Trim<NameWord>; query: Trim<SubQuery>; rest: Trim<Rest> }
+        : never
+      : never
+    : never
+  : never;
+
+type ParseCteList<S extends string, Accumulated extends CteEntry[] = []> =
+  ParseCteEntry<S> extends {
+    name: infer Name extends string;
+    query: infer Query extends string;
+    rest: infer Rest extends string;
+  }
+    ? Rest extends `,${infer After}`
+      ? ParseCteList<Trim<After>, [...Accumulated, [Name, Query]]>
+      : { ctes: [...Accumulated, [Name, Query]]; rest: Rest }
+    : never;
+
+export type ParseWithClause<S extends string> = IsKeyword<FirstWord<S>, 'with'> extends true
+  ? ParseCteList<Trim<DropFirstWord<S>>> extends {
+      ctes: infer Ctes extends CteEntry[];
+      rest: infer Rest extends string;
+    }
+    ? { ctes: Ctes; rest: Rest }
+    : never
+  : never;
+
+export type BuildCteMap<
+  DB extends SchemaLike,
+  Ctes extends CteEntry[],
+  Strict extends boolean,
+  Accumulated extends Record<string, unknown> = Record<never, never>,
+> = Ctes extends [infer Head extends CteEntry, ...infer Tail extends CteEntry[]]
+  ? BuildCteMap<
+      DB,
+      Tail,
+      Strict,
+      Accumulated & { [Key in Head[0]]: Flatten<InferRowWith<DB & Accumulated, Head[1], Strict>> }
+    >
+  : Accumulated;

--- a/src/from.ts
+++ b/src/from.ts
@@ -5,12 +5,14 @@ import type {
   IsKeyword,
   Unquote,
   StripQualifier,
+  ExtractParenGroup,
 } from './string.js';
 
 export interface Source {
   table: string;
   alias: string;
   nullable: boolean;
+  derivedQuery?: string;
 }
 
 type ClauseBoundary =
@@ -31,14 +33,40 @@ type IsBoundary<Word extends string> = Lowercase<Word> extends ClauseBoundary
   ? true
   : false;
 
-type TakeFromClause<S extends string, Accumulated extends string = ''> =
-  S extends `${infer Head} ${infer Tail}`
+type OpenCount<S extends string, Accumulated extends unknown[] = []> = S extends `${string}(${infer After}`
+  ? OpenCount<After, [...Accumulated, unknown]>
+  : Accumulated;
+
+type CloseCount<S extends string, Accumulated extends unknown[] = []> = S extends `${string})${infer After}`
+  ? CloseCount<After, [...Accumulated, unknown]>
+  : Accumulated;
+
+type PopN<Depth extends unknown[], N extends unknown[]> = N extends [unknown, ...infer NRest]
+  ? Depth extends [unknown, ...infer DepthRest]
+    ? PopN<DepthRest, NRest>
+    : Depth
+  : Depth;
+
+type ApplyParenDelta<Depth extends unknown[], Token extends string> = PopN<
+  [...Depth, ...OpenCount<Token>],
+  CloseCount<Token>
+>;
+
+type TakeFromClause<
+  S extends string,
+  Depth extends unknown[] = [],
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
     ? IsBoundary<Head> extends true
       ? Trim<Accumulated>
-      : TakeFromClause<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
-    : IsBoundary<S> extends true
+      : TakeFromClause<Tail, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+    : TakeFromClause<Tail, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+  : Depth extends []
+    ? IsBoundary<S> extends true
       ? Trim<Accumulated>
-      : Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>;
+      : Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>
+    : Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>;
 
 type JoinAfterOuter<
   Tail extends string,
@@ -71,11 +99,15 @@ type JoinPhrase<Head extends string, Tail extends string> =
               ? JoinAfterOuter<Tail, true, true>
               : never;
 
-type SplitAtFirstJoin<S extends string, Accumulated extends string = ''> =
-  S extends `${infer Head} ${infer Tail}`
+type SplitAtFirstJoin<
+  S extends string,
+  Depth extends unknown[] = [],
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
     ? JoinPhrase<Head, Tail> extends infer Phrase
       ? [Phrase] extends [never]
-        ? SplitAtFirstJoin<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+        ? SplitAtFirstJoin<Tail, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
         : Phrase extends {
               joined: infer Joined extends boolean;
               prev: infer Prev extends boolean;
@@ -84,7 +116,8 @@ type SplitAtFirstJoin<S extends string, Accumulated extends string = ''> =
           ? { before: Trim<Accumulated>; joined: Joined; prev: Prev; after: Rest }
           : never
       : never
-    : never;
+    : SplitAtFirstJoin<Tail, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+  : never;
 
 type AliasOf<Segment extends string, Table extends string> =
   DropFirstWord<Segment> extends ''
@@ -103,8 +136,30 @@ type AliasOf<Segment extends string, Table extends string> =
 
 type CleanIdentifier<Raw extends string> = Unquote<StripQualifier<Raw>>;
 
-type SegmentToSource<Segment extends string, Nullable extends boolean> =
-  CleanIdentifier<FirstWord<Segment>> extends infer Table extends string
+type DerivedAlias<Rest extends string> = Trim<Rest> extends ''
+  ? never
+  : IsKeyword<FirstWord<Trim<Rest>>, 'as'> extends true
+    ? FirstWord<DropFirstWord<Trim<Rest>>>
+    : IsKeyword<FirstWord<Trim<Rest>>, 'on'> extends true
+      ? never
+      : FirstWord<Trim<Rest>>;
+
+type DerivedSegmentToSource<Segment extends string, Nullable extends boolean> = Trim<Segment> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends { inner: infer SubQuery extends string; rest: infer Rest extends string }
+    ? [DerivedAlias<Rest>] extends [never]
+      ? never
+      : {
+          table: DerivedAlias<Rest>;
+          alias: DerivedAlias<Rest>;
+          nullable: Nullable;
+          derivedQuery: Trim<SubQuery>;
+        }
+    : never
+  : never;
+
+type SegmentToSource<Segment extends string, Nullable extends boolean> = Trim<Segment> extends `(${string}`
+  ? DerivedSegmentToSource<Segment, Nullable>
+  : CleanIdentifier<FirstWord<Segment>> extends infer Table extends string
     ? {
         table: Table;
         alias: Unquote<AliasOf<Segment, Table>>;
@@ -113,11 +168,9 @@ type SegmentToSource<Segment extends string, Nullable extends boolean> =
     : never;
 
 type MarkNullable<Sources extends Source[]> = {
-  [Index in keyof Sources]: {
-    table: Sources[Index]['table'];
-    alias: Sources[Index]['alias'];
-    nullable: true;
-  };
+  [Index in keyof Sources]: Sources[Index] extends { derivedQuery: infer Q extends string }
+    ? { table: Sources[Index]['table']; alias: Sources[Index]['alias']; nullable: true; derivedQuery: Q }
+    : { table: Sources[Index]['table']; alias: Sources[Index]['alias']; nullable: true };
 };
 
 type CollectSources<

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -20,6 +20,17 @@ export interface FunctionReturnTypes {
   rtrim: string;
   concat: string;
   coalesce: unknown;
+  row_number: number;
+  rank: number;
+  dense_rank: number;
+  ntile: number;
+  percent_rank: number;
+  cume_dist: number;
+  lag: unknown;
+  lead: unknown;
+  first_value: unknown;
+  last_value: unknown;
+  nth_value: unknown;
 }
 
 export type IsFunctionCall<Expr extends string> = Expr extends `${string}(${string})`

--- a/src/params.ts
+++ b/src/params.ts
@@ -8,11 +8,37 @@ import type {
 
 type Operator = '=' | '<>' | '!=' | '<' | '>' | '<=' | '>=';
 
-type IsOperator<Token extends string> = Token extends Operator ? true : false;
+type WordOperator = 'like' | 'ilike' | 'in' | 'between';
 
-type IsPlaceholder<Token extends string> = Token extends '?'
+type ForcedNumberKeyword = 'limit' | 'offset';
+
+type IsOperator<Token extends string> = Token extends Operator
   ? true
-  : Token extends `$${string}`
+  : Lowercase<Token> extends WordOperator
+    ? true
+    : false;
+
+type IsTransparentToken<Token extends string> = Token extends '(' | ')' | ','
+  ? true
+  : Lowercase<Token> extends 'and' | 'or' | 'not'
+    ? true
+    : false;
+
+type StripLeadingParens<S extends string> = S extends `(${infer Rest}`
+  ? StripLeadingParens<Rest>
+  : S;
+
+type StripTrailingListPunctuation<S extends string> = S extends `${infer Rest})`
+  ? StripTrailingListPunctuation<Rest>
+  : S extends `${infer Rest},`
+    ? StripTrailingListPunctuation<Rest>
+    : S;
+
+type CleanPlaceholderToken<S extends string> = StripTrailingListPunctuation<StripLeadingParens<S>>;
+
+type IsPlaceholder<Token extends string> = CleanPlaceholderToken<Token> extends '?'
+  ? true
+  : CleanPlaceholderToken<Token> extends `$${string}`
     ? true
     : false;
 
@@ -21,7 +47,11 @@ type ParamType<
   Sources extends Source[],
   Column extends string,
   Op extends string,
-> = IsOperator<Op> extends true ? ResolveColumnLoose<DB, Sources, Column> : unknown;
+> = Lowercase<Op> extends ForcedNumberKeyword
+  ? number
+  : IsOperator<Op> extends true
+    ? ResolveColumnLoose<DB, Sources, Column>
+    : unknown;
 
 type ScanParams<
   S extends string,
@@ -32,8 +62,17 @@ type ScanParams<
   Accumulated extends unknown[] = [],
 > = S extends `${infer Head} ${infer Tail}`
   ? IsPlaceholder<Head> extends true
-    ? ScanParams<Tail, DB, Sources, '', '', [...Accumulated, ParamType<DB, Sources, PrevPrev, Prev>]>
-    : ScanParams<Tail, DB, Sources, Prev, Head, Accumulated>
+    ? ScanParams<
+        Tail,
+        DB,
+        Sources,
+        PrevPrev,
+        Prev,
+        [...Accumulated, ParamType<DB, Sources, PrevPrev, Prev>]
+      >
+    : IsTransparentToken<Head> extends true
+      ? ScanParams<Tail, DB, Sources, PrevPrev, Prev, Accumulated>
+      : ScanParams<Tail, DB, Sources, Prev, Head, Accumulated>
   : S extends ''
     ? Accumulated
     : IsPlaceholder<S> extends true

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -2,10 +2,12 @@ import type {
   Normalize,
   Trim,
   FirstWord,
+  DropFirstWord,
   StripQualifier,
   Qualifier,
   IsKeyword,
   Unquote,
+  ExtractParenGroup,
 } from './string.js';
 import type {
   IsFunctionCall,
@@ -13,6 +15,8 @@ import type {
   FunctionReturnType,
 } from './functions.js';
 import type { Source, ParseFromClause } from './from.js';
+import type { IsCaseExpression, SplitCaseExpression, CaseExpressionType } from './case.js';
+import type { ParseWithClause, BuildCteMap } from './cte.js';
 
 export type Schema = Record<string, Record<string, unknown>>;
 
@@ -103,14 +107,53 @@ type OutputName<Expression extends string> = IsFunctionCall<Expression> extends 
   ? FunctionOutputName<Expression>
   : Unquote<StripQualifier<Expression>>;
 
-type ParseColumnEntry<Entry extends string> =
-  Entry extends `${infer Expression} ${infer Middle} ${infer Alias}`
-    ? IsKeyword<Middle, 'as'> extends true
-      ? [Unquote<Trim<Alias>>, Trim<Expression>]
-      : [OutputName<Entry>, Entry]
-    : Entry extends `${infer Expression} ${infer Alias}`
-      ? [Unquote<Trim<Alias>>, Trim<Expression>]
-      : [OutputName<Trim<Entry>>, Trim<Entry>];
+type FindOverKeyword<S extends string, Accumulated extends string = ''> =
+  S extends `${infer Head} ${infer Tail}`
+    ? IsKeyword<Head, 'over'> extends true
+      ? IsFunctionCall<Trim<Accumulated>> extends true
+        ? { expr: Trim<Accumulated>; rest: Tail }
+        : FindOverKeyword<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+      : FindOverKeyword<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+    : never;
+
+type StripLeadingOpenParen<S extends string> = Trim<S> extends `(${infer Rest}` ? Rest : never;
+
+type SplitWindowExpression<Entry extends string> = FindOverKeyword<Entry> extends {
+  expr: infer Expr extends string;
+  rest: infer Rest extends string;
+}
+  ? StripLeadingOpenParen<Rest> extends infer AfterOpen extends string
+    ? [AfterOpen] extends [never]
+      ? never
+      : ExtractParenGroup<AfterOpen> extends { rest: infer AfterClose extends string }
+        ? { expr: Expr; after: Trim<AfterClose> }
+        : never
+    : never
+  : never;
+
+type IsWindowExpression<Entry extends string> = [SplitWindowExpression<Entry>] extends [never]
+  ? false
+  : true;
+
+type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends true
+  ? SplitCaseExpression<Entry> extends { body: infer Body extends string; alias: infer Alias extends string }
+    ? [Alias, `case ${Body} end`]
+    : [OutputName<Trim<Entry>>, Trim<Entry>]
+  : IsWindowExpression<Entry> extends true
+    ? SplitWindowExpression<Entry> extends { expr: infer Expr extends string; after: infer After extends string }
+      ? After extends ''
+        ? [OutputName<Expr>, Expr]
+        : IsKeyword<FirstWord<After>, 'as'> extends true
+          ? [Unquote<Trim<DropFirstWord<After>>>, Expr]
+          : [Unquote<Trim<After>>, Expr]
+      : [OutputName<Trim<Entry>>, Trim<Entry>]
+    : Entry extends `${infer Expression} ${infer Middle} ${infer Alias}`
+      ? IsKeyword<Middle, 'as'> extends true
+        ? [Unquote<Trim<Alias>>, Trim<Expression>]
+        : [OutputName<Entry>, Entry]
+      : Entry extends `${infer Expression} ${infer Alias}`
+        ? [Unquote<Trim<Alias>>, Trim<Expression>]
+        : [OutputName<Trim<Entry>>, Trim<Entry>];
 
 type ParseColumnEntries<Columns extends string[]> = {
   [Index in keyof Columns]: ParseColumnEntry<Columns[Index]>;
@@ -209,22 +252,26 @@ type QualifiedColumnType<
       : never
   : never;
 
-type ResolveColumnType<
+export type ResolveColumnType<
   DB extends SchemaLike,
   Sources extends Source[],
   Expression extends string,
   Strict extends boolean,
-> = IsFunctionCall<Expression> extends true
-  ? FunctionReturnType<Expression>
-  : Qualifier<Expression> extends ''
-    ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
-    : QualifiedColumnType<
-        DB,
-        Sources,
-        Unquote<Qualifier<Expression>>,
-        Unquote<StripQualifier<Expression>>,
-        Strict
-      >;
+> = IsCaseExpression<Expression> extends true
+  ? SplitCaseExpression<Expression> extends { body: infer Body extends string }
+    ? CaseExpressionType<DB, Sources, Body, Strict>
+    : unknown
+  : IsFunctionCall<Expression> extends true
+    ? FunctionReturnType<Expression>
+    : Qualifier<Expression> extends ''
+      ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
+      : QualifiedColumnType<
+          DB,
+          Sources,
+          Unquote<Qualifier<Expression>>,
+          Unquote<StripQualifier<Expression>>,
+          Strict
+        >;
 
 export type ResolveColumnLoose<
   DB extends SchemaLike,
@@ -251,7 +298,7 @@ type MergedStarColumns<DB extends SchemaLike, Sources extends Source[]> = Source
   ? MergeSourceColumns<DB, Head> & MergedStarColumns<DB, Tail>
   : unknown;
 
-type Flatten<T> = { [Key in keyof T]: T[Key] };
+export type Flatten<T> = { [Key in keyof T]: T[Key] };
 
 type AllKnownTables<DB extends SchemaLike, Sources extends Source[]> = Sources extends [
   infer Head extends Source,
@@ -319,26 +366,62 @@ type IsSelectAll<Columns extends string> = Trim<Columns> extends '*' ? true : fa
 
 type EmptyRow = Record<string, never>;
 
-type InferRowWith<
+type ResolveCteContext<
   DB extends SchemaLike,
   Q extends string,
   Strict extends boolean,
-> = ParseStatement<Q> extends {
-  columns: infer Columns extends string;
-  sources: infer Sources extends Source[];
+> = [ParseWithClause<Normalize<Q>>] extends [never]
+  ? { db: DB; query: Normalize<Q> }
+  : ParseWithClause<Normalize<Q>> extends {
+        ctes: infer Ctes extends [string, string][];
+        rest: infer Rest extends string;
+      }
+    ? { db: DB & BuildCteMap<DB, Ctes, Strict>; query: Rest }
+    : { db: DB; query: Normalize<Q> };
+
+type BuildDerivedSourceMap<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Strict extends boolean,
+  Accumulated extends Record<string, unknown> = Record<never, never>,
+> = Sources extends [infer Head extends Source, ...infer Tail extends Source[]]
+  ? Head extends { derivedQuery: infer Q extends string }
+    ? BuildDerivedSourceMap<
+        DB,
+        Tail,
+        Strict,
+        Accumulated & { [Key in Head['alias']]: Flatten<InferRowWith<DB, Q, Strict>> }
+      >
+    : BuildDerivedSourceMap<DB, Tail, Strict, Accumulated>
+  : Accumulated;
+
+export type InferRowWith<
+  DB extends SchemaLike,
+  Q extends string,
+  Strict extends boolean,
+> = ResolveCteContext<DB, Q, Strict> extends {
+  db: infer CteDB extends SchemaLike;
+  query: infer EffectiveQuery extends string;
 }
-  ? Trim<Columns> extends ''
-    ? EmptyRow
-    : IsSelectAll<Columns> extends true
-      ? StarRow<DB, Sources, Strict>
-      : BuildSelection<
-          DB,
-          Sources,
-          ParseColumnEntries<SplitColumnList<Columns>> extends [string, string][]
-            ? ParseColumnEntries<SplitColumnList<Columns>>
-            : [],
-          Strict
-        >
+  ? ParseStatementNormalized<EffectiveQuery> extends {
+      columns: infer Columns extends string;
+      sources: infer Sources extends Source[];
+    }
+    ? (CteDB & BuildDerivedSourceMap<CteDB, Sources, Strict>) extends infer EffectiveDB extends SchemaLike
+      ? Trim<Columns> extends ''
+        ? EmptyRow
+        : IsSelectAll<Columns> extends true
+          ? StarRow<EffectiveDB, Sources, Strict>
+          : BuildSelection<
+              EffectiveDB,
+              Sources,
+              ParseColumnEntries<SplitColumnList<Columns>> extends [string, string][]
+                ? ParseColumnEntries<SplitColumnList<Columns>>
+                : [],
+              Strict
+            >
+      : never
+    : never
   : never;
 
 export type InferRow<DB extends SchemaLike, Q extends string> = InferRowWith<DB, Q, false>;

--- a/src/string.ts
+++ b/src/string.ts
@@ -51,3 +51,19 @@ export type DropFirstWord<S extends string> = S extends `${string} ${infer Rest}
 
 export type IsKeyword<Token extends string, Keyword extends string> =
   Lowercase<Token> extends Lowercase<Keyword> ? true : false;
+
+type ScanParenGroup<
+  S extends string,
+  Depth extends unknown[],
+  Inner extends string,
+> = S extends `${infer Char}${infer Rest}`
+  ? Char extends '('
+    ? ScanParenGroup<Rest, [...Depth, unknown], `${Inner}${Char}`>
+    : Char extends ')'
+      ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
+        ? ScanParenGroup<Rest, DepthRest, `${Inner}${Char}`>
+        : { inner: Inner; rest: Rest }
+      : ScanParenGroup<Rest, Depth, `${Inner}${Char}`>
+  : { inner: Inner; rest: '' };
+
+export type ExtractParenGroup<S extends string> = ScanParenGroup<S, [], ''>;

--- a/tests/case.test-d.ts
+++ b/tests/case.test-d.ts
@@ -1,0 +1,66 @@
+import type { Query } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; active: boolean; age: number };
+}
+
+type CaseWithLiterals = Expect<
+  Equal<
+    Query<DB, "select case when active then 'yes' else 'no' end as status from users">,
+    { status: string }[]
+  >
+>;
+
+type CaseWithoutElseIsNullable = Expect<
+  Equal<
+    Query<DB, "select case when active then 'yes' end as status from users">,
+    { status: string | null }[]
+  >
+>;
+
+type CaseWithMultipleWhen = Expect<
+  Equal<
+    Query<
+      DB,
+      "select case when age < 18 then 'minor' when age < 65 then 'adult' else 'senior' end as bracket from users"
+    >,
+    { bracket: string }[]
+  >
+>;
+
+type CaseWithColumnBranch = Expect<
+  Equal<
+    Query<DB, 'select case when active then name else id end as label from users'>,
+    { label: string | number }[]
+  >
+>;
+
+type CaseWithoutAliasDefaultsToCase = Expect<
+  Equal<
+    Query<DB, "select case when active then 'yes' else 'no' end from users">,
+    { case: string }[]
+  >
+>;
+
+type CaseWithUnknownColumnFallsBackToUnknown = Expect<
+  Equal<
+    Query<DB, "select case when active then nope else 'no' end as status from users">,
+    { status: unknown }[]
+  >
+>;
+
+export type CaseLock = [
+  CaseWithLiterals,
+  CaseWithoutElseIsNullable,
+  CaseWithMultipleWhen,
+  CaseWithColumnBranch,
+  CaseWithoutAliasDefaultsToCase,
+  CaseWithUnknownColumnFallsBackToUnknown,
+];

--- a/tests/clauses.test-d.ts
+++ b/tests/clauses.test-d.ts
@@ -1,0 +1,54 @@
+import type { Query, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  posts: { id: number; user_id: number; title: string; views: number };
+}
+
+type GroupByKeepsSelectShape = Expect<
+  Equal<
+    Query<DB, 'select user_id, count(*) from posts group by user_id'>,
+    { user_id: number; count: number }[]
+  >
+>;
+
+type HavingKeepsSelectShape = Expect<
+  Equal<
+    Query<DB, 'select user_id from posts group by user_id having count(*) > 1'>,
+    { user_id: number }[]
+  >
+>;
+
+type HavingParamIsTypedFromAggregate = Expect<
+  Equal<
+    Params<DB, 'select user_id from posts group by user_id having count(*) > $1'>,
+    [number]
+  >
+>;
+
+type OrderByKeepsSelectShape = Expect<
+  Equal<Query<DB, 'select title from posts order by views desc'>, { title: string }[]>
+>;
+
+type LimitOffsetKeepsSelectShape = Expect<
+  Equal<Query<DB, 'select id from posts limit 10 offset 5'>, { id: number }[]>
+>;
+
+type LimitOffsetParamsAreNumeric = Expect<
+  Equal<Params<DB, 'select id from posts limit $1 offset $2'>, [number, number]>
+>;
+
+export type ClausesLock = [
+  GroupByKeepsSelectShape,
+  HavingKeepsSelectShape,
+  HavingParamIsTypedFromAggregate,
+  OrderByKeepsSelectShape,
+  LimitOffsetKeepsSelectShape,
+  LimitOffsetParamsAreNumeric,
+];

--- a/tests/cte.test-d.ts
+++ b/tests/cte.test-d.ts
@@ -1,0 +1,54 @@
+import type { Query, StrictQuery, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  posts: { id: number; user_id: number; title: string; views: number };
+}
+
+type SimpleCte = Expect<
+  Equal<
+    Query<DB, 'with popular as (select id, title from posts where views > 100) select id, title from popular'>,
+    { id: number; title: string }[]
+  >
+>;
+
+type CteWithJoinAgainstRealTable = Expect<
+  Equal<
+    Query<
+      DB,
+      'with popular as (select id, user_id, title from posts where views > 100) select u.name, p.title from users u join popular p on u.id = p.user_id'
+    >,
+    { name: string; title: string }[]
+  >
+>;
+
+type MultipleCtesSecondReferencesFirst = Expect<
+  Equal<
+    Query<
+      DB,
+      'with popular as (select id, user_id, title from posts where views > 100), popular_titles as (select title from popular) select title from popular_titles'
+    >,
+    { title: string }[]
+  >
+>;
+
+type CteStrictUnknownColumnIsTypeError = Expect<
+  Equal<
+    StrictQuery<DB, 'with bad as (select nope from posts) select nope from bad'>,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+export type CteLock = [
+  SimpleCte,
+  CteWithJoinAgainstRealTable,
+  MultipleCtesSecondReferencesFirst,
+  CteStrictUnknownColumnIsTypeError,
+];

--- a/tests/derived-table.test-d.ts
+++ b/tests/derived-table.test-d.ts
@@ -1,0 +1,52 @@
+import type { Query } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  posts: { id: number; user_id: number; title: string; views: number };
+  comments: { id: number; post_id: number; body: string };
+}
+
+type SimpleDerivedTable = Expect<
+  Equal<Query<DB, 'select id, title from (select id, title from posts) p'>, { id: number; title: string }[]>
+>;
+
+type DerivedTableWithWhereClauseInside = Expect<
+  Equal<
+    Query<DB, 'select id, title from (select id, title from posts where views > 100) p'>,
+    { id: number; title: string }[]
+  >
+>;
+
+type DerivedTableJoinedWithRealTable = Expect<
+  Equal<
+    Query<
+      DB,
+      'select u.name, p.title from users u join (select id, user_id, title from posts where views > 100) p on u.id = p.user_id'
+    >,
+    { name: string; title: string }[]
+  >
+>;
+
+type DerivedTableContainingItsOwnJoin = Expect<
+  Equal<
+    Query<
+      DB,
+      'select title, body from (select p.title, c.body from posts p join comments c on p.id = c.post_id) merged'
+    >,
+    { title: string; body: string }[]
+  >
+>;
+
+export type DerivedTableLock = [
+  SimpleDerivedTable,
+  DerivedTableWithWhereClauseInside,
+  DerivedTableJoinedWithRealTable,
+  DerivedTableContainingItsOwnJoin,
+];

--- a/tests/union.test-d.ts
+++ b/tests/union.test-d.ts
@@ -1,0 +1,32 @@
+import type { Query } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  active_users: { id: number; name: string };
+  archived_users: { id: number; name: string };
+}
+
+type UnionUsesFirstBranchShape = Expect<
+  Equal<
+    Query<DB, 'select id, name from active_users union select id, name from archived_users'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type UnionAllUsesFirstBranchShape = Expect<
+  Equal<
+    Query<
+      DB,
+      'select id, name from active_users union all select id, name from archived_users'
+    >,
+    { id: number; name: string }[]
+  >
+>;
+
+export type UnionLock = [UnionUsesFirstBranchShape, UnionAllUsesFirstBranchShape];

--- a/tests/where.test-d.ts
+++ b/tests/where.test-d.ts
@@ -1,0 +1,77 @@
+import type { Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; age: number; active: boolean; deleted_at: string | null };
+}
+
+type LikeParam = Expect<
+  Equal<Params<DB, 'select id from users where name like $1'>, [string]>
+>;
+
+type NotLikeParam = Expect<
+  Equal<Params<DB, 'select id from users where name not like $1'>, [string]>
+>;
+
+type IlikeParam = Expect<
+  Equal<Params<DB, 'select id from users where name ilike $1'>, [string]>
+>;
+
+type InListParams = Expect<
+  Equal<Params<DB, 'select id from users where id in ($1, $2)'>, [number, number]>
+>;
+
+type NotInListParams = Expect<
+  Equal<Params<DB, 'select id from users where id not in ($1, $2)'>, [number, number]>
+>;
+
+type BetweenParams = Expect<
+  Equal<Params<DB, 'select id from users where age between $1 and $2'>, [number, number]>
+>;
+
+type IsNullDoesNotAffectArity = Expect<
+  Equal<
+    Params<DB, 'select id from users where deleted_at is null and id = $1'>,
+    [number]
+  >
+>;
+
+type IsNotNullDoesNotAffectArity = Expect<
+  Equal<
+    Params<DB, 'select id from users where deleted_at is not null and id = $1'>,
+    [number]
+  >
+>;
+
+type MultipleAndConditions = Expect<
+  Equal<
+    Params<DB, 'select id from users where active = $1 and age > $2 and name = $3'>,
+    [boolean, number, string]
+  >
+>;
+
+type OrConditions = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = $1 or name = $2'>,
+    [number, string]
+  >
+>;
+
+export type WhereLock = [
+  LikeParam,
+  NotLikeParam,
+  IlikeParam,
+  InListParams,
+  NotInListParams,
+  BetweenParams,
+  IsNullDoesNotAffectArity,
+  IsNotNullDoesNotAffectArity,
+  MultipleAndConditions,
+  OrConditions,
+];

--- a/tests/window.test-d.ts
+++ b/tests/window.test-d.ts
@@ -1,0 +1,47 @@
+import type { Query } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  employees: { id: number; dept: string; salary: number };
+}
+
+type RowNumberWithAlias = Expect<
+  Equal<
+    Query<
+      DB,
+      'select id, row_number() over (partition by dept order by salary desc) as rn from employees'
+    >,
+    { id: number; rn: number }[]
+  >
+>;
+
+type RankWithoutAliasDefaultsToFunctionName = Expect<
+  Equal<
+    Query<DB, 'select rank() over (order by salary desc) from employees'>,
+    { rank: number }[]
+  >
+>;
+
+type EmptyOverClause = Expect<
+  Equal<Query<DB, 'select dense_rank() over () as d from employees'>, { d: number }[]>
+>;
+
+type WindowFunctionAlongsideRegularColumn = Expect<
+  Equal<
+    Query<DB, 'select dept, ntile(4) over (order by salary) as bucket from employees'>,
+    { dept: string; bucket: number }[]
+  >
+>;
+
+export type WindowLock = [
+  RowNumberWithAlias,
+  RankWithoutAliasDefaultsToFunctionName,
+  EmptyOverClause,
+  WindowFunctionAlongsideRegularColumn,
+];


### PR DESCRIPTION
## Summary

Broadens the type-level SQL parser beyond single-table/JOIN SELECTs:

- **WHERE**: `LIKE`/`ILIKE`/`IN (...)`/`BETWEEN`/`NOT` variants now type correctly, including multi-value `IN` lists (previously only the last placeholder resolved — a real bug, not just a limitation).
- **GROUP BY / HAVING / ORDER BY / LIMIT / OFFSET / UNION**: already worked via existing clause-boundary parsing; locked with regression tests.
- **CASE WHEN/THEN/ELSE/END** expressions — branch types are unioned, `| null` added when there's no `ELSE`.
- **Window functions** (`row_number()`, `rank()`, `dense_rank()`, etc. with `OVER (...)`).
- **CTEs** (`WITH ... AS (...)`), including CTEs that reference earlier CTEs, and strict-mode error propagation.
- **Derived table subqueries in FROM** (`from (select ...) x`), including subqueries with their own `WHERE`/`JOIN` — required a paren-depth fix in the FROM-clause boundary scanner so nested keywords don't get mistaken for the outer clause's boundaries.

README updated with the new supported-feature table and documented limitations (scalar subqueries remain untyped by design, no nested CASE, etc).

## Test plan

- [x] `npm run test:types` (full type-test suite, all `.test-d.ts` files)
- [x] `npm run test:runtime` (vitest, 8 tests)
- [x] New regression suites added: `where`, `clauses`, `union`, `case`, `window`, `cte`, `derived-table`
- [x] Verified existing JOIN/tier2/tier3/params suites still pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded SQL type inference for `CASE` expressions, window functions, CTEs, derived tables, set operations, and common query clauses.
  * Improved parameter type inference for `WHERE` conditions, including `LIKE`, `IN`, `BETWEEN`, and compound predicates.
  * Added support for cross-referencing CTEs and nested derived queries, including strict validation.

* **Documentation**
  * Updated supported SQL capabilities, limitations, typing behavior, and JOIN guidance.

* **Tests**
  * Added comprehensive compile-time coverage for the new SQL features and parameter inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->