### PR TITLE
Fix: SELECT without FROM loses all inference

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -62,8 +62,8 @@ type ColumnsBeforeFrom<
   : Depth extends []
     ? IsKeyword<S, 'from'> extends true
       ? { columns: Trim<Accumulated>; afterFrom: '' }
-      : never
-    : never;
+      : { columns: Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>; afterFrom: null }
+    : { columns: Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>; afterFrom: null };
 
 type AfterKeyword<S extends string, Keyword extends string> =
   S extends `${infer Head} ${infer Tail}`
@@ -131,9 +131,11 @@ type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer B
   ? Body extends string
     ? ColumnsBeforeFrom<StripTopClause<Body>> extends {
         columns: infer Columns extends string;
-        afterFrom: infer AfterFrom extends string;
+        afterFrom: infer AfterFrom;
       }
-      ? { columns: Columns; sources: ParseFromClause<AfterFrom> }
+      ? AfterFrom extends string
+        ? { columns: Columns; sources: ParseFromClause<AfterFrom> }
+        : { columns: Columns; sources: [] }
       : never
     : never
   : never;
@@ -299,9 +301,11 @@ type BareColumnType<
 > = ResolveBareAcross<DB, Sources, Column> extends infer Type
   ? [Type] extends [never]
     ? Strict extends true
-      ? AnyKnownTable<DB, Sources> extends true
-        ? QueryTypeError<`unknown column: ${Column}`>
-        : QueryTypeError<`unknown table: ${FirstSourceTable<Sources>}`>
+      ? Sources extends []
+        ? QueryTypeError<`no FROM clause: cannot resolve column "${Column}"`>
+        : AnyKnownTable<DB, Sources> extends true
+          ? QueryTypeError<`unknown column: ${Column}`>
+          : QueryTypeError<`unknown table: ${FirstSourceTable<Sources>}`>
       : unknown
     : Type
   : never;

--- a/tests/select-without-from.test-d.ts
+++ b/tests/select-without-from.test-d.ts
@@ -1,0 +1,43 @@
+import type { Query, StrictQuery, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+type LiteralAliasResolvesKey = Expect<
+  Equal<Query<DB, 'select 1 as one'>, { one: unknown }[]>
+>;
+
+type FunctionCallWithNoFromResolvesKey = Expect<
+  Equal<Query<DB, 'select now() as now'>, { now: unknown }[]>
+>;
+
+type StrictModeReportsNoFromClauseInsteadOfEmptyTableName = Expect<
+  Equal<
+    StrictQuery<DB, 'select 1 as one'>,
+    QueryTypeError<'no FROM clause: cannot resolve column "1"'>[]
+  >
+>;
+
+type OrdinaryFromQueryIsUnaffected = Expect<
+  Equal<Query<DB, 'select id, name from users'>, { id: number; name: string }[]>
+>;
+
+type OrdinaryFromQueryStrictModeIsUnaffected = Expect<
+  Equal<StrictQuery<DB, 'select id, name from users'>, { id: number; name: string }[]>
+>;
+
+export type BehaviorLock = [
+  LiteralAliasResolvesKey,
+  FunctionCallWithNoFromResolvesKey,
+  StrictModeReportsNoFromClauseInsteadOfEmptyTableName,
+  OrdinaryFromQueryIsUnaffected,
+  OrdinaryFromQueryStrictModeIsUnaffected,
+];


### PR DESCRIPTION
Fixes #20.

## What

A SELECT with no FROM clause lost all inference:

```ts
Row<DB, 'select 1 as one'>
// loose:  { [x: string]: unknown }
// strict: QueryTypeError<"unknown table: ">  (empty table name)
```

This is common in practice: `select 1`, `select now() as now`, health-check pings, or dialects like SQL Server/Postgres where FROM is optional.

## Why

`ColumnsBeforeFrom` in `src/parse.ts` required a `from` token to produce a result - without one it returned `never`. That propagated through `ParseSelectBody`'s `never extends {...}` conditional into an index-signature row in loose mode, and a `QueryTypeError` with an empty table name in strict mode (via `FirstSourceTable` resolving to `''` for a source list that was never actually built).

## Fix

- `ColumnsBeforeFrom` now returns `{ columns, afterFrom: null }` when no `from` boundary is found, instead of `never`.
- `ParseSelectBody` treats a non-string `afterFrom` as "no sources" and resolves against an empty `Sources` tuple rather than calling `ParseFromClause` on garbage.
- `BareColumnType`'s strict-mode branch gets a dedicated message for this case (`no FROM clause: cannot resolve column "..."`) instead of reusing `unknown table: ` with an empty interpolation.

## Test plan

- [x] `npm test` (types + runtime) green, 55/55
- [x] New `tests/select-without-from.test-d.ts`: `select 1 as one`, `select now() as now`, strict-mode message, and two regression locks confirming ordinary `FROM`-having queries are unaffected in both modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript query inference for `SELECT` statements without a `FROM` clause.
  - Literal aliases and functions such as `now()` now resolve correctly when no data source is used.
  - Strict mode now reports a clear error when columns cannot be resolved without a `FROM` clause.
  - Existing queries that use `FROM` continue to infer result types correctly.

- **Tests**
  - Added compile-time coverage for queries with and without `FROM` clauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->