### PR TITLE
Fix: paren-unaware from-boundary scan corrupts SELECT list

### DIFF
--- a/src/from.ts
+++ b/src/from.ts
@@ -6,6 +6,7 @@ import type {
   Unquote,
   StripQualifier,
   ExtractParenGroup,
+  ApplyParenDelta,
 } from './string.js';
 
 export interface Source {
@@ -32,25 +33,6 @@ type ClauseBoundary =
 type IsBoundary<Word extends string> = Lowercase<Word> extends ClauseBoundary
   ? true
   : false;
-
-type OpenCount<S extends string, Accumulated extends unknown[] = []> = S extends `${string}(${infer After}`
-  ? OpenCount<After, [...Accumulated, unknown]>
-  : Accumulated;
-
-type CloseCount<S extends string, Accumulated extends unknown[] = []> = S extends `${string})${infer After}`
-  ? CloseCount<After, [...Accumulated, unknown]>
-  : Accumulated;
-
-type PopN<Depth extends unknown[], N extends unknown[]> = N extends [unknown, ...infer NRest]
-  ? Depth extends [unknown, ...infer DepthRest]
-    ? PopN<DepthRest, NRest>
-    : Depth
-  : Depth;
-
-type ApplyParenDelta<Depth extends unknown[], Token extends string> = PopN<
-  [...Depth, ...OpenCount<Token>],
-  CloseCount<Token>
->;
 
 type TakeFromClause<
   S extends string,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -8,6 +8,7 @@ import type {
   IsKeyword,
   Unquote,
   ExtractParenGroup,
+  ApplyParenDelta,
 } from './string.js';
 import type {
   IsFunctionCall,
@@ -50,13 +51,18 @@ type StripTopClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'top'> ext
 
 type ColumnsBeforeFrom<
   S extends string,
+  Depth extends unknown[] = [],
   Accumulated extends string = '',
 > = S extends `${infer Head} ${infer Tail}`
-  ? IsKeyword<Head, 'from'> extends true
-    ? { columns: Trim<Accumulated>; afterFrom: Tail }
-    : ColumnsBeforeFrom<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
-  : IsKeyword<S, 'from'> extends true
-    ? { columns: Trim<Accumulated>; afterFrom: '' }
+  ? Depth extends []
+    ? IsKeyword<Head, 'from'> extends true
+      ? { columns: Trim<Accumulated>; afterFrom: Tail }
+      : ColumnsBeforeFrom<Tail, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+    : ColumnsBeforeFrom<Tail, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+  : Depth extends []
+    ? IsKeyword<S, 'from'> extends true
+      ? { columns: Trim<Accumulated>; afterFrom: '' }
+      : never
     : never;
 
 type AfterKeyword<S extends string, Keyword extends string> =
@@ -184,6 +190,18 @@ type IsWindowExpression<Entry extends string> = [SplitWindowExpression<Entry>] e
   ? false
   : true;
 
+type SplitParenthesizedEntry<Entry extends string> = StripLeadingOpenParen<Entry> extends infer AfterOpen extends string
+  ? [AfterOpen] extends [never]
+    ? never
+    : ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string; rest: infer AfterClose extends string }
+      ? { expr: `(${Inner})`; after: Trim<AfterClose> }
+      : never
+  : never;
+
+type IsParenthesizedEntry<Entry extends string> = [SplitParenthesizedEntry<Entry>] extends [never]
+  ? false
+  : true;
+
 type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends true
   ? SplitCaseExpression<Entry> extends { body: infer Body extends string; alias: infer Alias extends string }
     ? [Alias, `case ${Body} end`]
@@ -196,7 +214,15 @@ type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends tr
           ? [Unquote<Trim<DropFirstWord<After>>>, Expr]
           : [Unquote<Trim<After>>, Expr]
       : [OutputName<Trim<Entry>>, Trim<Entry>]
-    : Entry extends `${infer Expression} ${infer Middle} ${infer Alias}`
+    : IsParenthesizedEntry<Entry> extends true
+      ? SplitParenthesizedEntry<Entry> extends { expr: infer Expr extends string; after: infer After extends string }
+        ? After extends ''
+          ? [Trim<Entry>, Expr]
+          : IsKeyword<FirstWord<After>, 'as'> extends true
+            ? [Unquote<Trim<DropFirstWord<After>>>, Expr]
+            : [Unquote<Trim<After>>, Expr]
+        : [Trim<Entry>, Trim<Entry>]
+      : Entry extends `${infer Expression} ${infer Middle} ${infer Alias}`
       ? IsKeyword<Middle, 'as'> extends true
         ? [Unquote<Trim<Alias>>, Trim<Expression>]
         : [OutputName<Entry>, Entry]

--- a/src/string.ts
+++ b/src/string.ts
@@ -69,3 +69,28 @@ type ScanParenGroup<
   : { inner: Inner; rest: '' };
 
 export type ExtractParenGroup<S extends string> = ScanParenGroup<S, [], ''>;
+
+export type OpenCount<
+  S extends string,
+  Accumulated extends unknown[] = [],
+> = S extends `${string}(${infer After}`
+  ? OpenCount<After, [...Accumulated, unknown]>
+  : Accumulated;
+
+export type CloseCount<
+  S extends string,
+  Accumulated extends unknown[] = [],
+> = S extends `${string})${infer After}`
+  ? CloseCount<After, [...Accumulated, unknown]>
+  : Accumulated;
+
+type PopN<Depth extends unknown[], N extends unknown[]> = N extends [unknown, ...infer NRest]
+  ? Depth extends [unknown, ...infer DepthRest]
+    ? PopN<DepthRest, NRest>
+    : Depth
+  : Depth;
+
+export type ApplyParenDelta<Depth extends unknown[], Token extends string> = PopN<
+  [...Depth, ...OpenCount<Token>],
+  CloseCount<Token>
+>;

--- a/tests/paren-boundary.test-d.ts
+++ b/tests/paren-boundary.test-d.ts
@@ -1,0 +1,48 @@
+import type { Query } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; created_at: Date };
+  orders: { id: number; user_id: number; price: number };
+}
+
+type ScalarSubqueryKeepsSiblingColumns = Expect<
+  Equal<
+    Query<DB, 'select (select max(id) from orders) as m, name from users'>,
+    { m: unknown; name: string }[]
+  >
+>;
+
+type ScalarSubqueryNoAliasFallsBackToRawText = Expect<
+  Equal<
+    Query<DB, 'select (select max(id) from orders), name from users'>,
+    { '(select max(id) from orders)': unknown; name: string }[]
+  >
+>;
+
+type ParenthesizedArithmeticGroupResolvesAlias = Expect<
+  Equal<
+    Query<DB, 'select (price * 2) as total, id from orders'>,
+    { total: unknown; id: number }[]
+  >
+>;
+
+type FunctionArgWithFromKeywordKeepsSiblingColumns = Expect<
+  Equal<
+    Query<DB, 'select extract(year from created_at) as y, id from users'>,
+    { 'extract(year from created_at) as y': unknown; id: number }[]
+  >
+>;
+
+export type BehaviorLock = [
+  ScalarSubqueryKeepsSiblingColumns,
+  ScalarSubqueryNoAliasFallsBackToRawText,
+  ParenthesizedArithmeticGroupResolvesAlias,
+  FunctionArgWithFromKeywordKeepsSiblingColumns,
+];


### PR DESCRIPTION
## What

Fixes #17.

`ColumnsBeforeFrom` split the SELECT/FROM boundary at the first `from` token, with no notion of parenthesis depth. A `from` inside a parenthesized subquery or function call was treated as the real clause boundary, corrupting the column list and misparsing the FROM clause:

```ts
Query<DB, 'select (select max(id) from orders) as m, name from users'>
// before: name column dropped, FROM clause misparsed as "orders) as m, name"
// after:  { m: unknown; name: string }[]
```

## How

- Moved the paren-depth counter (`OpenCount`/`CloseCount`/`PopN`/`ApplyParenDelta`) that `from.ts` already used for its own boundary scans into `string.ts`, exported, so it's one implementation instead of two.
- Threaded the same depth tracking through `ColumnsBeforeFrom` in `parse.ts` (same shape as `TakeFromClause`).
- Added a parenthesized-entry branch to `ParseColumnEntry`, mirroring the existing window-expression handling, so `(select ...) as alias` and `(expr) as alias` resolve their alias correctly instead of falling through to the generic split (which only handles single-word expressions before `as`).

## Known non-goal

`extract(year from created_at) as y` still keys by its raw text instead of `y` - that's the pre-existing, documented "function arguments must not contain spaces" limitation, unrelated to this fix. What changes is that it no longer drops sibling columns or misparses the FROM clause.

## Test plan

- [x] `npm test` (types + runtime) green
- [x] New `tests/paren-boundary.test-d.ts` locks: scalar subquery with sibling column, scalar subquery with no alias, parenthesized arithmetic group, function-call-with-embedded-`from` no longer corrupting siblings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL parsing for parenthesized expressions and nested content.
  - Prevented `FROM` keywords inside parentheses from incorrectly ending the selected column list.
  - Improved alias detection for parenthesized expressions, including aliases specified with or without `AS`.
  - Preserved sibling columns when parsing scalar subqueries and function arguments.

- **Tests**
  - Added coverage for nested expressions, scalar subqueries, aliases, and parenthesis boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->