### PR TITLE
Type INSERT VALUES params and outer-query params after WITH

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,10 +746,15 @@ This is a focused tool for the common read path, not a full SQL grammar:
   column name (e.g. both have `id`), the types are intersected rather than kept
   separate. Alias the columns to keep them distinct.
 - **Typed parameters need spaced operators.** `where id = $1` is typed;
-  `where id=$1` is not. Parameters inside `INSERT ... VALUES` are not typed
-  (they fall back to a flexible `unknown[]`), and parameters inside a `WITH`
-  query's own CTE bodies are not typed either. Numbered placeholders are
-  assumed to appear in ascending order (`$1`, `$2`, ...).
+  `where id=$1` is not. `INSERT ... VALUES` parameters are matched
+  positionally against the INSERT's column list — `insert into t (a, b)
+  values ($1, $2)` types `$1`/`$2` as `a`/`b`; without an explicit column
+  list they fall back to a flexible `unknown[]`. A query's own `WITH` CTE
+  bodies can't have their placeholders typed, and if one contains a
+  parameter the whole query falls back to `unknown[]` rather than silently
+  dropping that parameter — placeholders in the outer query (referencing a
+  CTE by name) are unaffected either way. Numbered placeholders are assumed
+  to appear in ascending order (`$1`, `$2`, ...).
 - **Quoted identifiers** use `"..."` (standard), `[...]` (SQL Server), or
   `` `...` `` (MySQL — escape the backtick with `\`` inside the template
   literal). Schema-qualified tables (`public.users`) resolve by their final

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,9 +37,12 @@ first-timer-sized, but open if you want to dig in:
   but surfaced as a `tsserver` diagnostic instead of a type), and `JOIN`/
   alias-aware completions (right now only the first `FROM <table>` is used
   to scope suggestions).
-- **Typed params inside `INSERT ... VALUES`** and **inside a `WITH` CTE's
-  own body** — both currently fall back to `unknown[]`/untyped, documented
-  as known gaps in [README limitations](README.md#limitations).
+- **Typed params inside a `WITH` CTE's own subquery body** — a placeholder
+  written inside a CTE's own definition still can't be typed; the whole
+  query falls back to `unknown[]` rather than mistyping it. (`INSERT ...
+  VALUES` params against an explicit column list, and params in a query's
+  outer `SELECT` referencing a CTE by name, are both typed now — see
+  [README limitations](README.md#limitations).)
 - **Nested `CASE`** — the parser currently finds the first top-level `END`
   only.
 - **`ts-plugin` on TypeScript 7+** — TS 7's native (Go) compiler dropped the

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,10 +1,14 @@
-import type { Normalize, FirstWord, IsKeyword } from './string.js';
+import type { Normalize, FirstWord, DropFirstWord, Trim, IsKeyword, ExtractParenGroup } from './string.js';
 import type {
   Source,
   SchemaLike,
   ParseStatement,
   ResolveColumnLoose,
+  ResolveCteContext,
+  AfterKeyword,
+  SplitColumnList,
 } from './parse.js';
+import type { ParseWithClause } from './cte.js';
 
 type Operator = '=' | '<>' | '!=' | '<' | '>' | '<=' | '>=';
 
@@ -81,11 +85,88 @@ type ScanParams<
       ? [...Accumulated, ParamType<DB, Sources, PrevPrev, Prev>]
       : Accumulated;
 
+type InsertColumnList<S extends string> = AfterKeyword<S, 'into'> extends infer AfterInto extends string
+  ? Trim<DropFirstWord<AfterInto>> extends `(${infer AfterOpen}`
+    ? ExtractParenGroup<AfterOpen> extends { inner: infer Cols extends string; rest: infer Rest extends string }
+      ? { columns: SplitColumnList<Cols>; rest: Trim<Rest> }
+      : never
+    : never
+  : never;
+
+type InsertValuesGroup<S extends string> = AfterKeyword<S, 'values'> extends infer AfterValues extends string
+  ? Trim<AfterValues> extends `(${infer AfterOpen}`
+    ? ExtractParenGroup<AfterOpen> extends { inner: infer Vals extends string }
+      ? Vals
+      : never
+    : never
+  : never;
+
+type ColumnTypeAt<DB extends SchemaLike, Table extends string, Column extends string> =
+  Table extends keyof DB
+    ? Column extends keyof DB[Table]
+      ? DB[Table][Column]
+      : unknown
+    : unknown;
+
+type MatchInsertValueTypes<
+  DB extends SchemaLike,
+  Table extends string,
+  Columns extends string[],
+  Values extends string[],
+> = Values extends [infer Head extends string, ...infer ValuesTail extends string[]]
+  ? Columns extends [infer ColumnHead extends string, ...infer ColumnsTail extends string[]]
+    ? IsPlaceholder<Trim<Head>> extends true
+      ? [ColumnTypeAt<DB, Table, ColumnHead>, ...MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail>]
+      : MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail>
+    : []
+  : [];
+
+type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<Q> extends {
+  sources: [infer Src extends Source];
+}
+  ? [InsertColumnList<Q>] extends [never]
+    ? unknown[]
+    : InsertColumnList<Q> extends { columns: infer Columns extends string[]; rest: infer AfterColumns extends string }
+      ? [InsertValuesGroup<AfterColumns>] extends [never]
+        ? unknown[]
+        : MatchInsertValueTypes<DB, Src['table'], Columns, SplitColumnList<InsertValuesGroup<AfterColumns>>>
+      : unknown[]
+    : unknown[];
+
+type ContainsPlaceholderLikeChar<S extends string> = S extends
+  | `${string}$${string}`
+  | `${string}?${string}`
+  | `${string}@${string}`
+  ? true
+  : false;
+
+type AnyCteBodyHasPlaceholder<Ctes extends [string, string][]> = Ctes extends [
+  infer Head extends [string, string],
+  ...infer Tail extends [string, string][],
+]
+  ? ContainsPlaceholderLikeChar<Head[1]> extends true
+    ? true
+    : AnyCteBodyHasPlaceholder<Tail>
+  : false;
+
+type CteBodiesHavePlaceholder<Q extends string> = [ParseWithClause<Normalize<Q>>] extends [never]
+  ? false
+  : ParseWithClause<Normalize<Q>> extends { ctes: infer Ctes extends [string, string][] }
+    ? AnyCteBodyHasPlaceholder<Ctes>
+    : false;
+
 export type InferParams<DB extends SchemaLike, Q extends string> =
   IsKeyword<FirstWord<Normalize<Q>>, 'insert'> extends true
-    ? unknown[]
-    : [ParseStatement<Q>] extends [never]
+    ? InsertParamTypes<DB, Normalize<Q>>
+    : CteBodiesHavePlaceholder<Q> extends true
       ? unknown[]
-      : ParseStatement<Q> extends { sources: infer Sources extends Source[] }
-        ? ScanParams<Normalize<Q>, DB, Sources>
+      : ResolveCteContext<DB, Q, false> extends {
+            db: infer CteDB extends SchemaLike;
+            query: infer EffectiveQuery extends string;
+          }
+        ? [ParseStatement<EffectiveQuery>] extends [never]
+          ? unknown[]
+          : ParseStatement<EffectiveQuery> extends { sources: infer Sources extends Source[] }
+            ? ScanParams<EffectiveQuery, CteDB, Sources>
+            : unknown[]
         : unknown[];

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -65,7 +65,7 @@ type ColumnsBeforeFrom<
       : { columns: Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>; afterFrom: null }
     : { columns: Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>; afterFrom: null };
 
-type AfterKeyword<S extends string, Keyword extends string> =
+export type AfterKeyword<S extends string, Keyword extends string> =
   S extends `${infer Head} ${infer Tail}`
     ? IsKeyword<Head, Keyword> extends true
       ? Tail
@@ -174,7 +174,7 @@ type ScanColumnList<
         : ScanColumnList<Rest, Depth, `${Current}${Char}`>
   : [Trim<Current>];
 
-type SplitColumnList<S extends string> = ScanColumnList<S, [], ''>;
+export type SplitColumnList<S extends string> = ScanColumnList<S, [], ''>;
 
 type OutputName<Expression extends string> = IsFunctionCall<Expression> extends true
   ? FunctionOutputName<Expression>
@@ -473,7 +473,7 @@ type IsSelectAll<Columns extends string> = Trim<Columns> extends '*' ? true : fa
 
 type EmptyRow = Record<string, never>;
 
-type ResolveCteContext<
+export type ResolveCteContext<
   DB extends SchemaLike,
   Q extends string,
   Strict extends boolean,

--- a/tests/cte.test-d.ts
+++ b/tests/cte.test-d.ts
@@ -1,4 +1,4 @@
-import type { Query, StrictQuery, QueryTypeError } from '../src/index.js';
+import type { Query, StrictQuery, QueryTypeError, Params } from '../src/index.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -74,6 +74,30 @@ type CteMultiColumnListAlsoResolvesByName = Expect<
   >
 >;
 
+type ParamAfterCteResolvesAgainstCteShape = Expect<
+  Equal<
+    Params<DB, 'with popular as (select id, views from posts) select id from popular where views > $1'>,
+    [number]
+  >
+>;
+
+type ParamAfterMultipleCtesStillResolves = Expect<
+  Equal<
+    Params<
+      DB,
+      'with popular as (select id, title, views from posts), popular_titles as (select title from popular) select title from popular_titles where title = $1'
+    >,
+    [string]
+  >
+>;
+
+type ParamInsideCteBodyFallsBackSafelyInsteadOfClaimingZeroParams = Expect<
+  Equal<
+    Params<DB, 'with popular as (select id from posts where views > $1) select id from popular'>,
+    unknown[]
+  >
+>;
+
 export type CteLock = [
   SimpleCte,
   CteWithJoinAgainstRealTable,
@@ -83,4 +107,7 @@ export type CteLock = [
   WithRecursiveResolvesInStrictModeToo,
   CteColumnListDoesNotBreakTheCteName,
   CteMultiColumnListAlsoResolvesByName,
+  ParamAfterCteResolvesAgainstCteShape,
+  ParamAfterMultipleCtesStillResolves,
+  ParamInsideCteBodyFallsBackSafelyInsteadOfClaimingZeroParams,
 ];

--- a/tests/params.test-d.ts
+++ b/tests/params.test-d.ts
@@ -45,8 +45,16 @@ type JoinQualifiedParam = Expect<
   >
 >;
 
-type InsertParamsAreFlexible = Expect<
-  Equal<Params<DB, 'insert into users (name) values ($1)'>, unknown[]>
+type InsertValuesParamsMatchColumnList = Expect<
+  Equal<Params<DB, 'insert into users (name) values ($1)'>, [string]>
+>;
+
+type InsertValuesParamsMatchMultipleColumns = Expect<
+  Equal<Params<DB, 'insert into users (name, active) values ($1, $2)'>, [string, boolean]>
+>;
+
+type InsertWithoutColumnListIsFlexible = Expect<
+  Equal<Params<DB, 'insert into users values ($1, $2, $3)'>, unknown[]>
 >;
 
 declare const db: ReturnType<typeof createTypedDb<DB>>;
@@ -72,5 +80,7 @@ export type ParamLock = [
   UpdateParams,
   DeleteParams,
   JoinQualifiedParam,
-  InsertParamsAreFlexible,
+  InsertValuesParamsMatchColumnList,
+  InsertValuesParamsMatchMultipleColumns,
+  InsertWithoutColumnListIsFlexible,
 ];


### PR DESCRIPTION
Fixes #13. Does both independent halves the issue describes.

## What

Two gaps in `src/params.ts`'s `InferParams`, both previously a blanket `unknown[]` fallback:

### 1. `INSERT ... VALUES` params matched positionally

```ts
Params<DB, 'insert into users (name, age) values ($1, $2)'>
// before: unknown[]
// after:  [string, number]  (matching users.name/users.age)
```

New `InsertColumnList`/`InsertValuesGroup` extract the column list and values tuple (reusing `AfterKeyword` and the paren-depth-aware `SplitColumnList` from #37, both now exported from `parse.ts`). `MatchInsertValueTypes` walks both lists in lockstep, skipping non-placeholder values (`values ($1, now())` only types `$1`) so the result only contains actual bind parameters.

INSERT without an explicit column list still falls back to `unknown[]` - matching a bare `VALUES` list against the table's declared column *order* isn't attempted (not reliably derivable from `keyof DB[Table]`, which is an unordered union).

### 2. Outer-query params after a `WITH` clause

```ts
Params<DB, 'with recent as (select id, price from orders) select id from recent where price = $1'>
// before: unknown[]  (ParseStatement can't parse a WITH-prefixed string at all, so params.ts
//         short-circuited for the whole query, not just the CTE part)
// after:  [number]   (typed via the CTE's own row shape)
```

Reuses `ResolveCteContext` (now exported from `parse.ts`) instead of duplicating the "strip WITH prefix, extend DB with the CTE map" logic `InferRowWith` already has.

## A regression I caught and fixed before it shipped

Params written *inside* a CTE's own subquery body still can't be typed (only the text after `WITH ... AS (...)` is scanned). My first pass silently reported **zero** params for the whole query in that case - worse than the old permissive `unknown[]`, and a real regression: `with t as (select id from x where price > $1) select id from t` would have gone from "accepts any args" to "expects exactly no args as a type error." Root cause was the `[X] extends [never]` "never takes the true branch" gotcha this codebase has hit before (documented in the JOIN work). Fixed by detecting when a CTE body contains anything placeholder-shaped and falling back the whole query to `unknown[]` in that case, same as before this PR - outer-query params (the case actually being fixed) are unaffected.

## Test plan

- [x] `npm test` (types + runtime) green, 55/55
- [x] Updated `tests/params.test-d.ts`'s old `InsertParamsAreFlexible` lock (asserted blanket `unknown[]` for any INSERT) to the new positionally-typed cases, plus a no-column-list case confirming the flexible fallback still applies there
- [x] New in `tests/cte.test-d.ts`: outer-query param after a single CTE, after multiple CTEs, and the inner-CTE-body safety net

## Docs

Updated the README's "Typed parameters need spaced operators" limitations bullet and ROADMAP's help-wanted item to describe the narrower remaining gap (CTE-body-internal params only).