### PR TITLE
Official support for PostgreSQL, MySQL, SQLite, and SQL Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ if (result.status === ResultStatus.Ok) {
   - [9. Joins](#9-joins)
   - [10. Typed parameters](#10-typed-parameters)
 - [Driver recipes](#driver-recipes)
+- [Database support](#database-support)
 - [API reference](#api-reference)
 - [Supported SQL subset](#supported-sql-subset)
 - [Limitations](#limitations)
@@ -452,6 +453,45 @@ const db = createTypedDb<DB>(async (text, params) => {
 });
 ```
 
+**mssql (SQL Server)**
+
+```ts
+import sql from 'mssql';
+const pool = await sql.connect({ /* ... */ });
+const db = createTypedDb<DB>(async (query, params) => {
+  const request = pool.request();
+  params.forEach((value, index) => request.input(`p${index + 1}`, value));
+  const result = await request.query(query);
+  return result.recordset;
+});
+```
+
+`mssql` binds named parameters (`request.input('name', value)`), so build the
+query with matching `@pN` placeholders — `Params<DB, Q>` still gives you a
+positional tuple typed against the query's `@` placeholders, in the order they
+appear.
+
+## Database support
+
+The parser accepts the SQL used by each of the four major engines, without any
+per-dialect configuration — it stays permissive and recognizes each dialect's
+syntax by shape, not by a declared "mode".
+
+| Feature | PostgreSQL | MySQL | SQLite | SQL Server |
+| ------- | ---------- | ----- | ------ | ---------- |
+| Placeholders | `$1`, `$2`, ... | `?` | `?` | `@name`, `@p1` |
+| Quoted identifiers | `"col"` | `` `col` `` | `"col"` | `[col]`, `"col"` |
+| Row-returning writes | `RETURNING col` | *(not supported by the engine — `INSERT`/`UPDATE`/`DELETE` type as `Record<string, never>[]`)* | `RETURNING col` | `OUTPUT inserted.col` / `OUTPUT deleted.col` |
+| Pagination | `LIMIT n OFFSET m` | `LIMIT n OFFSET m` | `LIMIT n OFFSET m` | `TOP n`, `TOP (n) PERCENT`, or `OFFSET ... FETCH NEXT n ROWS ONLY` |
+| `ILIKE` | ✓ | — | — | — |
+| Joins, CTEs, `CASE`, window functions, subqueries in `FROM` | ✓ | ✓ | ✓ | ✓ (dialect-agnostic — see [Supported SQL subset](#supported-sql-subset)) |
+
+See [`tests/dialect-postgres.test-d.ts`](tests/dialect-postgres.test-d.ts),
+[`tests/dialect-mysql.test-d.ts`](tests/dialect-mysql.test-d.ts),
+[`tests/dialect-sqlite.test-d.ts`](tests/dialect-sqlite.test-d.ts), and
+[`tests/dialect-mssql.test-d.ts`](tests/dialect-mssql.test-d.ts) for the exact
+query shapes each engine is tested against.
+
 ## API reference
 
 | Export | Kind | Description |
@@ -520,6 +560,10 @@ this.**
 | Window functions | `row_number() over (partition by ... order by ...)`, `rank()`, `dense_rank()`, etc. |
 | CTEs (`WITH ... AS (...)`) | later CTEs may reference earlier ones; works with strict mode |
 | Derived tables | `from (select ...) x`, including subqueries with their own `WHERE`/`JOIN` |
+| Named parameters | `where id = @id` (SQL Server style) |
+| Backtick identifiers | `` select `id` from `users` `` (MySQL style) |
+| `TOP` clause | `select top 10 id from users`, `top (n)`, `top n percent` (SQL Server) |
+| `OUTPUT` clause | `insert ... output inserted.id values (...)` (SQL Server) |
 
 ## Limitations
 
@@ -550,9 +594,14 @@ This is a focused tool for the common read path, not a full SQL grammar:
   (they fall back to a flexible `unknown[]`), and parameters inside a `WITH`
   query's own CTE bodies are not typed either. Numbered placeholders are
   assumed to appear in ascending order (`$1`, `$2`, ...).
-- **Quoted identifiers** use `"..."` (standard) or `[...]` (SQL Server);
-  MySQL backticks are not supported. Schema-qualified tables (`public.users`)
-  resolve by their final segment (`users`).
+- **Quoted identifiers** use `"..."` (standard), `[...]` (SQL Server), or
+  `` `...` `` (MySQL — escape the backtick with `\`` inside the template
+  literal). Schema-qualified tables (`public.users`) resolve by their final
+  segment (`users`).
+- **`TOP` supports a plain count or `TOP N PERCENT`** — `TOP N WITH TIES` is
+  not parsed. `OUTPUT` only recognizes the `inserted`/`deleted` pseudo-table
+  prefixes (they resolve against the statement's single table); `OUTPUT ...
+  INTO @table` is not supported.
 - **Unknown columns, tables, or aliases resolve to `unknown`** by default — pass
   `{ strict: true }` to turn them into a `QueryTypeError` instead.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sql-template-typed",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sql-template-typed",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sql-template-typed",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Parse SQL in TypeScript template literal types and infer the result shape from your schema — no codegen, no ORM.",
   "type": "module",
   "sideEffects": false,

--- a/src/params.ts
+++ b/src/params.ts
@@ -40,7 +40,9 @@ type IsPlaceholder<Token extends string> = CleanPlaceholderToken<Token> extends 
   ? true
   : CleanPlaceholderToken<Token> extends `$${string}`
     ? true
-    : false;
+    : CleanPlaceholderToken<Token> extends `@${string}`
+      ? true
+      : false;
 
 type ParamType<
   DB extends SchemaLike,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -34,6 +34,20 @@ type StatementAfterSelect<S extends string> = S extends `${infer Keyword} ${infe
     : never
   : never;
 
+type StripTopCount<S extends string> = Trim<S> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends { rest: infer Rest extends string }
+    ? Trim<Rest>
+    : Trim<S>
+  : DropFirstWord<Trim<S>>;
+
+type StripTopClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'top'> extends true
+  ? StripTopCount<DropFirstWord<Trim<S>>> extends infer AfterCount extends string
+    ? IsKeyword<FirstWord<AfterCount>, 'percent'> extends true
+      ? Trim<DropFirstWord<AfterCount>>
+      : AfterCount
+    : S
+  : S;
+
 type ColumnsBeforeFrom<
   S extends string,
   Accumulated extends string = '',
@@ -65,6 +79,41 @@ type ReturningColumns<S extends string> = AfterKeyword<S, 'returning'> extends i
     : ''
   : '';
 
+type AccumulateUntil<
+  S extends string,
+  StopKeyword extends string,
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? IsKeyword<Head, StopKeyword> extends true
+    ? Trim<Accumulated>
+    : AccumulateUntil<Tail, StopKeyword, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+  : IsKeyword<S, StopKeyword> extends true
+    ? Trim<Accumulated>
+    : Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>;
+
+type OutputClauseColumns<S extends string, StopKeyword extends string> = AfterKeyword<
+  S,
+  'output'
+> extends infer Rest
+  ? Rest extends string
+    ? AccumulateUntil<Rest, StopKeyword>
+    : ''
+  : '';
+
+type StripPseudoTableEntry<Entry extends string> = Lowercase<
+  Qualifier<Trim<Entry>>
+> extends 'inserted' | 'deleted'
+  ? StripQualifier<Trim<Entry>>
+  : Entry;
+
+type StripPseudoTableQualifiers<S extends string> = S extends `${infer Head},${infer Tail}`
+  ? `${StripPseudoTableEntry<Head>},${StripPseudoTableQualifiers<Tail>}`
+  : StripPseudoTableEntry<S>;
+
+type ReturningOrOutputColumns<S extends string, StopKeyword extends string> = ReturningColumns<S> extends ''
+  ? StripPseudoTableQualifiers<OutputClauseColumns<S, StopKeyword>>
+  : ReturningColumns<S>;
+
 type SingleSource<Table extends string> = [{ table: Table; alias: Table; nullable: false }];
 
 export interface ParsedStatement {
@@ -74,7 +123,7 @@ export interface ParsedStatement {
 
 type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer Body
   ? Body extends string
-    ? ColumnsBeforeFrom<Body> extends {
+    ? ColumnsBeforeFrom<StripTopClause<Body>> extends {
         columns: infer Columns extends string;
         afterFrom: infer AfterFrom extends string;
       }
@@ -87,11 +136,11 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
   ? IsKeyword<Keyword, 'select'> extends true
     ? ParseSelectBody<S>
     : IsKeyword<Keyword, 'insert'> extends true
-      ? { columns: ReturningColumns<S>; sources: SingleSource<WordAfterKeyword<S, 'into'>> }
+      ? { columns: ReturningOrOutputColumns<S, 'values'>; sources: SingleSource<WordAfterKeyword<S, 'into'>> }
       : IsKeyword<Keyword, 'update'> extends true
-        ? { columns: ReturningColumns<S>; sources: SingleSource<WordAfterKeyword<S, 'update'>> }
+        ? { columns: ReturningOrOutputColumns<S, 'where'>; sources: SingleSource<WordAfterKeyword<S, 'update'>> }
         : IsKeyword<Keyword, 'delete'> extends true
-          ? { columns: ReturningColumns<S>; sources: SingleSource<WordAfterKeyword<S, 'from'>> }
+          ? { columns: ReturningOrOutputColumns<S, 'where'>; sources: SingleSource<WordAfterKeyword<S, 'from'>> }
           : never
   : never;
 

--- a/src/string.ts
+++ b/src/string.ts
@@ -33,7 +33,9 @@ export type Unquote<S extends string> = S extends `"${infer Inner}"`
   ? Inner
   : S extends `[${infer Inner}]`
     ? Inner
-    : S;
+    : S extends `\`${infer Inner}\``
+      ? Inner
+      : S;
 
 export type FirstWord<S extends string> = S extends `${infer Head} ${string}`
   ? Head

--- a/tests/dialect-mssql.test-d.ts
+++ b/tests/dialect-mssql.test-d.ts
@@ -1,0 +1,82 @@
+import type { Query, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; email: string };
+}
+
+type NamedParamSingle = Expect<
+  Equal<Params<DB, 'select id from users where id = @id'>, [number]>
+>;
+
+type NamedParamMultiple = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = @p1 and name = @p2'>,
+    [number, string]
+  >
+>;
+
+type NamedParamLike = Expect<
+  Equal<Params<DB, 'select id from users where name like @name'>, [string]>
+>;
+
+type BracketIdentifiers = Expect<
+  Equal<Query<DB, 'select [id], [name] from [users]'>, { id: number; name: string }[]>
+>;
+
+type TopClause = Expect<
+  Equal<Query<DB, 'select top 10 id, name from users'>, { id: number; name: string }[]>
+>;
+
+type TopClauseWithParens = Expect<
+  Equal<Query<DB, 'select top (5) id from users'>, { id: number }[]>
+>;
+
+type TopClauseWithPercent = Expect<
+  Equal<Query<DB, 'select top 10 percent id from users'>, { id: number }[]>
+>;
+
+type InsertOutputClause = Expect<
+  Equal<
+    Query<DB, 'insert into users (name) output inserted.id values (@name)'>,
+    { id: number }[]
+  >
+>;
+
+type UpdateOutputClause = Expect<
+  Equal<
+    Query<DB, 'update users set name = @name output inserted.id where id = @id'>,
+    { id: number }[]
+  >
+>;
+
+type DeleteOutputClause = Expect<
+  Equal<
+    Query<DB, 'delete from users output deleted.id where id = @id'>,
+    { id: number }[]
+  >
+>;
+
+type NoOutputClauseIsEmptyRow = Expect<
+  Equal<Query<DB, 'insert into users (name) values (@name)'>, Record<string, never>[]>
+>;
+
+export type MssqlLock = [
+  NamedParamSingle,
+  NamedParamMultiple,
+  NamedParamLike,
+  BracketIdentifiers,
+  TopClause,
+  TopClauseWithParens,
+  TopClauseWithPercent,
+  InsertOutputClause,
+  UpdateOutputClause,
+  DeleteOutputClause,
+  NoOutputClauseIsEmptyRow,
+];

--- a/tests/dialect-mysql.test-d.ts
+++ b/tests/dialect-mysql.test-d.ts
@@ -1,0 +1,46 @@
+import type { Query, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; email: string };
+}
+
+type PositionalParams = Expect<
+  Equal<Params<DB, 'select id from users where id = ? and name = ?'>, [number, string]>
+>;
+
+type BacktickIdentifiers = Expect<
+  Equal<
+    Query<DB, `select \`id\`, \`name\` from \`users\``>,
+    { id: number; name: string }[]
+  >
+>;
+
+type BacktickAlias = Expect<
+  Equal<
+    Query<DB, `select \`name\` as \`username\` from \`users\``>,
+    { username: string }[]
+  >
+>;
+
+type NoReturningIsEmptyRow = Expect<
+  Equal<Query<DB, 'insert into users (name) values (?)'>, Record<string, never>[]>
+>;
+
+type LimitClause = Expect<
+  Equal<Query<DB, 'select id, name from users limit 10'>, { id: number; name: string }[]>
+>;
+
+export type MysqlLock = [
+  PositionalParams,
+  BacktickIdentifiers,
+  BacktickAlias,
+  NoReturningIsEmptyRow,
+  LimitClause,
+];

--- a/tests/dialect-postgres.test-d.ts
+++ b/tests/dialect-postgres.test-d.ts
@@ -1,0 +1,38 @@
+import type { Query, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; email: string };
+}
+
+type NumberedParams = Expect<
+  Equal<Params<DB, 'select id from users where id = $1 and name = $2'>, [number, string]>
+>;
+
+type DoubleQuotedIdentifiers = Expect<
+  Equal<Query<DB, 'select "id", "name" from "users"'>, { id: number; name: string }[]>
+>;
+
+type ReturningClause = Expect<
+  Equal<
+    Query<DB, 'insert into users (name) values ($1) returning id, name'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type IlikeOperator = Expect<
+  Equal<Params<DB, 'select id from users where name ilike $1'>, [string]>
+>;
+
+export type PostgresLock = [
+  NumberedParams,
+  DoubleQuotedIdentifiers,
+  ReturningClause,
+  IlikeOperator,
+];

--- a/tests/dialect-sqlite.test-d.ts
+++ b/tests/dialect-sqlite.test-d.ts
@@ -1,0 +1,38 @@
+import type { Query, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; email: string };
+}
+
+type PositionalParams = Expect<
+  Equal<Params<DB, 'select id from users where id = ? and name = ?'>, [number, string]>
+>;
+
+type DoubleQuotedIdentifiers = Expect<
+  Equal<Query<DB, 'select "id", "name" from "users"'>, { id: number; name: string }[]>
+>;
+
+type ReturningClause = Expect<
+  Equal<
+    Query<DB, 'insert into users (name) values (?) returning id, name'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type LimitOffset = Expect<
+  Equal<Query<DB, 'select id from users limit 10 offset 5'>, { id: number }[]>
+>;
+
+export type SqliteLock = [
+  PositionalParams,
+  DoubleQuotedIdentifiers,
+  ReturningClause,
+  LimitOffset,
+];


### PR DESCRIPTION
## Summary

Closes real per-dialect parsing gaps so all four major engines are officially covered — no dialect flag added to the API, the parser stays permissive and recognizes each syntax by shape:

- **SQL Server named parameters** (`@id`, `@p1`) typed alongside `$n` and `?`.
- **MySQL backtick identifiers** (`` `col` ``) — a previous limitation note claiming this was impossible was wrong; TypeScript allows escaping a backtick inside a template literal type, so it's fully supported now.
- **SQL Server `TOP N [PERCENT]`** clause, including `TOP (n)`.
- **SQL Server `OUTPUT`** clause (the `RETURNING` equivalent) for `INSERT`/`UPDATE`/`DELETE`, with `inserted.`/`deleted.` pseudo-table columns resolved correctly against the statement's table.
- **README**: driver recipe for `mssql`, a database-support feature matrix, and updated limitations.
- Bumped package version to `0.1.3`.

## Test plan

- [x] `npm run test:types` (full type-test suite)
- [x] `npm run test:runtime` (vitest, 8 tests)
- [x] New per-dialect regression suites: `tests/dialect-postgres.test-d.ts`, `tests/dialect-mysql.test-d.ts`, `tests/dialect-sqlite.test-d.ts`, `tests/dialect-mssql.test-d.ts`
- [x] Verified existing `RETURNING`/params/join suites still pass unchanged