### PR TITLE
generate: SQL Server introspection ignores --schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ commit it, edit it by hand afterward, rename fields, anything. Running
 | `--url` | yes | Connection string (or a file path for SQLite). |
 | `--out` | no | Output file. Defaults to `./schema.ts`. |
 | `--dialect` | no | `postgres` \| `mysql` \| `sqlite` \| `mssql`. Auto-detected from the URL scheme (`postgres://`/`postgresql://`, `mysql://`, `mssql://`/`sqlserver://`) — falls back to `sqlite` for a bare file path, so it's only needed when that's ambiguous. |
-| `--schema` | no | Schema/database name to introspect. Defaults to `public` (Postgres) or the connected database (MySQL). Not used for SQLite/SQL Server. |
+| `--schema` | no | Schema/database name to introspect. Defaults to `public` (Postgres), the connected database (MySQL), or `dbo` (SQL Server). Not used for SQLite. |
 
 `generate` needs the matching driver installed as a real dependency (`pg`,
 `mysql2`, or `mssql` — SQLite uses the `node:sqlite` builtin, Node ≥22.5). It

--- a/src/cli/dialects/mssql.ts
+++ b/src/cli/dialects/mssql.ts
@@ -53,16 +53,21 @@ export async function introspectMssql(connection: ConnectionInfo): Promise<Table
   }
 
   const pool = await connect(connection.url);
+  const schema = connection.schema ?? 'dbo';
 
   try {
-    const result = await pool.request().query<MssqlColumnRow>(
-      `select t.name as table_name, c.name as column_name, ty.name as data_type,
-              c.is_nullable as is_nullable
-       from sys.tables t
-       join sys.columns c on c.object_id = t.object_id
-       join sys.types ty on ty.user_type_id = c.user_type_id
-       order by t.name, c.column_id`,
-    );
+    const result = await pool
+      .request()
+      .input('schema', schema)
+      .query<MssqlColumnRow>(
+        `select t.name as table_name, c.name as column_name, ty.name as data_type,
+                c.is_nullable as is_nullable
+         from sys.tables t
+         join sys.columns c on c.object_id = t.object_id
+         join sys.types ty on ty.user_type_id = c.user_type_id
+         where schema_name(t.schema_id) = @schema
+         order by t.name, c.column_id`,
+      );
 
     return groupColumns(result.recordset);
   } finally {


### PR DESCRIPTION
Fixes #22.

## What

`introspectMssql` in `src/cli/dialects/mssql.ts` queried `sys.tables`/`sys.columns`/`sys.types` with no schema filter at all, unlike the Postgres and MySQL introspectors which both scope by schema. Two consequences:

- `owlsql generate --url mssql://... --schema app` silently behaved as if `--schema` wasn't passed.
- Two tables with the same name in different schemas (`dbo.users`, `app.users`) merged into a single `users` interface in the generated schema, since `groupColumns` keys by the bare table name.

## Fix

Filter by `schema_name(t.schema_id)`, bound via `request.input('schema', ...)` rather than string-interpolated, defaulting to `dbo` the same way the Postgres introspector defaults to `public`. Updated the README's `--schema` row, which documented this as "not used for SQL Server".

## Test plan

- [x] `npm test` (types + runtime) green, 53/53
- No new test: `introspectMssql` has no live-database test in this environment - the same accepted limitation noted for the rest of the mssql adapter surface (no SQL Server instance available here). The query change is a straightforward `WHERE` addition parallel to the already-tested Postgres/MySQL schema-scoping pattern.