### PR TITLE
CLI: support --flag=value syntax in parseFlags

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,7 @@ import { runGenerate } from './generate.js';
 
 const DIALECTS: Dialect[] = ['postgres', 'mysql', 'sqlite', 'mssql'];
 
-function parseFlags(args: string[]): Map<string, string> {
+export function parseFlags(args: string[]): Map<string, string> {
   const flags = new Map<string, string>();
 
   for (let index = 0; index < args.length; index += 1) {
@@ -13,13 +13,19 @@ function parseFlags(args: string[]): Map<string, string> {
       continue;
     }
 
-    const name = arg.slice(2);
-    const value = args[index + 1];
-    if (value === undefined || value.startsWith('--')) {
-      throw new Error(`Missing value for --${name}`);
+    const body = arg.slice(2);
+    const equalsIndex = body.indexOf('=');
+    if (equalsIndex !== -1) {
+      flags.set(body.slice(0, equalsIndex), body.slice(equalsIndex + 1));
+      continue;
     }
 
-    flags.set(name, value);
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for --${body}`);
+    }
+
+    flags.set(body, value);
     index += 1;
   }
 

--- a/tests/cli-flags.test.ts
+++ b/tests/cli-flags.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { parseFlags } from '../src/cli/index';
+
+describe('parseFlags', () => {
+  it('parses the spaced form', () => {
+    const flags = parseFlags(['--url', 'postgres://localhost/db', '--out', './schema.ts']);
+    expect(flags.get('url')).toBe('postgres://localhost/db');
+    expect(flags.get('out')).toBe('./schema.ts');
+  });
+
+  it('parses the --flag=value form', () => {
+    const flags = parseFlags(['--url=postgres://localhost/db', '--schema=app']);
+    expect(flags.get('url')).toBe('postgres://localhost/db');
+    expect(flags.get('schema')).toBe('app');
+  });
+
+  it('mixes the spaced and equals forms in the same call', () => {
+    const flags = parseFlags(['--url=postgres://localhost/db', '--out', './schema.ts']);
+    expect(flags.get('url')).toBe('postgres://localhost/db');
+    expect(flags.get('out')).toBe('./schema.ts');
+  });
+
+  it('passes a value starting with -- through the equals form', () => {
+    const flags = parseFlags(['--url=--weird-value']);
+    expect(flags.get('url')).toBe('--weird-value');
+  });
+
+  it('still rejects a missing value in the spaced form', () => {
+    expect(() => parseFlags(['--url'])).toThrow('Missing value for --url');
+    expect(() => parseFlags(['--url', '--out', './schema.ts'])).toThrow('Missing value for --url');
+  });
+});


### PR DESCRIPTION
Fixes #25.

## What

`parseFlags` in `src/cli/index.ts` only understood the spaced `--flag value` form. `--flag=value` failed with a misleading error (`Missing value for --url=postgres://...`), since the whole `flag=value` fragment was read as the flag name.

## Fix

Split each token on its first `=` before falling back to the spaced-form handling. As a side effect this also lets a value legitimately start with `--` when passed via the equals form (`--url=--weird-value`), since it bypasses the spaced form's `startsWith('--')` guard entirely.

## Test plan

- [x] `npm test` (types + runtime) green, 53/53
- [x] New `tests/cli-flags.test.ts`: spaced form, equals form, mixed in one call, `--`-prefixed value via equals, missing-value error still thrown for the spaced form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command-line flags now support both `--key value` and `--key=value` formats.
  * Improved error messages identify the specific flag missing a value.

* **Tests**
  * Added coverage for mixed flag formats, values beginning with `--`, and missing-value errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->