### PR TITLE
generate: SQLite BOOLEAN columns typed as 0 | 1, not boolean

### DIFF
--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -4,7 +4,7 @@ export function mapSqliteType(declaredType: string): string {
   const type = declaredType.toUpperCase().trim();
 
   if (type === 'BOOLEAN') {
-    return 'boolean';
+    return '0 | 1';
   }
 
   if (type === 'DATE' || type === 'DATETIME' || type === 'TIMESTAMP') {

--- a/tests/cli-sqlite-introspect.test.ts
+++ b/tests/cli-sqlite-introspect.test.ts
@@ -36,7 +36,7 @@ describe('introspectSqlite', () => {
         { name: 'id', tsType: 'number', nullable: true },
         { name: 'name', tsType: 'string', nullable: false },
         { name: 'bio', tsType: 'string', nullable: true },
-        { name: 'active', tsType: 'boolean', nullable: false },
+        { name: 'active', tsType: '0 | 1', nullable: false },
       ]);
     } finally {
       rmSync(join(file, '..'), { recursive: true, force: true });

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -73,7 +73,7 @@ describe('mapSqliteType', () => {
   });
 
   it('special-cases BOOLEAN and DATE-like declared types', () => {
-    expect(mapSqliteType('BOOLEAN')).toBe('boolean');
+    expect(mapSqliteType('BOOLEAN')).toBe('0 | 1');
     expect(mapSqliteType('DATE')).toBe('string');
     expect(mapSqliteType('DATETIME')).toBe('string');
   });


### PR DESCRIPTION
Fixes #24.

## What

`mapSqliteType` in `src/cli/dialects/sqlite.ts` mapped a declared `BOOLEAN` column to `boolean`. SQLite has no boolean storage class, and `node:sqlite` reflects that on both sides:

- A `SELECT` on a `BOOLEAN` column returns the number `0`/`1`, not `true`/`false`.
- Binding an actual `true`/`false` to a parameter throws: `Provided value cannot be bound to SQLite parameter`.

So the generated `boolean` type was wrong both ways: `row.active === true` never matches what the driver returns, and a typed `where active = ?` parameter (via `InferParams`) would demand a `true`/`false` value the driver rejects at runtime.

## Fix

Map `BOOLEAN` to `0 | 1` instead of `boolean` or a bare `number` - matches what the driver actually returns/accepts while keeping the declared intent visible in the generated schema.

## Test plan

- [x] `npm test` (types + runtime) green, 53/53
- [x] `tests/cli-type-mapping.test.ts` updated (`mapSqliteType('BOOLEAN')` now expects `'0 | 1'`)
- [x] `tests/cli-sqlite-introspect.test.ts` updated (real `node:sqlite` end-to-end introspection of a `boolean not null` column)