### PR TITLE
Fix: alias after a multi-word expression is ignored

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -202,6 +202,18 @@ type IsParenthesizedEntry<Entry extends string> = [SplitParenthesizedEntry<Entry
   ? false
   : true;
 
+type FindTopLevelAsKeyword<
+  S extends string,
+  Depth extends unknown[] = [],
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? IsKeyword<Head, 'as'> extends true
+      ? { expr: Trim<Accumulated>; alias: Tail }
+      : FindTopLevelAsKeyword<Tail, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+    : FindTopLevelAsKeyword<Tail, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+  : never;
+
 type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends true
   ? SplitCaseExpression<Entry> extends { body: infer Body extends string; alias: infer Alias extends string }
     ? [Alias, `case ${Body} end`]
@@ -222,12 +234,12 @@ type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends tr
             ? [Unquote<Trim<DropFirstWord<After>>>, Expr]
             : [Unquote<Trim<After>>, Expr]
         : [Trim<Entry>, Trim<Entry>]
-      : Entry extends `${infer Expression} ${infer Middle} ${infer Alias}`
-      ? IsKeyword<Middle, 'as'> extends true
+      : [FindTopLevelAsKeyword<Entry>] extends [never]
+      ? Entry extends `${infer Expression} ${infer Alias}`
         ? [Unquote<Trim<Alias>>, Trim<Expression>]
-        : [OutputName<Entry>, Entry]
-      : Entry extends `${infer Expression} ${infer Alias}`
-        ? [Unquote<Trim<Alias>>, Trim<Expression>]
+        : [OutputName<Trim<Entry>>, Trim<Entry>]
+      : FindTopLevelAsKeyword<Entry> extends { expr: infer Expr extends string; alias: infer Alias extends string }
+        ? [Unquote<Trim<Alias>>, Expr]
         : [OutputName<Trim<Entry>>, Trim<Entry>];
 
 type ParseColumnEntries<Columns extends string[]> = {

--- a/tests/multiword-alias.test-d.ts
+++ b/tests/multiword-alias.test-d.ts
@@ -1,0 +1,40 @@
+import type { Query } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  orders: { id: number; user_id: number; price: number };
+}
+
+type MultiWordArithmeticExpressionResolvesAlias = Expect<
+  Equal<Query<DB, 'select price * 2 as total from orders'>, { total: unknown }[]>
+>;
+
+type CastInsideAsKeywordDoesNotConfuseTheAliasBoundary = Expect<
+  Equal<Query<DB, 'select cast(price as int) as p from orders'>, { p: unknown }[]>
+>;
+
+type SingleWordAliasStillWorks = Expect<
+  Equal<Query<DB, 'select price as total from orders'>, { total: number }[]>
+>;
+
+type FunctionCallAliasStillWorks = Expect<
+  Equal<Query<DB, 'select count(*) as total from orders'>, { total: number }[]>
+>;
+
+type BareAliasWithoutAsStillWorks = Expect<
+  Equal<Query<DB, 'select price total from orders'>, { total: number }[]>
+>;
+
+export type BehaviorLock = [
+  MultiWordArithmeticExpressionResolvesAlias,
+  CastInsideAsKeywordDoesNotConfuseTheAliasBoundary,
+  SingleWordAliasStillWorks,
+  FunctionCallAliasStillWorks,
+  BareAliasWithoutAsStillWorks,
+];

--- a/tests/paren-boundary.test-d.ts
+++ b/tests/paren-boundary.test-d.ts
@@ -33,10 +33,10 @@ type ParenthesizedArithmeticGroupResolvesAlias = Expect<
   >
 >;
 
-type FunctionArgWithFromKeywordKeepsSiblingColumns = Expect<
+type FunctionArgWithFromKeywordResolvesAlias = Expect<
   Equal<
     Query<DB, 'select extract(year from created_at) as y, id from users'>,
-    { 'extract(year from created_at) as y': unknown; id: number }[]
+    { y: unknown; id: number }[]
   >
 >;
 
@@ -44,5 +44,5 @@ export type BehaviorLock = [
   ScalarSubqueryKeepsSiblingColumns,
   ScalarSubqueryNoAliasFallsBackToRawText,
   ParenthesizedArithmeticGroupResolvesAlias,
-  FunctionArgWithFromKeywordKeepsSiblingColumns,
+  FunctionArgWithFromKeywordResolvesAlias,
 ];


### PR DESCRIPTION
Fixes #18.

## What

`ParseColumnEntry` matched a column entry against `` `${Expression} ${Middle} ${Alias}` ``, which splits at the first two spaces. For `price * 2 as total` that binds `Expression="price"`, `Middle="*"`, sees `Middle` isn't `as`, and gives up - the whole entry becomes the raw column key instead of `total`.

## Fix

Replaced the fixed-position split with `FindTopLevelAsKeyword`, a paren-depth-aware word scan (reuses the `ApplyParenDelta` counter already used elsewhere in `parse.ts`) that finds the top-level `as`, so `cast(price as int) as p` isn't confused by the `as` inside the cast.

## Bonus fix

As a side effect this also fixes the alias for `extract(year from created_at) as y` - previously fell back to the raw entry text as its key, called out as a known non-goal in #17's PR (#27). Updated `tests/paren-boundary.test-d.ts` to lock the corrected key instead of the old fallback.

Single-word aliases, function-call aliases (`count(*) as total`), and bare no-`AS` aliases (`price total`) are unchanged - all three still resolve through their existing paths, locked by new regression tests.

## Test plan

- [x] `npm test` (types + runtime) green, 53/53
- [x] New `tests/multiword-alias.test-d.ts`: multi-word arithmetic alias, cast-with-as-inside not confused, and three unchanged-behavior regression locks
- [x] Updated `tests/paren-boundary.test-d.ts`'s `extract()` case to the corrected key