### PR TITLE
Fix: multi-argument function calls in SELECT list get split at the wrong comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,9 +738,6 @@ This is a focused tool for the common read path, not a full SQL grammar:
 - **Window `OVER (...)` clauses are only used as a boundary**, not parsed for
   their own typing — `PARTITION BY`/`ORDER BY` content inside `OVER (...)` is
   discarded, not validated.
-- **Function arguments must not contain spaces.** `count(*)`, `lower(name)`,
-  `sum(price)` work; `count(distinct id)` and `concat(a, b)` (space after the
-  comma) do not.
 - **Aggregates assume numeric output.** `min`/`max` resolve to `number` even
   over a text column; unrecognized functions resolve to `unknown`. `lag`,
   `lead`, `first_value`, `last_value`, `nth_value` resolve to `unknown` (their

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -156,9 +156,25 @@ export type ParseStatement<S extends string> = ParseStatementNormalized<Normaliz
 
 export type ParseSelect<S extends string> = ParseSelectBody<Normalize<S>>;
 
-type SplitColumnList<S extends string> = S extends `${infer Head},${infer Tail}`
-  ? [Trim<Head>, ...SplitColumnList<Tail>]
-  : [Trim<S>];
+type ScanColumnList<
+  S extends string,
+  Depth extends unknown[],
+  Current extends string,
+> = S extends `${infer Char}${infer Rest}`
+  ? Char extends '('
+    ? ScanColumnList<Rest, [...Depth, unknown], `${Current}${Char}`>
+    : Char extends ')'
+      ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
+        ? ScanColumnList<Rest, DepthRest, `${Current}${Char}`>
+        : ScanColumnList<Rest, Depth, `${Current}${Char}`>
+      : Char extends ','
+        ? Depth extends []
+          ? [Trim<Current>, ...ScanColumnList<Rest, Depth, ''>]
+          : ScanColumnList<Rest, Depth, `${Current}${Char}`>
+        : ScanColumnList<Rest, Depth, `${Current}${Char}`>
+  : [Trim<Current>];
+
+type SplitColumnList<S extends string> = ScanColumnList<S, [], ''>;
 
 type OutputName<Expression extends string> = IsFunctionCall<Expression> extends true
   ? FunctionOutputName<Expression>

--- a/tests/multiarg-function-columns.test-d.ts
+++ b/tests/multiarg-function-columns.test-d.ts
@@ -1,0 +1,51 @@
+import type { Query } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; age: number };
+}
+
+type MultiArgFunctionDoesNotSwallowSiblingColumn = Expect<
+  Equal<
+    Query<DB, 'select power(age, 2) as squared, id from users'>,
+    { squared: number; id: number }[]
+  >
+>;
+
+type TwoMultiArgFunctionsBothSplitCorrectly = Expect<
+  Equal<
+    Query<DB, 'select coalesce(name, id) as x, count(*) as total from users'>,
+    { x: unknown; total: number }[]
+  >
+>;
+
+type SingleArgFunctionCallStillWorks = Expect<
+  Equal<Query<DB, 'select count(*) from users'>, { count: number }[]>
+>;
+
+type PlainColumnListStillWorks = Expect<
+  Equal<Query<DB, 'select id, name from users'>, { id: number; name: string }[]>
+>;
+
+type ConcatWithSpaceAfterCommaResolvesAlias = Expect<
+  Equal<Query<DB, 'select concat(name, name) as full_name from users'>, { full_name: string }[]>
+>;
+
+type CountDistinctResolvesAlias = Expect<
+  Equal<Query<DB, 'select count(distinct name) as total from users'>, { total: number }[]>
+>;
+
+export type BehaviorLock = [
+  MultiArgFunctionDoesNotSwallowSiblingColumn,
+  TwoMultiArgFunctionsBothSplitCorrectly,
+  SingleArgFunctionCallStillWorks,
+  PlainColumnListStillWorks,
+  ConcatWithSpaceAfterCommaResolvesAlias,
+  CountDistinctResolvesAlias,
+];


### PR DESCRIPTION
Fixes #37.

## What

`SplitColumnList` in `src/parse.ts` split the SELECT column list on every comma with no parenthesis awareness:

```ts
Row<DB, 'select power(age, 2) as squared, id from users'>
// before: splits into "power(age" and "2) as squared, id" - both entries corrupted,
//         "id" never becomes its own column
// after:  { squared: number; id: number }
```

Any multi-argument function call - `power(age, 2)`, `coalesce(a, b)`, `concat(a, b)` - got torn apart at the comma inside its own parens.

## Fix

Rewrote `SplitColumnList` as a character-level scan (same style as `ScanParenGroup` in `string.ts`) that tracks paren depth and only splits on a comma at depth zero, instead of the naive first-comma template-literal match.

## Bonus fix

This also fixes two cases the README explicitly documented as broken - `concat(a, b)` and `count(distinct id)`. Turns out those were never really about "spaces in function arguments" so much as this same comma/depth blind spot, plus the alias-boundary scan #18 already fixed. Verified both now resolve correctly and removed the now-false "function arguments must not contain spaces" limitation from the README.

## Test plan

- [x] `npm test` (types + runtime) green, 55/55
- [x] New `tests/multiarg-function-columns.test-d.ts`: multi-arg function doesn't swallow a sibling column, two multi-arg functions in the same list both split correctly, single-arg calls and plain column lists unaffected, `concat(a, b)` and `count(distinct id)` resolve their alias correctly