### PR TITLE
fix: map postgres time types to string

### DIFF
--- a/src/cli/dialects/postgres.ts
+++ b/src/cli/dialects/postgres.ts
@@ -23,8 +23,8 @@ const POSTGRES_SCALAR_TYPES: Record<string, string> = {
   timestamp: 'Date',
   timestamptz: 'Date',
   date: 'Date',
-  time: 'Date',
-  timetz: 'Date',
+  time: 'string',
+  timetz: 'string',
 };
 
 export function mapPostgresType(udtName: string): string {

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -24,6 +24,11 @@ describe('mapPostgresType', () => {
     expect(mapPostgresType('bytea')).toBe('Buffer');
   });
 
+  it('maps time-only values to strings to match pg defaults', () => {
+    expect(mapPostgresType('time')).toBe('string');
+    expect(mapPostgresType('timetz')).toBe('string');
+  });
+
   it('maps array udt names (leading underscore) to T[]', () => {
     expect(mapPostgresType('_int4')).toBe('number[]');
     expect(mapPostgresType('_text')).toBe('string[]');


### PR DESCRIPTION
## Summary
Postgres schema generation now maps `time` and `timetz` columns to `string` instead of `Date`, matching node-postgres default parsing behavior.

## Root cause
The Postgres type map treated `time` and `timetz` like `date`, `timestamp`, and `timestamptz`. node-postgres only parses date/timestamp variants into JavaScript `Date` objects by default; unregistered types are returned as strings.

## Changes
- Updated the Postgres scalar type map for `time` and `timetz`.
- Added regression coverage for both type mappings.

## Testing
- `npm run test:runtime -- tests/cli-type-mapping.test.ts`
- `npm run test:types`
- `npm run test:runtime`
- `npm test`

Fixes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL `time` and `timetz` columns are now correctly represented as `string` values instead of dates.
  * Improved type accuracy for PostgreSQL schema introspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->