### PR TITLE
Add sql-template-typed/ts-plugin editor autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ if (result.status === ResultStatus.Ok) {
   - [10. Typed parameters](#10-typed-parameters)
 - [Driver recipes](#driver-recipes)
 - [Database support](#database-support)
+- [Editor autocomplete](#editor-autocomplete)
 - [API reference](#api-reference)
 - [Supported SQL subset](#supported-sql-subset)
 - [Limitations](#limitations)
@@ -567,6 +568,59 @@ See [`tests/dialect-postgres.test-d.ts`](tests/dialect-postgres.test-d.ts),
 [`tests/dialect-sqlite.test-d.ts`](tests/dialect-sqlite.test-d.ts), and
 [`tests/dialect-mssql.test-d.ts`](tests/dialect-mssql.test-d.ts) for the exact
 query shapes each engine is tested against.
+
+## Editor autocomplete
+
+```ts
+db.query(`
+  select id, na
+`)
+//              ^ autocomplete suggests `name`
+```
+
+`sql-template-typed/ts-plugin` is a **TypeScript Language Service Plugin** —
+it runs inside `tsserver`, the same process that already powers VSCode's
+IntelliSense, and adds column-name completions while you're still typing the
+query string. This is a genuinely different mechanism from the rest of the
+library: everything else works by *type-checking* a finished query string;
+this works by hooking into the editor's completion request for a string
+that isn't even valid SQL yet.
+
+**Setup** — add it to your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [{ "name": "sql-template-typed/ts-plugin" }]
+  }
+}
+```
+
+Then, in VSCode, open the Command Palette and run **"TypeScript: Select
+TypeScript Version" → "Use Workspace Version"**. This step is not optional —
+VSCode's *bundled* TypeScript does not load workspace plugins, so skipping it
+is the #1 reason this kind of plugin appears to do nothing. Other editors
+that talk to `tsserver` (Cursor, some Neovim/Sublime LSP setups) generally
+pick up `tsconfig.json` plugins automatically.
+
+**What v1 does:** suggests column names right after `SELECT` or a comma in
+the column list, for `db.query(...)` calls made through a client built with
+`createTypedDb<DB>`. If a `FROM <table>` is already present anywhere later in
+the same string, suggestions are scoped to that table; otherwise you get the
+deduplicated union of every table's columns in `DB` — which is exactly what
+covers the example above before you've typed `FROM` at all.
+
+**What v1 does not do** (documented scope, not bugs):
+
+- No hover info and no inline diagnostics/squiggles — completions only.
+- No `JOIN`/alias awareness — only the first `FROM <table>` in the string is
+  used to scope suggestions; a second table from a `JOIN` is not offered.
+- Only plain string/template literals with **no interpolation**
+  (`` db.query(`select ...`) ``) are recognized — which is the only form the
+  library ever expects you to write, since parameters are SQL placeholders
+  (`$1`/`?`/`@name`), never JS template interpolation.
+- Completions after `WHERE`/`ORDER BY`/etc. aren't offered yet — only the
+  `SELECT` column list.
 
 ## API reference
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "./kysely": {
       "types": "./dist/adapters/kysely.d.ts",
       "import": "./dist/adapters/kysely.js"
+    },
+    "./ts-plugin": {
+      "types": "./dist/ts-plugin/index.d.cts",
+      "require": "./dist/ts-plugin/index.cjs"
     }
   },
   "files": [
@@ -44,9 +48,9 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && tsc -p tsconfig.ts-plugin.json",
     "typecheck": "tsc --noEmit",
-    "test:types": "tsc --noEmit -p tsconfig.json",
+    "test:types": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.ts-plugin.json",
     "test:runtime": "vitest run",
     "test": "npm run test:types && npm run test:runtime",
     "prepublishOnly": "npm run test && npm run build"

--- a/src/ts-plugin/detect.cts
+++ b/src/ts-plugin/detect.cts
@@ -1,0 +1,92 @@
+import type * as ts from 'typescript';
+
+type TypeScript = typeof import('typescript');
+
+interface QueryLiteralMatch {
+  literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral;
+  dbType: ts.Type;
+}
+
+function findNodeAtPosition(typescript: TypeScript, sourceFile: ts.SourceFile, position: number): ts.Node {
+  let best: ts.Node = sourceFile;
+
+  const visit = (node: ts.Node): void => {
+    if (position < node.getFullStart() || position > node.getEnd()) {
+      return;
+    }
+
+    best = node;
+    typescript.forEachChild(node, visit);
+  };
+
+  typescript.forEachChild(sourceFile, visit);
+  return best;
+}
+
+function isSqlLiteral(
+  typescript: TypeScript,
+  node: ts.Node,
+): node is ts.StringLiteral | ts.NoSubstitutionTemplateLiteral {
+  return typescript.isStringLiteral(node) || typescript.isNoSubstitutionTemplateLiteral(node);
+}
+
+function findEnclosingQueryCall(
+  typescript: TypeScript,
+  literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral,
+): ts.CallExpression | null {
+  const call = literal.parent;
+  if (!call || !typescript.isCallExpression(call) || call.arguments[0] !== literal) {
+    return null;
+  }
+
+  if (!typescript.isPropertyAccessExpression(call.expression) || call.expression.name.text !== 'query') {
+    return null;
+  }
+
+  return call;
+}
+
+function isTypeReference(typescript: TypeScript, type: ts.Type): type is ts.TypeReference {
+  return (
+    (type.flags & typescript.TypeFlags.Object) !== 0 &&
+    (((type as ts.ObjectType).objectFlags & typescript.ObjectFlags.Reference) !== 0)
+  );
+}
+
+function isTypedDbQueryMethod(checker: ts.TypeChecker, call: ts.CallExpression): boolean {
+  const signature = checker.getResolvedSignature(call);
+  const declaration = signature?.declaration;
+  const parent = declaration?.parent;
+  return parent !== undefined && 'name' in parent && (parent as { name?: ts.Identifier }).name?.text === 'TypedDb';
+}
+
+function matchQueryLiteral(
+  typescript: TypeScript,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  position: number,
+): QueryLiteralMatch | null {
+  const node = findNodeAtPosition(typescript, sourceFile, position);
+  if (!isSqlLiteral(typescript, node)) {
+    return null;
+  }
+
+  const call = findEnclosingQueryCall(typescript, node);
+  if (!call || !isTypedDbQueryMethod(checker, call)) {
+    return null;
+  }
+
+  const objectExpression = (call.expression as ts.PropertyAccessExpression).expression;
+  const objectType = checker.getTypeAtLocation(objectExpression);
+  const dbType = isTypeReference(typescript, objectType)
+    ? checker.getTypeArguments(objectType)[0]
+    : undefined;
+
+  if (!dbType) {
+    return null;
+  }
+
+  return { literal: node, dbType };
+}
+
+export = { matchQueryLiteral };

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -1,0 +1,74 @@
+import type * as ts from 'typescript/lib/tsserverlibrary';
+import sqlContext = require('./sql-context.cjs');
+import schemaModule = require('./schema.cjs');
+import detectModule = require('./detect.cjs');
+
+const { getSelectListContext, findFromTable } = sqlContext;
+const { getColumnNames } = schemaModule;
+const { matchQueryLiteral } = detectModule;
+
+function init(modules: { typescript: typeof ts }) {
+  const typescript = modules.typescript;
+
+  function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
+    const languageService = info.languageService;
+    const proxy = Object.create(null) as Record<string, unknown>;
+    for (const key of Object.keys(languageService) as (keyof ts.LanguageService)[]) {
+      const original = languageService[key];
+      if (typeof original === 'function') {
+        proxy[key] = (original as (...args: unknown[]) => unknown).bind(languageService);
+      }
+    }
+
+    const getCompletionsAtPosition: ts.LanguageService['getCompletionsAtPosition'] = (
+      fileName,
+      position,
+      options,
+    ) => {
+      const prior = info.languageService.getCompletionsAtPosition(fileName, position, options);
+
+      const program = info.languageService.getProgram();
+      const sourceFile = program?.getSourceFile(fileName);
+      if (!program || !sourceFile) {
+        return prior;
+      }
+
+      const checker = program.getTypeChecker();
+      const match = matchQueryLiteral(typescript, checker, sourceFile, position);
+      if (!match) {
+        return prior;
+      }
+
+      const literalStart = match.literal.getStart(sourceFile) + 1;
+      const textBeforeCursor = sourceFile.text.slice(literalStart, position);
+      const context = getSelectListContext(textBeforeCursor);
+      if (!context) {
+        return prior;
+      }
+
+      const fullLiteralText = match.literal.text;
+      const table = findFromTable(fullLiteralText);
+      const columns = getColumnNames(checker, match.dbType, match.literal, table);
+      const filtered = columns.filter((name) => name.startsWith(context.prefix));
+
+      return {
+        isGlobalCompletion: false,
+        isMemberCompletion: false,
+        isNewIdentifierLocation: false,
+        entries: filtered.map((name) => ({
+          name,
+          kind: typescript.ScriptElementKind.memberVariableElement,
+          sortText: '0',
+        })),
+      };
+    };
+
+    proxy.getCompletionsAtPosition = getCompletionsAtPosition;
+
+    return proxy as unknown as ts.LanguageService;
+  }
+
+  return { create };
+}
+
+export = init;

--- a/src/ts-plugin/schema.cts
+++ b/src/ts-plugin/schema.cts
@@ -1,0 +1,29 @@
+import type * as ts from 'typescript';
+
+function getColumnNames(
+  checker: ts.TypeChecker,
+  dbType: ts.Type,
+  node: ts.Node,
+  onlyTable: string | null,
+): string[] {
+  const tableSymbols = dbType.getProperties();
+
+  const scopedTables = onlyTable
+    ? tableSymbols.filter((symbol) => symbol.getName() === onlyTable)
+    : tableSymbols;
+
+  const tables = scopedTables.length > 0 ? scopedTables : tableSymbols;
+
+  const columnNames = new Set<string>();
+
+  for (const tableSymbol of tables) {
+    const tableType = checker.getTypeOfSymbolAtLocation(tableSymbol, node);
+    for (const columnSymbol of tableType.getProperties()) {
+      columnNames.add(columnSymbol.getName());
+    }
+  }
+
+  return [...columnNames];
+}
+
+export = { getColumnNames };

--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -1,0 +1,30 @@
+const SELECT_START = /^select\b/i;
+const HAS_FROM = /\bfrom\b/i;
+const TRAILING_WORD = /([A-Za-z_][A-Za-z0-9_]*)$/;
+const FROM_TABLE = /\bfrom\s+([A-Za-z_][A-Za-z0-9_]*)/i;
+
+interface SelectListContext {
+  prefix: string;
+}
+
+function getSelectListContext(textBeforeCursor: string): SelectListContext | null {
+  const trimmed = textBeforeCursor.trimStart();
+
+  if (!SELECT_START.test(trimmed)) {
+    return null;
+  }
+
+  if (HAS_FROM.test(textBeforeCursor)) {
+    return null;
+  }
+
+  const match = TRAILING_WORD.exec(textBeforeCursor);
+  return { prefix: match?.[1] ?? '' };
+}
+
+function findFromTable(fullLiteralText: string): string | null {
+  const match = FROM_TABLE.exec(fullLiteralText);
+  return match?.[1] ?? null;
+}
+
+export = { getSelectListContext, findFromTable };

--- a/tests/ts-plugin-completions.test.ts
+++ b/tests/ts-plugin-completions.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import ts from 'typescript';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { matchQueryLiteral } from '../src/ts-plugin/detect.cts';
+import { getColumnNames } from '../src/ts-plugin/schema.cts';
+import { getSelectListContext, findFromTable } from '../src/ts-plugin/sql-context.cts';
+
+const FIXTURE = `
+interface TypedDb<DB> {
+  query(sql: string): Promise<unknown>;
+}
+
+interface DB {
+  users: { id: number; name: string; email: string };
+  posts: { id: number; title: string };
+}
+
+declare const db: TypedDb<DB>;
+
+db.query(\`select id, na\`);
+db.query(\`select id, na from posts\`);
+`;
+
+function buildProgram(source: string): { program: ts.Program; sourceFile: ts.SourceFile; filePath: string; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'sql-template-typed-ts-plugin-'));
+  const filePath = join(dir, 'fixture.ts');
+  writeFileSync(filePath, source, 'utf8');
+
+  const program = ts.createProgram([filePath], {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+  });
+
+  const sourceFile = program.getSourceFile(filePath);
+  if (!sourceFile) {
+    throw new Error('fixture source file was not found in the program');
+  }
+
+  return { program, sourceFile, filePath, dir };
+}
+
+describe('ts-plugin: detect + schema against a real ts.Program', () => {
+  let cleanupDir: string | null = null;
+
+  afterEach(() => {
+    if (cleanupDir) {
+      rmSync(cleanupDir, { recursive: true, force: true });
+      cleanupDir = null;
+    }
+  });
+
+  it('detects a db.query(...) call and resolves its DB type argument', () => {
+    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+
+    const cursor = sourceFile.text.indexOf('select id, na') + 'select id, na'.length;
+    const match = matchQueryLiteral(ts, checker, sourceFile, cursor);
+
+    expect(match).not.toBeNull();
+  });
+
+  it('suggests columns from the union of all tables when no FROM is typed yet', () => {
+    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+
+    const literalStart = sourceFile.text.indexOf('`select id, na`') + 1;
+    const cursor = sourceFile.text.indexOf('select id, na') + 'select id, na'.length;
+    const match = matchQueryLiteral(ts, checker, sourceFile, cursor);
+    expect(match).not.toBeNull();
+    if (!match) return;
+
+    const textBeforeCursor = sourceFile.text.slice(literalStart, cursor);
+    const context = getSelectListContext(textBeforeCursor);
+    expect(context).toEqual({ prefix: 'na' });
+    if (!context) return;
+
+    const table = findFromTable(match.literal.text);
+    expect(table).toBeNull();
+
+    const columns = getColumnNames(checker, match.dbType, match.literal, table);
+    const filtered = columns.filter((name) => name.startsWith(context.prefix));
+
+    expect(filtered).toEqual(['name']);
+  });
+
+  it('scopes columns to the FROM table once one is present', () => {
+    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+
+    const secondCallText = 'select id, na from posts';
+    const cursor = sourceFile.text.indexOf(secondCallText) + 'select id, na'.length;
+    const match = matchQueryLiteral(ts, checker, sourceFile, cursor);
+    expect(match).not.toBeNull();
+    if (!match) return;
+
+    const table = findFromTable(match.literal.text);
+    expect(table).toBe('posts');
+
+    const columns = getColumnNames(checker, match.dbType, match.literal, table);
+
+    expect(columns.sort()).toEqual(['id', 'title']);
+    expect(columns).not.toContain('name');
+    expect(columns).not.toContain('email');
+  });
+});

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { getSelectListContext, findFromTable } from '../src/ts-plugin/sql-context.cts';
+
+describe('getSelectListContext', () => {
+  it('extracts the partial word being typed in a SELECT list', () => {
+    expect(getSelectListContext('select id, na')).toEqual({ prefix: 'na' });
+  });
+
+  it('returns an empty prefix right after SELECT or a comma', () => {
+    expect(getSelectListContext('select ')).toEqual({ prefix: '' });
+    expect(getSelectListContext('select id, ')).toEqual({ prefix: '' });
+  });
+
+  it('returns null once a FROM clause has already been typed', () => {
+    expect(getSelectListContext('select id, name from users where na')).toBeNull();
+  });
+
+  it('returns null for text that does not start with SELECT', () => {
+    expect(getSelectListContext('')).toBeNull();
+    expect(getSelectListContext('update users set na')).toBeNull();
+  });
+
+  it('is case-insensitive on the SELECT keyword', () => {
+    expect(getSelectListContext('SELECT id, na')).toEqual({ prefix: 'na' });
+  });
+});
+
+describe('findFromTable', () => {
+  it('finds the table name after FROM', () => {
+    expect(findFromTable('select id, name from users')).toBe('users');
+  });
+
+  it('is case-insensitive', () => {
+    expect(findFromTable('SELECT id FROM users')).toBe('users');
+  });
+
+  it('returns null when there is no FROM clause yet', () => {
+    expect(findFromTable('select id, na')).toBeNull();
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/ts-plugin"]
 }

--- a/tsconfig.ts-plugin.json
+++ b/tsconfig.ts-plugin.json
@@ -1,19 +1,20 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "CommonJS",
+    "moduleResolution": "Node10",
     "lib": ["ES2022"],
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "declaration": true,
-    "noEmit": true,
+    "noEmit": false,
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist/ts-plugin",
+    "rootDir": "src/ts-plugin"
   },
-  "include": ["src", "tests"],
-  "exclude": ["src/ts-plugin", "tests/ts-plugin-sql-context.test.ts", "tests/ts-plugin-completions.test.ts"]
+  "include": ["src/ts-plugin"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  oxc: {
+    include: /\.[cm]?[tj]sx?$/,
+  },
+  resolve: {
+    extensions: ['.mts', '.cts', '.ts', '.mjs', '.cjs', '.js', '.json'],
+  },
+});


### PR DESCRIPTION
## Summary

A TypeScript Language Service Plugin that suggests column names while typing inside a `db.query(\`select id, na\`)` string, before it's even valid SQL. This is a different mechanism from the rest of the library: everything else type-checks a *finished* query string; this hooks into `tsserver`'s live completion request against *incomplete* text — the same process that already powers VSCode's IntelliSense.

**v1 scope** (deliberately narrow, confirmed before building): column-name completion right after `SELECT` or a comma, for `db.query(...)` calls made through a `createTypedDb<DB>` client. If a `FROM <table>` is already present anywhere in the string, suggestions are scoped to that table; otherwise it's the deduplicated union of every table's columns in `DB`. No hover, no inline diagnostics, no `JOIN`/alias resolution, and only plain literals with no interpolation are recognized (the only form the library ever expects, since params are SQL placeholders, not JS template interpolation).

**Architecture** (`src/ts-plugin/`):
- `sql-context.cts` — pure regex completion-context detection, no compiler API
- `schema.cts` — walks `DB` → table → column via `ts.TypeChecker`
- `detect.cts` — finds the string literal at the cursor position (manual AST walk, TS doesn't expose `getTokenAtPosition` publicly), confirms it's a `.query(...)` call on a `TypedDb`-shaped object, extracts the `DB` type argument
- `index.cts` — the plugin factory/proxy, wired into `getCompletionsAtPosition`

Distributed as a subpath (`sql-template-typed/ts-plugin`), same pattern as the driver adapters — no new runtime dependency, `typescript` was already a peer dependency.

## Build/tooling notes for reviewers

- `.cts` files need their own `tsconfig.ts-plugin.json` with `module: CommonJS` — the extension-driven CJS auto-detection `.cts` is supposed to provide only kicks in under `module: NodeNext`/`Node16`, and this project intentionally keeps `module: ESNext` for everything else.
- Two test files that import `.cts` modules from the ESM-mode tsconfig couldn't be made to type-check cleanly under any `esModuleInterop`/`allowSyntheticDefaultImports`/`allowImportingTsExtensions` combination against `moduleResolution: Bundler`, so they're excluded from both `tsc` projects and verified purely by real `vitest` execution instead — a deliberate trade-off, not an oversight.
- Vitest 4 defaults to the `oxc` transform engine now; `esbuild` config options are silently ignored. Needed `oxc.include` in `vitest.config.ts` to get `.cts` files recognized as TypeScript at all.

## Test plan

- [x] `npm run test:types` (two separate `tsc` projects: main + ts-plugin)
- [x] `npm run test:runtime` — a real `ts.Program` built via `ts.createProgram` over a temp-file fixture exercises the full detection and column-extraction pipeline against the actual TypeScript compiler API
- [x] No VSCode GUI available in this environment to verify visually — README documents the required "Select TypeScript Version → Use Workspace Version" step, the most common reason this class of plugin appears to do nothing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TypeScript editor autocomplete for SQL query columns.
  - Suggestions appear while typing `SELECT` lists and can be scoped to the table in the `FROM` clause.
  - Added a public `ts-plugin` package entry with setup guidance for TypeScript and VS Code.

- **Documentation**
  - Documented installation, configuration, supported scenarios, and current limitations.

- **Tests**
  - Added coverage for query detection, column filtering, table scoping, and SQL context parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->