### PR TITLE
generate: unrecognized connection URL schemes no longer fall back to SQLite

### DIFF
--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import type { ConnectionInfo, TableSchema } from '../types.js';
 
 export function mapSqliteType(declaredType: string): string {
@@ -44,6 +45,10 @@ export async function introspectSqlite(connection: ConnectionInfo): Promise<Tabl
     throw new Error(
       "'node:sqlite' is not available in this Node.js version. Upgrade to Node >=22.5, or use better-sqlite3 and edit the generated schema by hand.",
     );
+  }
+
+  if (connection.url !== ':memory:' && !existsSync(connection.url)) {
+    throw new Error(`SQLite database file not found: "${connection.url}".`);
   }
 
   const db = new DatabaseSyncCtor(connection.url);

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -13,6 +13,8 @@ export interface GenerateOptions {
   schema?: string | undefined;
 }
 
+const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
+
 export function detectDialect(url: string): Dialect {
   if (url.startsWith('postgres://') || url.startsWith('postgresql://')) {
     return 'postgres';
@@ -24,6 +26,12 @@ export function detectDialect(url: string): Dialect {
 
   if (url.startsWith('mssql://') || url.startsWith('sqlserver://')) {
     return 'mssql';
+  }
+
+  if (SCHEME_PATTERN.test(url)) {
+    throw new Error(
+      `Unrecognized connection URL "${url}". Expected postgres://, postgresql://, mysql://, mssql://, sqlserver://, or a path to a SQLite database file.`,
+    );
   }
 
   return 'sqlite';

--- a/tests/cli-generate.test.ts
+++ b/tests/cli-generate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { DatabaseSync } from 'node:sqlite';
@@ -17,6 +17,13 @@ describe('detectDialect', () => {
   it('falls back to sqlite for a bare file path', () => {
     expect(detectDialect('./app.db')).toBe('sqlite');
     expect(detectDialect(':memory:')).toBe('sqlite');
+  });
+
+  it('rejects an unrecognized URL scheme instead of silently falling back to sqlite', () => {
+    expect(() => detectDialect('postgress://user:pass@host/db')).toThrow(
+      'Unrecognized connection URL "postgress://user:pass@host/db"',
+    );
+    expect(() => detectDialect('mongodb://user:pass@host/db')).toThrow('Unrecognized connection URL');
   });
 });
 
@@ -59,6 +66,21 @@ describe('runGenerate (end to end against a real sqlite file)', () => {
       await expect(
         runGenerate({ url: dbFile, out: join(dir, 'schema.ts'), dialect: 'sqlite' }),
       ).rejects.toThrow('No tables found');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to introspect a nonexistent sqlite file instead of creating one', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
+    const missingFile = join(dir, 'typo.db');
+
+    try {
+      await expect(
+        runGenerate({ url: missingFile, out: join(dir, 'schema.ts'), dialect: 'sqlite' }),
+      ).rejects.toThrow('SQLite database file not found');
+
+      expect(existsSync(missingFile)).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fixes #21.

## What

`detectDialect` in `src/cli/generate.ts` returned `'sqlite'` for any URL it didn't recognize, including a typo'd scheme like `postgress://user:pass@host/db`. That reached `introspectSqlite`, which passed it straight to `node:sqlite`'s `DatabaseSync` constructor - which creates the file if it doesn't exist. A simple typo silently produced a stray empty database file plus a misleading "No tables found" error that pointed at the wrong problem.

## Fix

- `detectDialect` now throws for anything shaped like a connection URL (`scheme://...`) that isn't one of the four known schemes, and only falls back to sqlite for inputs with no scheme at all - matching the already-documented/tested "bare file path" fallback exactly (`./app.db`, `:memory:` still detect as sqlite), just no longer catching typo'd schemes too.
- `introspectSqlite` now checks the file exists before opening it (skipped for `:memory:`), so even a legitimately sqlite-shaped but wrong path fails with a clear "file not found" error instead of creating an empty database.

## Test plan

- [x] `npm test` (types + runtime) green, 55/55
- [x] New: `detectDialect` throws for `postgress://...` and `mongodb://...`, existing bare-path/`:memory:` cases unchanged
- [x] New: `runGenerate` against a nonexistent sqlite path throws "SQLite database file not found" and leaves no file on disk (asserted via `existsSync`)