### PR TITLE
Rename project to OwlSQL (@owlsql/core)

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,4 +1,4 @@
-# Comparison: sql-template-typed vs Prisma, Kysely, pgTyped, Zapatos
+# Comparison: OwlSQL vs Prisma, Kysely, pgTyped, Zapatos
 
 This is **not** a runtime-speed benchmark — query execution speed is
 dominated by your database and driver, not the layer on top of it, and
@@ -23,7 +23,7 @@ check the source link and open an issue.
 
 ## At a glance
 
-| | sql-template-typed | Prisma | Kysely | pgTyped | Zapatos |
+| | OwlSQL | Prisma | Kysely | pgTyped | Zapatos |
 | --- | --- | --- | --- | --- | --- |
 | Approach | Type-level SQL parser | Schema DSL → generated ORM client | TypeScript query builder | SQL files/tags → generated wrapper functions | Generated schema + typed SQL helpers |
 | You write | Raw SQL strings | Prisma's own query API | Builder method chains | Raw SQL (in `.sql` files or tags) | Builder-ish helpers or raw SQL via `db.sql` |
@@ -118,7 +118,7 @@ check the source link and open an issue.
   difference is Zapatos also gives you typed query helpers on top, where
   this library stops at typing whatever SQL you hand it directly.
 
-## sql-template-typed
+## OwlSQL
 
 - **Build step**: none, ever, for queries — `Query<DB, 'select ...'>` is
   resolved by the same `tsc`/tsserver pass that already type-checks the rest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Maintainer notes for developing and releasing `sql-template-typed`.
+Maintainer notes for developing and releasing `@owlsql/core` (OwlSQL).
 
 ## Development
 
@@ -37,5 +37,5 @@ npm publish            # runs test:types, then build, then publishes dist/
 ```
 
 Before the first registry publish, the package is still usable via a local path
-(`npm i file:../sql-template-typed`), a tarball (`npm pack`), a workspace
+(`npm i file:../owlsql`), a tarball (`npm pack`), a workspace
 protocol, or a git URL.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# sql-template-typed
+# OwlSQL
 
 > Write raw SQL. Get fully-typed results. No codegen, no ORM, no runtime parsing.
 
-`sql-template-typed` reads your SQL **inside TypeScript's type system** and
+OwlSQL (`@owlsql/core`) reads your SQL **inside TypeScript's type system** and
 infers the row shape directly from the query string and your schema. The query
 `'select id, name from users'` becomes `{ id: number; name: string }[]` — at
 edit time, in your IDE, with zero build step.
@@ -145,7 +145,7 @@ lives in the `.d.ts` types.
 ## Install
 
 ```bash
-npm install sql-template-typed
+npm install @owlsql/core
 ```
 
 `typescript` is a peer dependency (**>= 5.0** — required for template literal
@@ -180,12 +180,12 @@ no runtime cost — it is erased during compilation. Mark nullable columns with
 `| null` (e.g. `bio: string | null`) and that nullability flows straight into
 your query results.
 
-**Optional: generate a starting point with `sql-template-typed generate`.**
+**Optional: generate a starting point with `owlsql generate`.**
 Writing that type by hand is fine for a handful of tables, but you can also
 have it generated from a real database:
 
 ```
-npx sql-template-typed generate --url postgres://user:pass@host/db --out schema.ts
+npx @owlsql/core generate --url postgres://user:pass@host/db --out schema.ts
 ```
 
 This connects to your database, introspects the tables/columns/nullability,
@@ -223,7 +223,7 @@ driver, and returns the raw rows.
 
 ```ts
 import { Pool } from 'pg';
-import { createTypedDb } from 'sql-template-typed';
+import { createTypedDb } from '@owlsql/core';
 
 const pool = new Pool();
 
@@ -242,7 +242,7 @@ against `DB`.
 union of success or error — so failures are values you handle explicitly.
 
 ```ts
-import { ResultStatus } from 'sql-template-typed';
+import { ResultStatus } from '@owlsql/core';
 
 const result = await db.query('select id, name from users');
 
@@ -261,7 +261,7 @@ for (const user of result.value) {
 Prefer a helper over the `status` field? `isOk` / `isErr` narrow the same way:
 
 ```ts
-import { isOk } from 'sql-template-typed';
+import { isOk } from '@owlsql/core';
 
 const result = await db.query('select id, email from users');
 
@@ -320,7 +320,7 @@ Sometimes you only want the *type* of a query — for an API contract, a DTO, or
 function signature — without running anything. Use the `Query` type directly:
 
 ```ts
-import type { Query } from 'sql-template-typed';
+import type { Query } from '@owlsql/core';
 
 type UserListRow = Query<DB, 'select id, email from users'>;
 //   ^? { id: number; email: string }[]
@@ -449,7 +449,7 @@ operator, and placeholder as separate tokens.
 ## Driver recipes
 
 The executor is the only thing that touches your database, so any driver
-works. For the most common drivers, `sql-template-typed` ships a ready-made
+works. For the most common drivers, OwlSQL ships a ready-made
 adapter — import it from its own subpath and pass your existing client
 straight in. No dependency is pulled in unless you import that specific
 subpath (each driver is an optional peer dependency).
@@ -458,7 +458,7 @@ subpath (each driver is an optional peer dependency).
 
 ```ts
 import { Pool } from 'pg';
-import { createPgExecutor } from 'sql-template-typed/pg';
+import { createPgExecutor } from '@owlsql/core/pg';
 
 const db = createTypedDb<DB>(createPgExecutor(new Pool()));
 ```
@@ -467,7 +467,7 @@ const db = createTypedDb<DB>(createPgExecutor(new Pool()));
 
 ```ts
 import { createPool } from 'mysql2/promise';
-import { createMysql2Executor } from 'sql-template-typed/mysql2';
+import { createMysql2Executor } from '@owlsql/core/mysql2';
 
 const db = createTypedDb<DB>(createMysql2Executor(createPool({ /* ... */ })));
 ```
@@ -476,7 +476,7 @@ const db = createTypedDb<DB>(createMysql2Executor(createPool({ /* ... */ })));
 
 ```ts
 import postgres from 'postgres';
-import { createPostgresJsExecutor } from 'sql-template-typed/postgres';
+import { createPostgresJsExecutor } from '@owlsql/core/postgres';
 
 const db = createTypedDb<DB>(createPostgresJsExecutor(postgres()));
 ```
@@ -485,7 +485,7 @@ const db = createTypedDb<DB>(createPostgresJsExecutor(postgres()));
 
 ```ts
 import { DatabaseSync } from 'node:sqlite';
-import { createNodeSqliteExecutor } from 'sql-template-typed/node-sqlite';
+import { createNodeSqliteExecutor } from '@owlsql/core/node-sqlite';
 
 const db = createTypedDb<DB>(createNodeSqliteExecutor(new DatabaseSync('app.db')));
 ```
@@ -504,7 +504,7 @@ const db = createTypedDb<DB>(async (sql, params) => sqlite.prepare(sql).all(...p
 
 ```ts
 import { Kysely, PostgresDialect } from 'kysely';
-import { createKyselyExecutor } from 'sql-template-typed/kysely';
+import { createKyselyExecutor } from '@owlsql/core/kysely';
 
 const kysely = new Kysely<KyselySchema>({ dialect: new PostgresDialect({ /* ... */ }) });
 const db = createTypedDb<DB>(createKyselyExecutor(kysely));
@@ -523,7 +523,7 @@ and reuse the matching adapter above — one extra line over the plain driver:
 
 ```ts
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { createPgExecutor } from 'sql-template-typed/pg';
+import { createPgExecutor } from '@owlsql/core/pg';
 
 const drizzleDb = drizzle(process.env.DATABASE_URL!);
 const db = createTypedDb<DB>(createPgExecutor(drizzleDb.$client));
@@ -582,7 +582,7 @@ db.query(`
 //              ^ autocomplete suggests `name`
 ```
 
-`sql-template-typed/ts-plugin` is a **TypeScript Language Service Plugin** —
+`@owlsql/core/ts-plugin` is a **TypeScript Language Service Plugin** —
 it runs inside `tsserver`, the same process that already powers VSCode's
 IntelliSense, and adds column-name completions while you're still typing the
 query string. This is a genuinely different mechanism from the rest of the
@@ -595,7 +595,7 @@ that isn't even valid SQL yet.
 ```json
 {
   "compilerOptions": {
-    "plugins": [{ "name": "sql-template-typed/ts-plugin" }]
+    "plugins": [{ "name": "@owlsql/core/ts-plugin" }]
   }
 }
 ```
@@ -655,11 +655,11 @@ ever required):
 
 | Export | Subpath | Description |
 | ------ | ------- | ----------- |
-| `createPgExecutor(pool)` | `sql-template-typed/pg` | `pg.Pool` → `Executor`. |
-| `createMysql2Executor(pool)` | `sql-template-typed/mysql2` | `mysql2/promise` `Pool` → `Executor`. |
-| `createPostgresJsExecutor(client)` | `sql-template-typed/postgres` | `postgres.Sql` → `Executor`. |
-| `createNodeSqliteExecutor(db)` | `sql-template-typed/node-sqlite` | `node:sqlite` `DatabaseSync` → `Executor`. |
-| `createKyselyExecutor(db)` | `sql-template-typed/kysely` | `Kysely<DB>` → `Executor`, via `CompiledQuery.raw`. |
+| `createPgExecutor(pool)` | `@owlsql/core/pg` | `pg.Pool` → `Executor`. |
+| `createMysql2Executor(pool)` | `@owlsql/core/mysql2` | `mysql2/promise` `Pool` → `Executor`. |
+| `createPostgresJsExecutor(client)` | `@owlsql/core/postgres` | `postgres.Sql` → `Executor`. |
+| `createNodeSqliteExecutor(db)` | `@owlsql/core/node-sqlite` | `node:sqlite` `DatabaseSync` → `Executor`. |
+| `createKyselyExecutor(db)` | `@owlsql/core/kysely` | `Kysely<DB>` → `Executor`, via `CompiledQuery.raw`. |
 
 **`query` return type.** `query` resolves to
 `Result<Query<DB, Q>, QueryError>`. On success, `result.value` holds the typed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
-  "name": "sql-template-typed",
-  "version": "0.1.3",
+  "name": "@owlsql/core",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sql-template-typed",
-      "version": "0.1.3",
+      "name": "@owlsql/core",
+      "version": "0.1.4",
       "license": "MIT",
+      "bin": {
+        "owlsql": "dist/cli/index.js"
+      },
       "devDependencies": {
         "@types/mssql": "^12.3.0",
         "@types/node": "^26.1.1",
@@ -25,6 +28,7 @@
       },
       "peerDependencies": {
         "kysely": ">=0.27.0",
+        "mssql": ">=10.0.0",
         "mysql2": ">=3.0.0",
         "pg": ">=8.0.0",
         "postgres": ">=3.0.0",
@@ -32,6 +36,9 @@
       },
       "peerDependenciesMeta": {
         "kysely": {
+          "optional": true
+        },
+        "mssql": {
           "optional": true
         },
         "mysql2": {

--- a/package.json
+++ b/package.json
@@ -93,11 +93,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tiagolauer/owlsql.git"
+    "url": "git+https://github.com/tiagolauer/OwlSQL.git"
   },
-  "homepage": "https://github.com/tiagolauer/owlsql#readme",
+  "homepage": "https://github.com/tiagolauer/OwlSQL#readme",
   "bugs": {
-    "url": "https://github.com/tiagolauer/owlsql/issues"
+    "url": "https://github.com/tiagolauer/OwlSQL/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "sql-template-typed",
-  "version": "0.1.3",
+  "name": "@owlsql/core",
+  "version": "0.1.4",
   "description": "Parse SQL in TypeScript template literal types and infer the result shape from your schema — no codegen, no ORM.",
   "type": "module",
   "sideEffects": false,
@@ -8,7 +8,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "sql-template-typed": "./dist/cli/index.js"
+    "owlsql": "./dist/cli/index.js"
   },
   "exports": {
     ".": {
@@ -81,6 +81,7 @@
     }
   },
   "keywords": [
+    "owlsql",
     "sql",
     "typescript",
     "template-literal-types",
@@ -90,6 +91,14 @@
     "no-codegen"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tiagolauer/owlsql.git"
+  },
+  "homepage": "https://github.com/tiagolauer/owlsql#readme",
+  "bugs": {
+    "url": "https://github.com/tiagolauer/owlsql/issues"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
 
   if (command !== 'generate') {
     process.stderr.write(
-      'Usage: sql-template-typed generate --url <connection-string> [--out ./schema.ts] [--dialect postgres|mysql|sqlite|mssql] [--schema <name>]\n',
+      'Usage: owlsql generate --url <connection-string> [--out ./schema.ts] [--dialect postgres|mysql|sqlite|mssql] [--schema <name>]\n',
     );
     process.exitCode = command === undefined ? 0 : 1;
     return;

--- a/tests/cli-generate.test.ts
+++ b/tests/cli-generate.test.ts
@@ -22,7 +22,7 @@ describe('detectDialect', () => {
 
 describe('runGenerate (end to end against a real sqlite file)', () => {
   it('introspects the database and writes the rendered schema to --out', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'sql-template-typed-'));
+    const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
     const dbFile = join(dir, 'app.db');
     const outFile = join(dir, 'schema.ts');
 
@@ -49,7 +49,7 @@ describe('runGenerate (end to end against a real sqlite file)', () => {
   });
 
   it('throws a clear error when no tables are found', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'sql-template-typed-'));
+    const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
     const dbFile = join(dir, 'empty.db');
 
     try {

--- a/tests/cli-sqlite-introspect.test.ts
+++ b/tests/cli-sqlite-introspect.test.ts
@@ -6,7 +6,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { introspectSqlite } from '../src/cli/dialects/sqlite';
 
 function withTempDatabase(setup: (db: DatabaseSync) => void): string {
-  const dir = mkdtempSync(join(tmpdir(), 'sql-template-typed-'));
+  const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
   const file = join(dir, 'test.db');
   const db = new DatabaseSync(file);
   setup(db);

--- a/tests/ts-plugin-completions.test.ts
+++ b/tests/ts-plugin-completions.test.ts
@@ -24,7 +24,7 @@ db.query(\`select id, na from posts\`);
 `;
 
 function buildProgram(source: string): { program: ts.Program; sourceFile: ts.SourceFile; filePath: string; dir: string } {
-  const dir = mkdtempSync(join(tmpdir(), 'sql-template-typed-ts-plugin-'));
+  const dir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-'));
   const filePath = join(dir, 'fixture.ts');
   writeFileSync(filePath, source, 'utf8');
 


### PR DESCRIPTION
## Summary

Renames the project and npm package from `sql-template-typed` to **OwlSQL** (`@owlsql/core`).

"TypeSQL" was the original pick, but an existing, actively-maintained project with the same name and a nearly identical pitch already exists (github.com/wsporto/typesql, generates typesafe TypeScript APIs from raw SQL, supports Postgres/MySQL/SQLite/LibSQL/D1) — checked before committing to anything, landed on OwlSQL instead. Verified free on npm (`owlsql` and `@owlsql/core` both) and no existing project collision found.

Scoped as `@owlsql/core` (not a bare `owlsql`) specifically so a future real split into separate driver/tool packages doesn't require renaming again — but this PR is a naming decision only. Package structure is unchanged: adapters and the ts-plugin stay as subpath exports (`@owlsql/core/pg`, `@owlsql/core/ts-plugin`, etc), same as before.

- `package.json`: name → `@owlsql/core`, bin → `owlsql`, version → `0.1.4` (continuing the existing version history rather than resetting to 0.1.0), added `repository`/`homepage`/`bugs` pointing at the GitHub repo (already renamed to `tiagolauer/OwlSQL` — confirmed via `gh repo view`, casing matched).
- README/COMPARISON.md/CONTRIBUTING.md: prose and code samples updated, distinguishing narrative mentions ("OwlSQL ships...") from literal package references (`@owlsql/core`, `npx @owlsql/core generate` — not `npx owlsql generate`, since a bare unscoped `npx` call would try to fetch a nonexistent package before anything's installed locally).
- CLI usage string, cosmetic temp-dir-prefix strings in three test files.

## Test plan

- [x] `npm run test:types && npm run test:runtime` — full suite green under the new name (47 tests)
- [x] Local build + a separate throwaway project installing the freshly-built local package and importing both `@owlsql/core` and `@owlsql/core/pg` — 0 type errors, not just a visual diff check

## Still pending (not this PR)

- Creating the `owlsql` org on npmjs.com and publishing under the new scoped name — account-level action, stays the maintainer's call.
- The `github-polish` branch (ROADMAP.md, example projects) predates this rename and still needs its naming swept — follow-up PR.