### PR TITLE
Fix: WITH RECURSIVE and CTE column lists break inference

### DIFF
--- a/src/cte.ts
+++ b/src/cte.ts
@@ -4,11 +4,22 @@ import type { InferRowWith } from './parse.js';
 
 type CteEntry = [name: string, query: string];
 
-type ParseCteEntry<S extends string> = Trim<S> extends `${infer NameWord} ${infer AfterName}`
-  ? IsKeyword<FirstWord<Trim<AfterName>>, 'as'> extends true
-    ? Trim<DropFirstWord<Trim<AfterName>>> extends `(${infer AfterOpen}`
-      ? ExtractParenGroup<AfterOpen> extends { inner: infer SubQuery extends string; rest: infer Rest extends string }
-        ? { name: Trim<NameWord>; query: Trim<SubQuery>; rest: Trim<Rest> }
+type CteNameAndRest<S extends string> = S extends `${infer NamePart}(${infer AfterOpen}`
+  ? NamePart extends `${string} ${string}`
+    ? { name: FirstWord<S>; rest: Trim<DropFirstWord<S>> }
+    : ExtractParenGroup<AfterOpen> extends { rest: infer Rest extends string }
+      ? { name: NamePart; rest: Trim<Rest> }
+      : never
+  : { name: FirstWord<S>; rest: Trim<DropFirstWord<S>> };
+
+type ParseCteEntry<S extends string> = CteNameAndRest<Trim<S>> extends {
+  name: infer Name extends string;
+  rest: infer Rest extends string;
+}
+  ? IsKeyword<FirstWord<Rest>, 'as'> extends true
+    ? Trim<DropFirstWord<Rest>> extends `(${infer AfterOpen}`
+      ? ExtractParenGroup<AfterOpen> extends { inner: infer SubQuery extends string; rest: infer AfterQuery extends string }
+        ? { name: Name; query: Trim<SubQuery>; rest: Trim<AfterQuery> }
         : never
       : never
     : never
@@ -25,8 +36,12 @@ type ParseCteList<S extends string, Accumulated extends CteEntry[] = []> =
       : { ctes: [...Accumulated, [Name, Query]]; rest: Rest }
     : never;
 
+type SkipRecursiveKeyword<S extends string> = IsKeyword<FirstWord<S>, 'recursive'> extends true
+  ? Trim<DropFirstWord<S>>
+  : S;
+
 export type ParseWithClause<S extends string> = IsKeyword<FirstWord<S>, 'with'> extends true
-  ? ParseCteList<Trim<DropFirstWord<S>>> extends {
+  ? ParseCteList<SkipRecursiveKeyword<Trim<DropFirstWord<S>>>> extends {
       ctes: infer Ctes extends CteEntry[];
       rest: infer Rest extends string;
     }

--- a/tests/cte.test-d.ts
+++ b/tests/cte.test-d.ts
@@ -46,9 +46,41 @@ type CteStrictUnknownColumnIsTypeError = Expect<
   >
 >;
 
+type WithRecursiveIsNotConfusedByTheKeyword = Expect<
+  Equal<
+    Query<DB, 'with recursive popular as (select id, title from posts) select id, title from popular'>,
+    { id: number; title: string }[]
+  >
+>;
+
+type WithRecursiveResolvesInStrictModeToo = Expect<
+  Equal<
+    StrictQuery<DB, 'with recursive popular as (select id, title from posts) select id, title from popular'>,
+    { id: number; title: string }[]
+  >
+>;
+
+type CteColumnListDoesNotBreakTheCteName = Expect<
+  Equal<
+    Query<DB, 'with popular(x) as (select id from posts) select x from popular'>,
+    { x: unknown }[]
+  >
+>;
+
+type CteMultiColumnListAlsoResolvesByName = Expect<
+  Equal<
+    Query<DB, 'with popular(x, y) as (select id, title from posts) select x, y from popular'>,
+    { x: unknown; y: unknown }[]
+  >
+>;
+
 export type CteLock = [
   SimpleCte,
   CteWithJoinAgainstRealTable,
   MultipleCtesSecondReferencesFirst,
   CteStrictUnknownColumnIsTypeError,
+  WithRecursiveIsNotConfusedByTheKeyword,
+  WithRecursiveResolvesInStrictModeToo,
+  CteColumnListDoesNotBreakTheCteName,
+  CteMultiColumnListAlsoResolvesByName,
 ];


### PR DESCRIPTION
Fixes #19.

## What

Two CTE forms made `ParseWithClause`/`ParseCteEntry` fail entirely instead of degrading gracefully:

```ts
Row<DB, 'with recursive t as (select id from users) select id from t'>
// loose:  { [x: string]: unknown }
// strict: QueryTypeError<"unknown table: ">  (empty table name)

Row<DB, 'with t(x) as (select id from users) select x from t'>
// { x: unknown } - CTE registered under the literal name "t(x)", so "t" resolved to nothing
```

## Why

- `with recursive t as (...)`: `ParseCteEntry` took the first word after `WITH` as the CTE name and required the next word to be `as`. For `RECURSIVE` queries the first word is `recursive`, not the name, so the entry parse returned `never` - same never-propagation failure mode as #20.
- `with t(x) as (...)`: the column list got captured as part of the name (`"t(x)"`), so later references to `t` found nothing.

## Fix

- Skip an optional `recursive` keyword right after `WITH`.
- Replace the naive first-word name split with a paren-aware `CteNameAndRest` that only treats a directly-attached `(...)` as a column list when there's no space between the name and the open paren (so it isn't confused with the `(` that starts the CTE's own subquery).

Column list contents are stripped, not remapped - querying an aliased column like `x` against a CTE shaped `{ id: ... }` resolves to `unknown` rather than the real underlying type. The fix is "look up the CTE by its right name," not full column-alias remapping (out of scope, not needed to fix the actual reported breakage).

Multi-column lists, including ones with spaces after the commas (`t(x, y)`), also work via the same paren-depth-aware extraction - came along with the fix at no extra cost, verified in the tests below.

## Test plan

- [x] `npm test` (types + runtime) green, 55/55
- [x] Added to `tests/cte.test-d.ts`: `WITH RECURSIVE` in loose and strict mode, single-column CTE list, multi-column CTE list