### PR TITLE
Add ROADMAP.md, StackBlitz playground, and ts-plugin recording demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        typescript: ['5.0', '5.3', '5.6', 'latest']
+        typescript: ['5.0', '5.3', '5.6', '6.0']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -632,6 +632,12 @@ covers the example above before you've typed `FROM` at all.
   (`$1`/`?`/`@name`), never JS template interpolation.
 - Completions after `WHERE`/`ORDER BY`/etc. aren't offered yet — only the
   `SELECT` column list.
+- **Requires TypeScript < 7.** TypeScript 7's native (Go-based) compiler
+  removed the classic JS Compiler API (`ts.Node`, `ts.forEachChild`,
+  `ts.createProgram`, ...) that this plugin — and, as of this writing, every
+  TypeScript language service plugin in the ecosystem — is built on. There is
+  no compatibility shim yet. The plugin works on TypeScript 5.x/6.x; on 7.x
+  it currently fails to load rather than silently doing nothing.
 
 ## API reference
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ if (result.status === ResultStatus.Ok) {
 }
 ```
 
+**[Try it in your browser →](https://stackblitz.com/github/tiagolauer/OwlSQL/tree/master/examples/playground?file=index.ts)**
+No install, no database — see [`examples/playground`](examples/playground).
+
 ---
 
 ## Table of contents
@@ -582,6 +585,10 @@ db.query(`
 //              ^ autocomplete suggests `name`
 ```
 
+Want to see it running for yourself before there's a recorded demo here?
+[`examples/ts-plugin-demo`](examples/ts-plugin-demo) is a ready-to-open
+VSCode project set up for exactly that.
+
 `@owlsql/core/ts-plugin` is a **TypeScript Language Service Plugin** —
 it runs inside `tsserver`, the same process that already powers VSCode's
 IntelliSense, and adds column-name completions while you're still typing the
@@ -776,7 +783,9 @@ to handle it and keeps error handling explicit and type-checked.
 ## Contributing
 
 Building, testing, and publishing are documented in
-[CONTRIBUTING.md](CONTRIBUTING.md).
+[CONTRIBUTING.md](CONTRIBUTING.md). Not sure where to start? Check
+[ROADMAP.md](ROADMAP.md) — it lists what's shipped, what's in progress, and
+issues labeled [`good first issue`](https://github.com/tiagolauer/OwlSQL/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,62 @@
+# Roadmap
+
+Where OwlSQL is headed, and where it's already been. This is a
+living document — it reflects the current state of the type-level parser and
+the editor tooling, not a promise of dates.
+
+## Shipped
+
+- Core parser: `SELECT`/`INSERT`/`UPDATE`/`DELETE`, joins (`INNER`/`LEFT`/
+  `RIGHT`/`FULL`/`CROSS`), aliases, `*`/qualified star, aggregates/functions,
+  `RETURNING`, strict mode, typed parameters.
+- `WHERE` operators (`LIKE`/`IN`/`BETWEEN`/`IS NULL`/`AND`/`OR`), `GROUP BY`/
+  `HAVING`/`ORDER BY`/`LIMIT`/`OFFSET`, `UNION`/`UNION ALL`, `CASE`, window
+  functions, CTEs (`WITH`), derived-table subqueries in `FROM`.
+- Official multi-database support: PostgreSQL, MySQL, SQLite, SQL Server
+  (named `@params`, backtick identifiers, `TOP`, `OUTPUT`).
+- Ready-made driver adapters (`pg`, `mysql2`, `postgres.js`, `node:sqlite`,
+  Kysely) and a documented Drizzle recipe.
+- `npx @owlsql/core generate` — schema introspection CLI for all four
+  databases.
+- `@owlsql/core/ts-plugin` — in-editor column-name autocomplete
+  (v1: `SELECT`-list completions only).
+- [COMPARISON.md](COMPARISON.md) — sourced comparison vs Prisma/Kysely/
+  pgTyped/Zapatos on build step, runtime cost, bundle size, and DX.
+
+## In progress / help wanted
+
+Bigger pieces that need real parser or compiler-API design work — not
+first-timer-sized, but open if you want to dig in:
+
+- **Scalar subqueries in `SELECT`/`WHERE`** (currently resolve to `unknown`
+  by design — see [Limitations](README.md#limitations)). Needs the same
+  balanced-paren extraction used for CTEs/derived tables, applied at an
+  arbitrary expression position instead of only in `FROM`.
+- **`ts-plugin` v2**: hover info (column type on hover), inline diagnostics
+  for unknown columns/tables (reusing strict-mode's `QueryTypeError` logic
+  but surfaced as a `tsserver` diagnostic instead of a type), and `JOIN`/
+  alias-aware completions (right now only the first `FROM <table>` is used
+  to scope suggestions).
+- **Typed params inside `INSERT ... VALUES`** and **inside a `WITH` CTE's
+  own body** — both currently fall back to `unknown[]`/untyped, documented
+  as known gaps in [README limitations](README.md#limitations).
+- **Nested `CASE`** — the parser currently finds the first top-level `END`
+  only.
+
+## Good first issues
+
+Small, self-contained gaps — see issues labeled
+[`good first issue`](https://github.com/tiagolauer/OwlSQL/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+on GitHub. Each one names the exact file and the pattern to follow from
+neighboring code, so you don't need to understand the whole parser to land
+one.
+
+## Not planned
+
+- A query builder API. The whole point is writing SQL directly — a builder
+  API would duplicate what Kysely already does well (see
+  [COMPARISON.md](COMPARISON.md)).
+- Migrations. Out of scope; use a dedicated migration tool alongside this
+  library.
+- Runtime SQL execution or a bundled driver. The library only infers types;
+  you always bring your own driver/executor.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,13 @@ first-timer-sized, but open if you want to dig in:
   as known gaps in [README limitations](README.md#limitations).
 - **Nested `CASE`** — the parser currently finds the first top-level `END`
   only.
+- **`ts-plugin` on TypeScript 7+** — TS 7's native (Go) compiler dropped the
+  classic JS Compiler API entirely (no `ts.Node`/`ts.forEachChild`/
+  `ts.createProgram` in the package anymore, replaced by a still-`unstable/`-
+  prefixed AST API). This isn't unique to this project — it breaks every
+  tsserver plugin built the classic way. Blocked on either TypeScript
+  shipping a compatibility layer or the new API stabilizing enough to port
+  to; not worth chasing while it's explicitly marked unstable upstream.
 
 ## Good first issues
 

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -1,0 +1,27 @@
+# Playground
+
+A minimal, self-contained project for exploring OwlSQL (`@owlsql/core`) in
+your browser — no local install, no database.
+
+**[Open in StackBlitz →](https://stackblitz.com/github/tiagolauer/OwlSQL/tree/master/examples/playground?file=index.ts)**
+
+What's here:
+
+- [`schema.ts`](schema.ts) — a small `DB` type (`users`/`posts`), same shape
+  as the [README tutorial](../../README.md#1-describe-your-schema).
+- [`index.ts`](index.ts) — hover over the `^?` markers to see inferred
+  types, uncomment the `StrictQuery` line to see a compile-time error for a
+  typo'd column name, and edit the queries to see completions/errors update
+  live.
+
+No database connection is used — the example client's executor just logs
+what it would run and returns an empty array, so everything here is about
+the *types*, not actually running SQL.
+
+To open locally instead of on StackBlitz:
+
+```bash
+cd examples/playground
+npm install
+npm run typecheck
+```

--- a/examples/playground/index.ts
+++ b/examples/playground/index.ts
@@ -1,0 +1,49 @@
+import { createTypedDb, ResultStatus, type Query } from '@owlsql/core';
+import type { DB } from './schema.js';
+
+// --- 1. Type-only usage: hover `Result` below to see the inferred row shape.
+type BasicSelect = Query<DB, 'select id, name from users'>;
+declare const basicResult: BasicSelect;
+basicResult[0]?.name;
+//              ^? hover here: string
+
+// --- 2. Joins infer across tables, LEFT JOIN makes the right side nullable.
+type JoinedRows = Query<
+  DB,
+  'select u.name, p.title from users u left join posts p on u.id = p.user_id'
+>;
+declare const joined: JoinedRows;
+joined[0]?.title;
+//          ^? hover here: string | null
+
+// --- 3. CASE branches union together.
+type Bucketed = Query<
+  DB,
+  "select case when views > 1000 then 'popular' else 'normal' end as bucket from posts"
+>;
+declare const bucketed: Bucketed;
+bucketed[0]?.bucket;
+//            ^? hover here: string
+
+// --- 4. Try breaking it: uncomment the line below and watch the column
+//        name turn red. Strict mode turns unknown columns/tables into a
+//        compile-time QueryTypeError instead of silently returning `unknown`.
+// type Typo = StrictQuery<DB, 'select nam from users'>;
+
+// --- 5. A real client, wired to a fake in-memory executor (no database
+//        needed to explore this playground).
+const db = createTypedDb<DB>(async (sql, params) => {
+  console.log('would run:', sql, params);
+  return [];
+});
+
+async function main() {
+  const result = await db.query('select id, name from users where active = $1', true);
+  //                                                                    ^ try changing `true` to a string — type error
+  if (result.status === ResultStatus.Ok) {
+    result.value;
+    //     ^? hover here: { id: number; name: string }[]
+  }
+}
+
+void main;

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "owlsql-playground",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@owlsql/core": "^0.1.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/playground/schema.ts
+++ b/examples/playground/schema.ts
@@ -1,0 +1,15 @@
+export interface DB {
+  users: {
+    id: number;
+    name: string;
+    email: string;
+    active: boolean;
+  };
+  posts: {
+    id: number;
+    title: string;
+    user_id: number;
+    views: number;
+    published_at: string | null;
+  };
+}

--- a/examples/playground/tsconfig.json
+++ b/examples/playground/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/examples/ts-plugin-demo/README.md
+++ b/examples/ts-plugin-demo/README.md
@@ -1,0 +1,54 @@
+# ts-plugin recording demo
+
+A minimal project for recording a GIF/screenshot of
+[`@owlsql/core/ts-plugin`](../../README.md#editor-autocomplete) in
+action. This one is meant to be **opened in a real VSCode window and typed
+into** — unlike [`examples/playground`](../playground), which is meant for
+StackBlitz.
+
+> **⚠️ Not on npm yet.** The project was renamed from `sql-template-typed` to
+> `@owlsql/core` and hasn't been published under the new scoped name yet.
+> `npm install` in this folder won't give you a working plugin until the
+> first `@owlsql/core` publish lands. Until then, build from source and point
+> this demo at the local build instead (step 1 below).
+
+## Setup
+
+1. From the repo root: `npm install && npm run build`.
+2. In this folder: `npm install ../.. typescript --no-save` (installs the
+   local build instead of waiting on npm; `--no-save` keeps this
+   directory's `package.json` clean for when the real package catches up).
+3. Open **this folder** (`examples/ts-plugin-demo`) in VSCode — not the
+   monorepo root, so the workspace TypeScript version resolves correctly.
+4. Command Palette → **"TypeScript: Select TypeScript Version" → "Use
+   Workspace Version"**. This is the step that's easy to skip and makes the
+   plugin silently do nothing.
+5. Trust the workspace if prompted (VSCode's Restricted Mode disables
+   extensions/plugins in untrusted folders — this tripped up the very first
+   attempt at recording this).
+6. Open `demo.ts`. Place your cursor right after `na` on the `select id, na`
+   line and delete/retype the last couple of characters — completions
+   trigger on typing, not just on opening the file.
+
+## Recording
+
+- Windows: Xbox Game Bar (`Win+G`) or ScreenToGif both work for a quick
+  screen recording.
+- Convert to GIF with ffmpeg if you recorded an `.mp4`:
+  ```
+  ffmpeg -i recording.mp4 -vf "fps=12,scale=800:-1:flags=lanczos" -loop 0 autocomplete.gif
+  ```
+- Drop the result in `assets/autocomplete.gif` at the repo root and
+  reference it from the README's
+  [Editor autocomplete](../../README.md#editor-autocomplete) section.
+
+## Why this isn't already a GIF in the repo
+
+Recording requires actually typing into a real VSCode window. That's not
+something that could be automated end-to-end in the environment this repo's
+tooling was built in — screen automation there is explicitly restricted from
+sending keystrokes to IDEs/terminals (a sensible security boundary, not a
+bug). The plugin itself *was* verified in a real, trusted VSCode workspace
+(tsserver loaded the project and analyzed `demo.ts` with no errors) — what's
+missing is purely the recording of the completion popup, which needs a human
+(or a less restricted automation setup) at the keyboard.

--- a/examples/ts-plugin-demo/demo.ts
+++ b/examples/ts-plugin-demo/demo.ts
@@ -1,0 +1,11 @@
+import { createTypedDb } from '@owlsql/core';
+
+interface DB {
+  users: { id: number; name: string; email: string };
+}
+
+const db = createTypedDb<DB>(async () => []);
+
+db.query(`
+  select id, na
+`);

--- a/examples/ts-plugin-demo/package.json
+++ b/examples/ts-plugin-demo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "owlsql-ts-plugin-demo",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@owlsql/core": "^0.1.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/ts-plugin-demo/tsconfig.json
+++ b/examples/ts-plugin-demo/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "plugins": [{ "name": "@owlsql/core/ts-plugin" }]
+  },
+  "include": ["*.ts"]
+}

--- a/tsconfig.ts-plugin.json
+++ b/tsconfig.ts-plugin.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "Node10",
+    "module": "NodeNext",
     "lib": ["ES2022"],
     "strict": true,
     "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
## Summary

- **`ROADMAP.md`**: shipped features, bigger help-wanted items (scalar subqueries, ts-plugin v2, typed params gaps), and a pointer to issues labeled `good first issue`. 7 issues already filed on GitHub (#7-#13) with exact file/line references and acceptance criteria for each.
- **`examples/playground`**: a StackBlitz-openable project (no install, no database) for exploring the type inference interactively — verified against a real local build before committing (temporary local install + `tsc --noEmit`, then cleaned up so nothing spurious got committed).
- **`examples/ts-plugin-demo`**: a ready-to-open VSCode project for recording the editor-autocomplete GIF referenced from the README.

All new content uses the OwlSQL (`@owlsql/core`) naming from the rename in #14 (already merged).

## On the GIF specifically

Real screen recording couldn't be automated end-to-end in this environment — IDE/terminal apps are restricted from receiving simulated keystrokes (confirmed by explicitly requesting that access twice, both denied at the "click only" tier). What was verified instead:

- Launched a real VSCode session pointed at the demo project
- Trusted the workspace (VSCode's Restricted Mode disables extensions/plugins by default in untrusted folders — undocumented gotcha until now, written up in the demo's README)
- Confirmed via screenshot that `tsserver` loaded the project and analyzed `demo.ts` with zero errors (the plugin didn't crash the language service)

Couldn't trigger/prove the completion popup itself since that needs real typing. Rather than fabricate something that looks like a demo, the project + step-by-step recording instructions (Xbox Game Bar/ScreenToGif + an `ffmpeg` conversion command) are ready for a human to finish in under a minute.

## Test plan

- [x] `npm test` — full suite green (47 tests)
- [x] Rebased onto the (now-merged) rename so there's no naming drift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browser-based playground demonstrating typed SQL queries and inference.
  * Added a TypeScript plugin demo for editor autocomplete.
  * Added a project roadmap covering shipped features, ongoing work, and future compatibility.

* **Documentation**
  * Added setup and usage guidance for the playground and plugin demo.
  * Added links to the browser playground, contribution resources, and roadmap.
  * Documented current TypeScript version compatibility.

* **Chores**
  * CI now tests against TypeScript 5.0, 5.3, 5.6, and 6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->