### PR TITLE
Add more SQL functions to the type registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,9 +353,10 @@ const shout = await db.query('select id, upper(name) as name from users');
 ```
 
 Recognized: `count`, `sum`, `avg`, `min`, `max`, `length`, `char_length`,
-`octet_length`, `abs`, `ceil`, `floor`, `round` → `number`; `lower`, `upper`,
-`trim`, `ltrim`, `rtrim`, `concat` → `string`; `coalesce` → `unknown`. Anything
-else resolves to `unknown`.
+`octet_length`, `abs`, `ceil`, `floor`, `round`, `power`, `mod`, `greatest`,
+`least` → `number`; `lower`, `upper`, `trim`, `ltrim`, `rtrim`, `concat` →
+`string`; `coalesce`, `nullif` → `unknown`; `now`, `current_timestamp`,
+`current_date` → `Date`. Anything else resolves to `unknown`.
 
 ### 7. INSERT / UPDATE / DELETE with RETURNING
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -13,6 +13,10 @@ export interface FunctionReturnTypes {
   ceil: number;
   floor: number;
   round: number;
+  power: number;
+  mod: number;
+  greatest: number;
+  least: number;
   lower: string;
   upper: string;
   trim: string;
@@ -20,6 +24,10 @@ export interface FunctionReturnTypes {
   rtrim: string;
   concat: string;
   coalesce: unknown;
+  nullif: unknown;
+  now: Date;
+  current_timestamp: Date;
+  current_date: Date;
   row_number: number;
   rank: number;
   dense_rank: number;

--- a/tests/select-without-from.test-d.ts
+++ b/tests/select-without-from.test-d.ts
@@ -16,7 +16,7 @@ type LiteralAliasResolvesKey = Expect<
 >;
 
 type FunctionCallWithNoFromResolvesKey = Expect<
-  Equal<Query<DB, 'select now() as now'>, { now: unknown }[]>
+  Equal<Query<DB, 'select random_seed() as seed'>, { seed: unknown }[]>
 >;
 
 type StrictModeReportsNoFromClauseInsteadOfEmptyTableName = Expect<

--- a/tests/tier2.test-d.ts
+++ b/tests/tier2.test-d.ts
@@ -69,6 +69,36 @@ type InsertWithoutReturning = Expect<
   Equal<Query<DB, 'insert into users (name) values ($1)'>, Record<string, never>[]>
 >;
 
+type NowIsDate = Expect<
+  Equal<Query<DB, 'select now() as created'>, { created: Date }[]>
+>;
+
+type CurrentTimestampIsDate = Expect<
+  Equal<Query<DB, 'select current_timestamp() as created'>, { created: Date }[]>
+>;
+
+type CurrentDateIsDate = Expect<
+  Equal<Query<DB, 'select current_date() as today'>, { today: Date }[]>
+>;
+
+type NullifIsUnknown = Expect<
+  Equal<Query<DB, 'select nullif(age) as age from users'>, { age: unknown }[]>
+>;
+
+type GreatestAndLeastAreNumber = Expect<
+  Equal<
+    Query<DB, 'select greatest(age) as hi, least(age) as lo from users'>,
+    { hi: number; lo: number }[]
+  >
+>;
+
+type PowerAndModAreNumber = Expect<
+  Equal<
+    Query<DB, 'select power(age) as squared, mod(age) as remainder from users'>,
+    { squared: number; remainder: number }[]
+  >
+>;
+
 export type Tier2Lock = [
   CountStar,
   CountAliased,
@@ -81,4 +111,10 @@ export type Tier2Lock = [
   UpdateReturningStar,
   DeleteReturning,
   InsertWithoutReturning,
+  NowIsDate,
+  CurrentTimestampIsDate,
+  CurrentDateIsDate,
+  NullifIsUnknown,
+  GreatestAndLeastAreNumber,
+  PowerAndModAreNumber,
 ];


### PR DESCRIPTION
Fixes #7.

## What

Extends `FunctionReturnTypes` in `src/functions.ts` with the functions requested in the issue:

- `now()`, `current_timestamp()`, `current_date()` → `Date`
- `nullif` → `unknown` (return type depends on the args, same reasoning as `coalesce`)
- `greatest`, `least`, `power`, `mod` → `number`

No other changes needed - `FunctionReturnType`/`FunctionOutputName` already look up any key present in the interface automatically, exactly as the issue described.

## Test plan

- [x] `npm test` (types + runtime) green, 55/55
- [x] Added a case per new function to `tests/tier2.test-d.ts`
- [x] Updated `select-without-from.test-d.ts`'s function-call regression case, which used `now()` as its "unresolved function still gets its key" example - swapped to a made-up function name since `now()` now legitimately resolves to `Date`
- [x] Updated the README's "recognized functions" list (aggregates/functions section) to match

## Note

Test cases for `power`/`mod`/`nullif`/`greatest`/`least` use a single argument (e.g. `power(age)` rather than `power(age, 2)`) to match the existing single-arg convention already used for `count(*)`/`lower(name)`/`max(age)` in this file - a multi-arg call with a comma would hit `SplitColumnList`'s comma-based column splitting (a separate, pre-existing limitation unrelated to this registry change).