### PR TITLE
CI: push trigger targets master, not main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Fixes #16.

## What

`.github/workflows/ci.yml`'s push trigger listed `branches: [main]`. This repo's default branch is `master` (confirmed via `origin/HEAD` → `master`), so the push trigger has never fired - every CI run so far only happened through `pull_request`. A direct push to `master`, including a merge commit, gets no CI run at all.

## Fix

One line: `branches: [main]` → `branches: [master]`.