### PR TITLE
Add npx sql-template-typed generate schema-introspection CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,41 @@ no runtime cost — it is erased during compilation. Mark nullable columns with
 `| null` (e.g. `bio: string | null`) and that nullability flows straight into
 your query results.
 
+**Optional: generate a starting point with `sql-template-typed generate`.**
+Writing that type by hand is fine for a handful of tables, but you can also
+have it generated from a real database:
+
+```
+npx sql-template-typed generate --url postgres://user:pass@host/db --out schema.ts
+```
+
+This connects to your database, introspects the tables/columns/nullability,
+and writes a `schema.ts` with `export interface DB { ... }` — the exact shape
+from step 1 above. It's a **one-shot generator, not a codegen pipeline**: the
+library still parses your queries entirely at the type level with zero
+runtime codegen, same as always. The generated file is a normal `.ts` file —
+commit it, edit it by hand afterward, rename fields, anything. Running
+`generate` again just overwrites it with a fresh snapshot; nothing stays
+"synced" automatically.
+
+| Flag | Required | Description |
+| ---- | -------- | ----------- |
+| `--url` | yes | Connection string (or a file path for SQLite). |
+| `--out` | no | Output file. Defaults to `./schema.ts`. |
+| `--dialect` | no | `postgres` \| `mysql` \| `sqlite` \| `mssql`. Auto-detected from the URL scheme (`postgres://`/`postgresql://`, `mysql://`, `mssql://`/`sqlserver://`) — falls back to `sqlite` for a bare file path, so it's only needed when that's ambiguous. |
+| `--schema` | no | Schema/database name to introspect. Defaults to `public` (Postgres) or the connected database (MySQL). Not used for SQLite/SQL Server. |
+
+`generate` needs the matching driver installed as a real dependency (`pg`,
+`mysql2`, or `mssql` — SQLite uses the `node:sqlite` builtin, Node ≥22.5). It
+prints a clear error telling you which one to install if it's missing.
+
+**Type mapping is conservative on purpose.** Types where the default driver
+behavior can lose precision — `bigint`, `numeric`/`decimal`, `money` — are
+generated as `string`, not `number`, because that's what `pg`/`mysql2` (and,
+assumed by analogy, `mssql`) actually hand back by default. If your driver is
+configured differently (e.g. mysql2's `supportBigNumbers`), just edit the
+generated field by hand; it's a plain type after that point.
+
 ### 2. Create a typed client
 
 The library never touches your database. You hand `createTypedDb` an

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
+        "@types/mssql": "^12.3.0",
         "@types/node": "^26.1.1",
         "@types/pg": "^8.20.0",
         "kysely": "^0.29.4",
+        "mssql": "^12.7.0",
         "mysql2": "^3.23.0",
         "pg": "^8.22.0",
         "postgres": "^3.4.9",
@@ -41,6 +43,264 @@
         "postgres": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@azure-rest/core-client": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.8.0.tgz",
+      "integrity": "sha512-F1ybHeN+++QhyFCF/ehLUEvrOB6fehPdFBFtGdj0C3B2lpQ9zkPiO5JDgsqc6IfjuUe6b3dAbXK0a7+VgSGfhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.24.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-fNAjWnA/nZ2jz31kxR/AqRaUT8ewHBw/WuBIosK0moMy1C9e5ValbDfFdIxJzVOOYaYkV/b2F1S4H/aHiqfVQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha512-IUZydyTUkDnYdstOW9pFOOUQlBjAepK5teihDE3x6yxsPJs/hsAaaYpeGxdxrgtOiJbBKSjKW7MDk7AEhb4LRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.0.tgz",
+      "integrity": "sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.7.0.tgz",
+      "integrity": "sha512-7GEAoIsaoBr6KELNRb8nypowCqvk8dnCHFCYg4XD4lOQGY2GqjQg5IhkRjyBFRO18CGSMq05PaNqSOE9GQro3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+      "integrity": "sha512-bMs8ekJLjX8wPV+9IPBges1SLPyuDtE9g5gLDWOpxzKcoOFQnpLGkbcT1tdw3FaAmDS1gnPmMmJ6y/T5B96kIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+      "integrity": "sha512-eGwxD0AtncrxeBM4tG8R55Pc3rdX1hNW2WibJAgYpCVA6E93mvvVH+LcssoVjOBrSKWS55yEIHsk0X8ctHmfOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha512-9n2pWK61veAuN0V20t9lOuoV4CFMdyAZ1ygZzvBGk/pBBJRib/PjL9PLXa/aI2CcPpyHfqVsxxqLCYl6uZlfDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-common/-/keyvault-common-2.1.0.tgz",
+      "integrity": "sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-keys": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/keyvault-keys/-/keyvault-keys-4.10.2.tgz",
+      "integrity": "sha512-VmUSLbXRAbSzDD8grXHGPaknYs0SKr3yuf6U+d4XMpX4XuVYskNqbTTwXce0zR1LyxfTZm9rWEBcvs3vdYwCmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/keyvault-common": "^2.1.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha512-rbAE25KUfjU/s3XHUdJgceoCP5dEOpMx85J04kF+QMdta73XkuG9JGHHinch+XIoKpBdqljin+KqURpJriSzLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
+      "integrity": "sha512-zBhRGzABKSI7hfWh5EaZmril5ybZ7imBN1qEZl5sDTaelr+l8SnPjZO50Q4dnKnm347YPIlBMSnXKZyh3Yu5DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.11.2"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.11.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.2.tgz",
+      "integrity": "sha512-yDhtBOGDCdK9ipQ9g3+wmlMEPnZx2pXaDicDd9jYyR1L+7lEbvEohTDmF5qejZDutZY3m9pWPxeYxzNC701A2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.4.1.tgz",
+      "integrity": "sha512-yqgoyOIMCH7TNaSLMBTP+4LUlbMMf1zgC8nzOFG95lmW82CmsAEtUT0J93e4BdqDcnX5qle/9X+yb7A8Mw9M0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.11.2",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@emnapi/core": {
@@ -83,6 +343,13 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@js-joda/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-H8NTMRDJqad/leyv/D/A3kSOsf5/58Ydj4DJGDyaCWk9OU/zuZOLhndVffJgQjsgrn5GC0znHMHie7TfvPPG4w==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -384,6 +651,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tediousjs/connection-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tediousjs/connection-string/-/connection-string-1.1.0.tgz",
+      "integrity": "sha512-z9ZBWEG+8pIB5V1zYzlRPXx0oRJ5H7coPnMQK8EZOw03UTPI9Umn6viL36f5w+CuqkKsnCM50RVStpjZmR0Bng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -420,6 +694,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mssql": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@types/mssql/-/mssql-12.3.0.tgz",
+      "integrity": "sha512-+jy+AJtfuTDI5+nhh0hDNcir1p8P+pf+qsHXpUpYvg7EikxUUePBe+a+Kr6j/Xs89o4EbHlVzrh0HOxbqWM31Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "tarn": "^3.0.1",
+        "tedious": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
@@ -440,6 +726,31 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
+      "integrity": "sha512-JVUD8X2tfDMWjcjLs4yVxxVrS8yR5vnh386GAXT9Qj79nBxxXSaHFQZg5FweLmT8HlPQ3kii6noUB+Z9RN7DvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -555,6 +866,29 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -575,6 +909,88 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -585,12 +1001,83 @@
         "node": ">=18"
       }
     },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/denque": {
       "version": "2.1.0",
@@ -612,6 +1099,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
@@ -627,6 +1124,26 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/expect-type": {
@@ -682,6 +1199,34 @@
         "is-property": "^1.0.2"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
@@ -699,12 +1244,144 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/kysely": {
       "version": "0.29.4",
@@ -977,6 +1654,55 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -1008,6 +1734,33 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mssql": {
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/mssql/-/mssql-12.7.0.tgz",
+      "integrity": "sha512-J6SJKXi1jYbhHjjooLNtPnX7+s3cq5IJ701Wgy/UW1SXRpgFlJJsYi3IPve9RVgCUkq0Cqv2aaaSJ4IXtIF3mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tediousjs/connection-string": "^1.0.0",
+        "commander": "^11.0.0",
+        "debug": "^4.3.3",
+        "tarn": "^3.0.2",
+        "tedious": "^19.2.2 || ^20.0.0"
+      },
+      "bin": {
+        "mssql": "bin/mssql"
+      },
+      "engines": {
+        "node": ">=18.19.0"
       }
     },
     "node_modules/mysql2": {
@@ -1065,6 +1818,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/native-duplexpair": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
+      "integrity": "sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
@@ -1077,6 +1837,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pathe": {
@@ -1289,6 +2068,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -1323,12 +2129,59 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -1356,6 +2209,13 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/sql-escaper": {
       "version": "1.5.1",
@@ -1386,6 +2246,48 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/tarn": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.1.2.tgz",
+      "integrity": "sha512-3RTvqKZcK/17jnJ8rMKFXbyNogywTs1z0gVPPwFsJGX46rkmUHOdIaSQ/aVO1rS7nH+soiXiWk7rvUXxndm8Dg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/tedious": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-20.0.0.tgz",
+      "integrity": "sha512-bTR0aou0Ghucf0ytvZUJjnKHGKDV8tT57jPYtEkSpfTWFe++4uR1wxJLQ4mh5wlSvAYXzmgBxbI0vaE56qigXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.10.1",
+        "@azure/identity": "^4.13.1",
+        "@azure/keyvault-keys": "^4.10.2",
+        "@js-joda/core": "^6.0.1",
+        "@types/node": ">=22",
+        "bl": "^6.1.4",
+        "iconv-lite": "^0.7.0",
+        "js-md4": "^0.3.2",
+        "native-duplexpair": "^1.0.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1436,8 +2338,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -1643,6 +2544,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "sql-template-typed": "./dist/cli/index.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -50,6 +53,7 @@
   },
   "peerDependencies": {
     "kysely": ">=0.27.0",
+    "mssql": ">=10.0.0",
     "mysql2": ">=3.0.0",
     "pg": ">=8.0.0",
     "postgres": ">=3.0.0",
@@ -57,6 +61,9 @@
   },
   "peerDependenciesMeta": {
     "kysely": {
+      "optional": true
+    },
+    "mssql": {
       "optional": true
     },
     "mysql2": {
@@ -83,9 +90,11 @@
     "access": "public"
   },
   "devDependencies": {
+    "@types/mssql": "^12.3.0",
     "@types/node": "^26.1.1",
     "@types/pg": "^8.20.0",
     "kysely": "^0.29.4",
+    "mssql": "^12.7.0",
     "mysql2": "^3.23.0",
     "pg": "^8.22.0",
     "postgres": "^3.4.9",

--- a/src/cli/codegen.ts
+++ b/src/cli/codegen.ts
@@ -1,0 +1,22 @@
+import type { ColumnSchema, TableSchema } from './types.js';
+
+const VALID_IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+function renderKey(name: string): string {
+  return VALID_IDENTIFIER.test(name) ? name : JSON.stringify(name);
+}
+
+function renderColumn(column: ColumnSchema): string {
+  const type = column.nullable ? `${column.tsType} | null` : column.tsType;
+  return `    ${renderKey(column.name)}: ${type};`;
+}
+
+function renderTable(table: TableSchema): string {
+  const columns = table.columns.map(renderColumn).join('\n');
+  return `  ${renderKey(table.name)}: {\n${columns}\n  };`;
+}
+
+export function renderSchema(tables: TableSchema[]): string {
+  const body = tables.map(renderTable).join('\n');
+  return `export interface DB {\n${body}\n}\n`;
+}

--- a/src/cli/dialects/mssql.ts
+++ b/src/cli/dialects/mssql.ts
@@ -1,0 +1,87 @@
+import type { ConnectionInfo, TableSchema } from '../types.js';
+
+const MSSQL_SCALAR_TYPES: Record<string, string> = {
+  int: 'number',
+  smallint: 'number',
+  tinyint: 'number',
+  float: 'number',
+  real: 'number',
+  bigint: 'string',
+  decimal: 'string',
+  numeric: 'string',
+  money: 'string',
+  smallmoney: 'string',
+  bit: 'boolean',
+  char: 'string',
+  varchar: 'string',
+  nchar: 'string',
+  nvarchar: 'string',
+  text: 'string',
+  ntext: 'string',
+  uniqueidentifier: 'string',
+  xml: 'string',
+  date: 'Date',
+  datetime: 'Date',
+  datetime2: 'Date',
+  smalldatetime: 'Date',
+  time: 'Date',
+  datetimeoffset: 'Date',
+  binary: 'Buffer',
+  varbinary: 'Buffer',
+  image: 'Buffer',
+};
+
+export function mapMssqlType(typeName: string): string {
+  return MSSQL_SCALAR_TYPES[typeName.toLowerCase()] ?? 'unknown';
+}
+
+interface MssqlColumnRow {
+  table_name: string;
+  column_name: string;
+  data_type: string;
+  is_nullable: boolean;
+}
+
+export async function introspectMssql(connection: ConnectionInfo): Promise<TableSchema[]> {
+  let connect: typeof import('mssql').connect;
+  try {
+    ({ connect } = await import('mssql'));
+  } catch {
+    throw new Error(
+      "The 'mssql' package is required to introspect SQL Server. Install it with: npm install mssql",
+    );
+  }
+
+  const pool = await connect(connection.url);
+
+  try {
+    const result = await pool.request().query<MssqlColumnRow>(
+      `select t.name as table_name, c.name as column_name, ty.name as data_type,
+              c.is_nullable as is_nullable
+       from sys.tables t
+       join sys.columns c on c.object_id = t.object_id
+       join sys.types ty on ty.user_type_id = c.user_type_id
+       order by t.name, c.column_id`,
+    );
+
+    return groupColumns(result.recordset);
+  } finally {
+    await pool.close();
+  }
+}
+
+function groupColumns(rows: MssqlColumnRow[]): TableSchema[] {
+  const tables = new Map<string, TableSchema>();
+
+  for (const row of rows) {
+    const table = tables.get(row.table_name) ?? { name: row.table_name, columns: [] };
+    table.columns.push({
+      name: row.column_name,
+      tsType: mapMssqlType(row.data_type),
+      nullable: row.is_nullable,
+    });
+    tables.set(row.table_name, table);
+  }
+
+  return [...tables.values()];
+}

--- a/src/cli/dialects/mysql.ts
+++ b/src/cli/dialects/mysql.ts
@@ -1,0 +1,106 @@
+import type { ConnectionInfo, TableSchema } from '../types.js';
+
+const MYSQL_SCALAR_TYPES: Record<string, string> = {
+  tinyint: 'number',
+  smallint: 'number',
+  mediumint: 'number',
+  int: 'number',
+  integer: 'number',
+  year: 'number',
+  float: 'number',
+  double: 'number',
+  bigint: 'string',
+  decimal: 'string',
+  numeric: 'string',
+  char: 'string',
+  varchar: 'string',
+  text: 'string',
+  tinytext: 'string',
+  mediumtext: 'string',
+  longtext: 'string',
+  enum: 'string',
+  set: 'string',
+  time: 'string',
+  date: 'Date',
+  datetime: 'Date',
+  timestamp: 'Date',
+  json: 'unknown',
+  binary: 'Buffer',
+  varbinary: 'Buffer',
+  blob: 'Buffer',
+  tinyblob: 'Buffer',
+  mediumblob: 'Buffer',
+  longblob: 'Buffer',
+  bit: 'Buffer',
+};
+
+export function mapMysqlType(dataType: string, columnType: string): string {
+  const type = dataType.toLowerCase();
+  const fullType = columnType.toLowerCase();
+
+  if (type === 'tinyint' && fullType.startsWith('tinyint(1)')) {
+    return 'boolean';
+  }
+
+  if (type === 'bit' && fullType.startsWith('bit(1)')) {
+    return 'boolean';
+  }
+
+  return MYSQL_SCALAR_TYPES[type] ?? 'unknown';
+}
+
+interface MysqlColumnRow {
+  table_name: string;
+  column_name: string;
+  data_type: string;
+  column_type: string;
+  is_nullable: 'YES' | 'NO';
+}
+
+export async function introspectMysql(connection: ConnectionInfo): Promise<TableSchema[]> {
+  let createConnection: typeof import('mysql2/promise').createConnection;
+  try {
+    ({ createConnection } = await import('mysql2/promise'));
+  } catch {
+    throw new Error(
+      "The 'mysql2' package is required to introspect MySQL. Install it with: npm install mysql2",
+    );
+  }
+
+  const connectionHandle = await createConnection(connection.url);
+
+  try {
+    const [rows] = await connectionHandle.query(
+      connection.schema
+        ? `select table_name, column_name, data_type, column_type, is_nullable
+           from information_schema.columns
+           where table_schema = ?
+           order by table_name, ordinal_position`
+        : `select table_name, column_name, data_type, column_type, is_nullable
+           from information_schema.columns
+           where table_schema = database()
+           order by table_name, ordinal_position`,
+      connection.schema ? [connection.schema] : [],
+    );
+
+    return groupColumns(rows as unknown as MysqlColumnRow[]);
+  } finally {
+    await connectionHandle.end();
+  }
+}
+
+function groupColumns(rows: MysqlColumnRow[]): TableSchema[] {
+  const tables = new Map<string, TableSchema>();
+
+  for (const row of rows) {
+    const table = tables.get(row.table_name) ?? { name: row.table_name, columns: [] };
+    table.columns.push({
+      name: row.column_name,
+      tsType: mapMysqlType(row.data_type, row.column_type),
+      nullable: row.is_nullable === 'YES',
+    });
+    tables.set(row.table_name, table);
+  }
+
+  return [...tables.values()];
+}

--- a/src/cli/dialects/postgres.ts
+++ b/src/cli/dialects/postgres.ts
@@ -1,0 +1,88 @@
+import type { ConnectionInfo, TableSchema } from '../types.js';
+
+const POSTGRES_SCALAR_TYPES: Record<string, string> = {
+  int2: 'number',
+  int4: 'number',
+  float4: 'number',
+  float8: 'number',
+  int8: 'string',
+  numeric: 'string',
+  money: 'string',
+  bool: 'boolean',
+  text: 'string',
+  varchar: 'string',
+  bpchar: 'string',
+  char: 'string',
+  uuid: 'string',
+  citext: 'string',
+  name: 'string',
+  xml: 'string',
+  json: 'unknown',
+  jsonb: 'unknown',
+  bytea: 'Buffer',
+  timestamp: 'Date',
+  timestamptz: 'Date',
+  date: 'Date',
+  time: 'Date',
+  timetz: 'Date',
+};
+
+export function mapPostgresType(udtName: string): string {
+  const isArray = udtName.startsWith('_');
+  const base = isArray ? udtName.slice(1) : udtName;
+  const scalar = POSTGRES_SCALAR_TYPES[base] ?? 'unknown';
+  return isArray ? `${scalar}[]` : scalar;
+}
+
+interface PgColumnRow {
+  table_name: string;
+  column_name: string;
+  udt_name: string;
+  is_nullable: 'YES' | 'NO';
+}
+
+export async function introspectPostgres(connection: ConnectionInfo): Promise<TableSchema[]> {
+  let PoolCtor: typeof import('pg').Pool;
+  try {
+    ({ Pool: PoolCtor } = await import('pg'));
+  } catch {
+    throw new Error(
+      "The 'pg' package is required to introspect PostgreSQL. Install it with: npm install pg",
+    );
+  }
+
+  const pool = new PoolCtor({ connectionString: connection.url });
+  const schema = connection.schema ?? 'public';
+
+  try {
+    const result = await pool.query<PgColumnRow>(
+      `select c.table_name, c.column_name, c.udt_name, c.is_nullable
+       from information_schema.columns c
+       join information_schema.tables t
+         on t.table_schema = c.table_schema and t.table_name = c.table_name
+       where c.table_schema = $1 and t.table_type = 'BASE TABLE'
+       order by c.table_name, c.ordinal_position`,
+      [schema],
+    );
+
+    return groupColumns(result.rows);
+  } finally {
+    await pool.end();
+  }
+}
+
+function groupColumns(rows: PgColumnRow[]): TableSchema[] {
+  const tables = new Map<string, TableSchema>();
+
+  for (const row of rows) {
+    const table = tables.get(row.table_name) ?? { name: row.table_name, columns: [] };
+    table.columns.push({
+      name: row.column_name,
+      tsType: mapPostgresType(row.udt_name),
+      nullable: row.is_nullable === 'YES',
+    });
+    tables.set(row.table_name, table);
+  }
+
+  return [...tables.values()];
+}

--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -1,0 +1,77 @@
+import type { ConnectionInfo, TableSchema } from '../types.js';
+
+export function mapSqliteType(declaredType: string): string {
+  const type = declaredType.toUpperCase().trim();
+
+  if (type === 'BOOLEAN') {
+    return 'boolean';
+  }
+
+  if (type === 'DATE' || type === 'DATETIME' || type === 'TIMESTAMP') {
+    return 'string';
+  }
+
+  if (type.includes('INT')) {
+    return 'number';
+  }
+
+  if (type.includes('CHAR') || type.includes('CLOB') || type.includes('TEXT')) {
+    return 'string';
+  }
+
+  if (type.includes('BLOB') || type === '') {
+    return 'Buffer';
+  }
+
+  if (type.includes('REAL') || type.includes('FLOA') || type.includes('DOUB')) {
+    return 'number';
+  }
+
+  return 'number';
+}
+
+interface SqliteTableInfoRow {
+  name: string;
+  type: string;
+  notnull: number;
+}
+
+export async function introspectSqlite(connection: ConnectionInfo): Promise<TableSchema[]> {
+  let DatabaseSyncCtor: typeof import('node:sqlite').DatabaseSync;
+  try {
+    ({ DatabaseSync: DatabaseSyncCtor } = await import('node:sqlite'));
+  } catch {
+    throw new Error(
+      "'node:sqlite' is not available in this Node.js version. Upgrade to Node >=22.5, or use better-sqlite3 and edit the generated schema by hand.",
+    );
+  }
+
+  const db = new DatabaseSyncCtor(connection.url);
+
+  try {
+    const tableRows = db
+      .prepare("select name from sqlite_master where type = 'table' and name not like 'sqlite_%'")
+      .all() as { name: string }[];
+
+    return tableRows.map((tableRow) => {
+      const columns = db
+        .prepare(`PRAGMA table_info(${quoteIdentifier(tableRow.name)})`)
+        .all() as unknown as SqliteTableInfoRow[];
+
+      return {
+        name: tableRow.name,
+        columns: columns.map((column) => ({
+          name: column.name,
+          tsType: mapSqliteType(column.type),
+          nullable: column.notnull === 0,
+        })),
+      };
+    });
+  } finally {
+    db.close();
+  }
+}
+
+function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -1,0 +1,51 @@
+import { writeFile } from 'node:fs/promises';
+import type { ConnectionInfo, Dialect, TableSchema } from './types.js';
+import { renderSchema } from './codegen.js';
+import { introspectPostgres } from './dialects/postgres.js';
+import { introspectMysql } from './dialects/mysql.js';
+import { introspectSqlite } from './dialects/sqlite.js';
+import { introspectMssql } from './dialects/mssql.js';
+
+export interface GenerateOptions {
+  url: string;
+  out: string;
+  dialect?: Dialect | undefined;
+  schema?: string | undefined;
+}
+
+export function detectDialect(url: string): Dialect {
+  if (url.startsWith('postgres://') || url.startsWith('postgresql://')) {
+    return 'postgres';
+  }
+
+  if (url.startsWith('mysql://')) {
+    return 'mysql';
+  }
+
+  if (url.startsWith('mssql://') || url.startsWith('sqlserver://')) {
+    return 'mssql';
+  }
+
+  return 'sqlite';
+}
+
+const INTROSPECTORS: Record<Dialect, (connection: ConnectionInfo) => Promise<TableSchema[]>> = {
+  postgres: introspectPostgres,
+  mysql: introspectMysql,
+  sqlite: introspectSqlite,
+  mssql: introspectMssql,
+};
+
+export async function runGenerate(options: GenerateOptions): Promise<void> {
+  const dialect = options.dialect ?? detectDialect(options.url);
+  const connection: ConnectionInfo = { url: options.url, schema: options.schema };
+
+  const tables = await INTROSPECTORS[dialect](connection);
+
+  if (tables.length === 0) {
+    throw new Error('No tables found. Check the connection URL and --schema, if provided.');
+  }
+
+  const source = renderSchema(tables);
+  await writeFile(options.out, source, 'utf8');
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import type { Dialect } from './types.js';
+import { runGenerate } from './generate.js';
+
+const DIALECTS: Dialect[] = ['postgres', 'mysql', 'sqlite', 'mssql'];
+
+function parseFlags(args: string[]): Map<string, string> {
+  const flags = new Map<string, string>();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg?.startsWith('--')) {
+      continue;
+    }
+
+    const name = arg.slice(2);
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for --${name}`);
+    }
+
+    flags.set(name, value);
+    index += 1;
+  }
+
+  return flags;
+}
+
+function parseDialect(raw: string | undefined): Dialect | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  if (!DIALECTS.includes(raw as Dialect)) {
+    throw new Error(`Unknown --dialect "${raw}". Expected one of: ${DIALECTS.join(', ')}`);
+  }
+
+  return raw as Dialect;
+}
+
+async function main(): Promise<void> {
+  const [command, ...rest] = process.argv.slice(2);
+
+  if (command !== 'generate') {
+    process.stderr.write(
+      'Usage: sql-template-typed generate --url <connection-string> [--out ./schema.ts] [--dialect postgres|mysql|sqlite|mssql] [--schema <name>]\n',
+    );
+    process.exitCode = command === undefined ? 0 : 1;
+    return;
+  }
+
+  const flags = parseFlags(rest);
+  const url = flags.get('url');
+  if (!url) {
+    throw new Error('--url is required, e.g. --url postgres://user:pass@host/db');
+  }
+
+  await runGenerate({
+    url,
+    out: flags.get('out') ?? './schema.ts',
+    dialect: parseDialect(flags.get('dialect')),
+    schema: flags.get('schema'),
+  });
+
+  process.stdout.write(`Wrote ${flags.get('out') ?? './schema.ts'}\n`);
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`Error: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,0 +1,17 @@
+export interface ColumnSchema {
+  name: string;
+  tsType: string;
+  nullable: boolean;
+}
+
+export interface TableSchema {
+  name: string;
+  columns: ColumnSchema[];
+}
+
+export type Dialect = 'postgres' | 'mysql' | 'sqlite' | 'mssql';
+
+export interface ConnectionInfo {
+  url: string;
+  schema?: string | undefined;
+}

--- a/tests/cli-codegen.test.ts
+++ b/tests/cli-codegen.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { renderSchema } from '../src/cli/codegen';
+import type { TableSchema } from '../src/cli/types';
+
+describe('renderSchema', () => {
+  it('renders multiple tables with their columns', () => {
+    const tables: TableSchema[] = [
+      {
+        name: 'users',
+        columns: [
+          { name: 'id', tsType: 'number', nullable: false },
+          { name: 'name', tsType: 'string', nullable: false },
+        ],
+      },
+      {
+        name: 'posts',
+        columns: [{ name: 'id', tsType: 'number', nullable: false }],
+      },
+    ];
+
+    expect(renderSchema(tables)).toBe(
+      'export interface DB {\n' +
+        '  users: {\n' +
+        '    id: number;\n' +
+        '    name: string;\n' +
+        '  };\n' +
+        '  posts: {\n' +
+        '    id: number;\n' +
+        '  };\n' +
+        '}\n',
+    );
+  });
+
+  it('appends | null for nullable columns', () => {
+    const tables: TableSchema[] = [
+      {
+        name: 'users',
+        columns: [{ name: 'bio', tsType: 'string', nullable: true }],
+      },
+    ];
+
+    expect(renderSchema(tables)).toContain('bio: string | null;');
+  });
+
+  it('quotes column and table names that are not valid identifiers', () => {
+    const tables: TableSchema[] = [
+      {
+        name: 'user-accounts',
+        columns: [{ name: 'display name', tsType: 'string', nullable: false }],
+      },
+    ];
+
+    const result = renderSchema(tables);
+
+    expect(result).toContain('"user-accounts": {');
+    expect(result).toContain('"display name": string;');
+  });
+
+  it('does not quote reserved-word-like identifiers that are still valid property names', () => {
+    const tables: TableSchema[] = [
+      {
+        name: 'order',
+        columns: [{ name: 'class', tsType: 'string', nullable: false }],
+      },
+    ];
+
+    const result = renderSchema(tables);
+
+    expect(result).toContain('order: {');
+    expect(result).toContain('class: string;');
+  });
+});

--- a/tests/cli-generate.test.ts
+++ b/tests/cli-generate.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+import { runGenerate, detectDialect } from '../src/cli/generate';
+
+describe('detectDialect', () => {
+  it('detects postgres, mysql, and mssql from the URL scheme', () => {
+    expect(detectDialect('postgres://user:pass@host/db')).toBe('postgres');
+    expect(detectDialect('postgresql://user:pass@host/db')).toBe('postgres');
+    expect(detectDialect('mysql://user:pass@host/db')).toBe('mysql');
+    expect(detectDialect('mssql://user:pass@host/db')).toBe('mssql');
+    expect(detectDialect('sqlserver://user:pass@host/db')).toBe('mssql');
+  });
+
+  it('falls back to sqlite for a bare file path', () => {
+    expect(detectDialect('./app.db')).toBe('sqlite');
+    expect(detectDialect(':memory:')).toBe('sqlite');
+  });
+});
+
+describe('runGenerate (end to end against a real sqlite file)', () => {
+  it('introspects the database and writes the rendered schema to --out', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sql-template-typed-'));
+    const dbFile = join(dir, 'app.db');
+    const outFile = join(dir, 'schema.ts');
+
+    try {
+      const db = new DatabaseSync(dbFile);
+      db.exec('create table users (id integer primary key, name text not null, bio text)');
+      db.close();
+
+      await runGenerate({ url: dbFile, out: outFile, dialect: 'sqlite' });
+
+      const written = readFileSync(outFile, 'utf8');
+      expect(written).toBe(
+        'export interface DB {\n' +
+          '  users: {\n' +
+          '    id: number | null;\n' +
+          '    name: string;\n' +
+          '    bio: string | null;\n' +
+          '  };\n' +
+          '}\n',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a clear error when no tables are found', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sql-template-typed-'));
+    const dbFile = join(dir, 'empty.db');
+
+    try {
+      const db = new DatabaseSync(dbFile);
+      db.close();
+
+      await expect(
+        runGenerate({ url: dbFile, out: join(dir, 'schema.ts'), dialect: 'sqlite' }),
+      ).rejects.toThrow('No tables found');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli-sqlite-introspect.test.ts
+++ b/tests/cli-sqlite-introspect.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+import { introspectSqlite } from '../src/cli/dialects/sqlite';
+
+function withTempDatabase(setup: (db: DatabaseSync) => void): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sql-template-typed-'));
+  const file = join(dir, 'test.db');
+  const db = new DatabaseSync(file);
+  setup(db);
+  db.close();
+  return file;
+}
+
+describe('introspectSqlite', () => {
+  it('introspects columns, types, and nullability from a real database file', async () => {
+    const file = withTempDatabase((db) => {
+      db.exec(`
+        create table users (
+          id integer primary key,
+          name text not null,
+          bio text,
+          active boolean not null
+        )
+      `);
+    });
+
+    try {
+      const tables = await introspectSqlite({ url: file });
+
+      expect(tables).toHaveLength(1);
+      expect(tables[0]?.name).toBe('users');
+      expect(tables[0]?.columns).toEqual([
+        { name: 'id', tsType: 'number', nullable: true },
+        { name: 'name', tsType: 'string', nullable: false },
+        { name: 'bio', tsType: 'string', nullable: true },
+        { name: 'active', tsType: 'boolean', nullable: false },
+      ]);
+    } finally {
+      rmSync(join(file, '..'), { recursive: true, force: true });
+    }
+  });
+
+  it('introspects multiple tables', async () => {
+    const file = withTempDatabase((db) => {
+      db.exec('create table users (id integer primary key, name text not null)');
+      db.exec('create table posts (id integer primary key, user_id integer not null, title text not null)');
+    });
+
+    try {
+      const tables = await introspectSqlite({ url: file });
+
+      expect(tables.map((table) => table.name).sort()).toEqual(['posts', 'users']);
+    } finally {
+      rmSync(join(file, '..'), { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { mapPostgresType } from '../src/cli/dialects/postgres';
+import { mapMysqlType } from '../src/cli/dialects/mysql';
+import { mapSqliteType } from '../src/cli/dialects/sqlite';
+import { mapMssqlType } from '../src/cli/dialects/mssql';
+
+describe('mapPostgresType', () => {
+  it('maps small integers to number', () => {
+    expect(mapPostgresType('int4')).toBe('number');
+    expect(mapPostgresType('int2')).toBe('number');
+    expect(mapPostgresType('float8')).toBe('number');
+  });
+
+  it('maps bigint and numeric to string to avoid precision loss', () => {
+    expect(mapPostgresType('int8')).toBe('string');
+    expect(mapPostgresType('numeric')).toBe('string');
+    expect(mapPostgresType('money')).toBe('string');
+  });
+
+  it('maps booleans, text, json, and binary types', () => {
+    expect(mapPostgresType('bool')).toBe('boolean');
+    expect(mapPostgresType('varchar')).toBe('string');
+    expect(mapPostgresType('jsonb')).toBe('unknown');
+    expect(mapPostgresType('bytea')).toBe('Buffer');
+  });
+
+  it('maps array udt names (leading underscore) to T[]', () => {
+    expect(mapPostgresType('_int4')).toBe('number[]');
+    expect(mapPostgresType('_text')).toBe('string[]');
+  });
+
+  it('falls back to unknown for unrecognized types', () => {
+    expect(mapPostgresType('some_custom_domain')).toBe('unknown');
+  });
+});
+
+describe('mapMysqlType', () => {
+  it('maps ordinary integers and floats to number', () => {
+    expect(mapMysqlType('int', 'int(11)')).toBe('number');
+    expect(mapMysqlType('smallint', 'smallint(6)')).toBe('number');
+  });
+
+  it('maps decimal and bigint to string to avoid precision loss', () => {
+    expect(mapMysqlType('decimal', 'decimal(10,2)')).toBe('string');
+    expect(mapMysqlType('bigint', 'bigint(20)')).toBe('string');
+  });
+
+  it('maps tinyint(1) to boolean but other tinyint widths to number', () => {
+    expect(mapMysqlType('tinyint', 'tinyint(1)')).toBe('boolean');
+    expect(mapMysqlType('tinyint', 'tinyint(4)')).toBe('number');
+  });
+
+  it('maps date/time types and binary types', () => {
+    expect(mapMysqlType('datetime', 'datetime')).toBe('Date');
+    expect(mapMysqlType('time', 'time')).toBe('string');
+    expect(mapMysqlType('blob', 'blob')).toBe('Buffer');
+  });
+});
+
+describe('mapSqliteType', () => {
+  it('applies standard SQLite type affinity rules', () => {
+    expect(mapSqliteType('INTEGER')).toBe('number');
+    expect(mapSqliteType('VARCHAR(255)')).toBe('string');
+    expect(mapSqliteType('TEXT')).toBe('string');
+    expect(mapSqliteType('REAL')).toBe('number');
+    expect(mapSqliteType('BLOB')).toBe('Buffer');
+    expect(mapSqliteType('')).toBe('Buffer');
+  });
+
+  it('special-cases BOOLEAN and DATE-like declared types', () => {
+    expect(mapSqliteType('BOOLEAN')).toBe('boolean');
+    expect(mapSqliteType('DATE')).toBe('string');
+    expect(mapSqliteType('DATETIME')).toBe('string');
+  });
+
+  it('falls back to number for NUMERIC-affinity types', () => {
+    expect(mapSqliteType('NUMERIC')).toBe('number');
+    expect(mapSqliteType('DECIMAL(10,2)')).toBe('number');
+  });
+});
+
+describe('mapMssqlType', () => {
+  it('maps ordinary integers and floats to number', () => {
+    expect(mapMssqlType('int')).toBe('number');
+    expect(mapMssqlType('real')).toBe('number');
+  });
+
+  it('maps bigint, decimal, numeric, and money to string', () => {
+    expect(mapMssqlType('bigint')).toBe('string');
+    expect(mapMssqlType('decimal')).toBe('string');
+    expect(mapMssqlType('money')).toBe('string');
+  });
+
+  it('maps bit to boolean and binary types to Buffer', () => {
+    expect(mapMssqlType('bit')).toBe('boolean');
+    expect(mapMssqlType('varbinary')).toBe('Buffer');
+  });
+
+  it('is case-insensitive and falls back to unknown', () => {
+    expect(mapMssqlType('INT')).toBe('number');
+    expect(mapMssqlType('geography')).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary

Connects to a real database, introspects tables/columns/nullability, and writes an `export interface DB { ... }` file matching the manual schema shape from the tutorial. Opt-in and one-shot — the library still parses queries entirely at the type level with zero runtime codegen; this only generates a starting point for the schema type that the user can edit by hand afterward. Running it again just overwrites the file with a fresh snapshot, nothing stays "synced" automatically.

Covers all four supported databases:

- **Postgres** and **MySQL** via `pg`/`mysql2`, dynamically imported so users generating from SQLite don't need those packages installed.
- **SQLite** via the `node:sqlite` builtin (no dependency to install).
- **SQL Server** via `mssql` (new peer dependency, plus `@types/mssql` since `mssql` doesn't ship its own type declarations).

**Type mapping is conservative where driver precision defaults matter**: `pg` and `mysql2` return `bigint`/`numeric`/`decimal` as strings by default (avoids overflow and precision loss), so `generate` maps those to `string` rather than `number` — confirmed against actual driver behavior via research, not assumed. SQL Server's exact driver defaults weren't verified, so the same conservative mapping is applied there by analogy and documented as an assumption, not a fact.

The CLI's argv parsing is hand-rolled (no `commander`/`yargs` dependency added). Driver connection code lives under `src/cli/dialects/`, with the SQL-to-TypeScript type mapping exposed as separate pure functions so they're unit testable without a live database connection.

## Test plan

- [x] `npm run test:types`
- [x] `npm run test:runtime` — `node:sqlite` is exercised for real end-to-end (a temp-file-backed database, asserting the exact generated file contents) since it needs no external service
- [x] Postgres/MySQL/SQL Server: type-mapping functions are unit tested; the introspection SQL queries themselves aren't covered by a live-database test in this environment — same limitation already accepted for the driver adapters shipped earlier
- [x] Did not run `npm run build` per project convention — verified via `tsc --noEmit` and by exercising `runGenerate()` directly in tests instead of spawning the compiled binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `sql-template-typed generate` command to create TypeScript schema definitions from PostgreSQL, MySQL, SQLite, and MSSQL databases.
  * Added automatic database dialect detection and options for connection URL, output path, dialect, and schema.
  * Added support for nullable columns and conservative SQL-to-TypeScript type mapping.
  * Registered the CLI command for direct use.

* **Documentation**
  * Added setup instructions, supported drivers, command options, and schema generation behavior to the tutorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->