### PR TITLE
ts-plugin: hover info for column types

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,9 @@ db.query(`
   select id, na
 `)
 //              ^ autocomplete suggests `name`
+
+db.query(`select id, name from users`)
+//                    ^ hovering shows (column) name: string
 ```
 
 Want to see it running for yourself before there's a recorded demo here?
@@ -615,18 +618,22 @@ is the #1 reason this kind of plugin appears to do nothing. Other editors
 that talk to `tsserver` (Cursor, some Neovim/Sublime LSP setups) generally
 pick up `tsconfig.json` plugins automatically.
 
-**What v1 does:** suggests column names right after `SELECT` or a comma in
-the column list, for `db.query(...)` calls made through a client built with
-`createTypedDb<DB>`. If a `FROM <table>` is already present anywhere later in
-the same string, suggestions are scoped to that table; otherwise you get the
-deduplicated union of every table's columns in `DB` — which is exactly what
-covers the example above before you've typed `FROM` at all.
+**What it does:** suggests column names right after `SELECT` or a comma in
+the column list, and shows a column's resolved type on hover, for
+`db.query(...)` calls made through a client built with `createTypedDb<DB>`.
+If a `FROM <table>` is already present anywhere later in the same string,
+both completions and hover are scoped to that table; otherwise completions
+fall back to the deduplicated union of every table's columns in `DB` — which
+is exactly what covers the example above before you've typed `FROM` at all.
 
-**What v1 does not do** (documented scope, not bugs):
+**What it does not do** (documented scope, not bugs):
 
-- No hover info and no inline diagnostics/squiggles — completions only.
+- No inline diagnostics/squiggles for unknown columns or tables — hover
+  and completions only. Strict mode (`{ strict: true }`) still catches
+  these as a compile-time `QueryTypeError`, just not as a live squiggle.
 - No `JOIN`/alias awareness — only the first `FROM <table>` in the string is
-  used to scope suggestions; a second table from a `JOIN` is not offered.
+  used to scope both completions and hover; a second table from a `JOIN` is
+  not offered.
 - Only plain string/template literals with **no interpolation**
   (`` db.query(`select ...`) ``) are recognized — which is the only form the
   library ever expects you to write, since parameters are SQL placeholders

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,8 +18,8 @@ the editor tooling, not a promise of dates.
   Kysely) and a documented Drizzle recipe.
 - `npx @owlsql/core generate` — schema introspection CLI for all four
   databases.
-- `@owlsql/core/ts-plugin` — in-editor column-name autocomplete
-  (v1: `SELECT`-list completions only).
+- `@owlsql/core/ts-plugin` — in-editor column-name autocomplete and
+  hover info (resolved column type on hover).
 - [COMPARISON.md](COMPARISON.md) — sourced comparison vs Prisma/Kysely/
   pgTyped/Zapatos on build step, runtime cost, bundle size, and DX.
 
@@ -32,11 +32,10 @@ first-timer-sized, but open if you want to dig in:
   by design — see [Limitations](README.md#limitations)). Needs the same
   balanced-paren extraction used for CTEs/derived tables, applied at an
   arbitrary expression position instead of only in `FROM`.
-- **`ts-plugin` v2**: hover info (column type on hover), inline diagnostics
-  for unknown columns/tables (reusing strict-mode's `QueryTypeError` logic
-  but surfaced as a `tsserver` diagnostic instead of a type), and `JOIN`/
-  alias-aware completions (right now only the first `FROM <table>` is used
-  to scope suggestions).
+- **`ts-plugin` v2**: inline diagnostics for unknown columns/tables (reusing
+  strict-mode's `QueryTypeError` logic but surfaced as a `tsserver`
+  diagnostic instead of a type), and `JOIN`/alias-aware completions and
+  hover (right now only the first `FROM <table>` is used to scope both).
 - **Typed params inside a `WITH` CTE's own subquery body** — a placeholder
   written inside a CTE's own definition still can't be typed; the whole
   query falls back to `unknown[]` rather than mistyping it. (`INSERT ...

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -3,8 +3,8 @@ import sqlContext = require('./sql-context.cjs');
 import schemaModule = require('./schema.cjs');
 import detectModule = require('./detect.cjs');
 
-const { getSelectListContext, findFromTable } = sqlContext;
-const { getColumnNames } = schemaModule;
+const { getSelectListContext, findFromTable, getWordAtOffset } = sqlContext;
+const { getColumnNames, getColumnType } = schemaModule;
 const { matchQueryLiteral } = detectModule;
 
 function init(modules: { typescript: typeof ts }) {
@@ -64,6 +64,45 @@ function init(modules: { typescript: typeof ts }) {
     };
 
     proxy.getCompletionsAtPosition = getCompletionsAtPosition;
+
+    const getQuickInfoAtPosition: ts.LanguageService['getQuickInfoAtPosition'] = (fileName, position) => {
+      const prior = info.languageService.getQuickInfoAtPosition(fileName, position);
+
+      const program = info.languageService.getProgram();
+      const sourceFile = program?.getSourceFile(fileName);
+      if (!program || !sourceFile) {
+        return prior;
+      }
+
+      const checker = program.getTypeChecker();
+      const match = matchQueryLiteral(typescript, checker, sourceFile, position);
+      if (!match) {
+        return prior;
+      }
+
+      const literalStart = match.literal.getStart(sourceFile) + 1;
+      const word = getWordAtOffset(match.literal.text, position - literalStart);
+      if (!word) {
+        return prior;
+      }
+
+      const table = findFromTable(match.literal.text);
+      const columnType = getColumnType(checker, match.dbType, match.literal, table, word.word);
+      if (!columnType) {
+        return prior;
+      }
+
+      const typeText = checker.typeToString(columnType);
+
+      return {
+        kind: typescript.ScriptElementKind.memberVariableElement,
+        kindModifiers: '',
+        textSpan: { start: literalStart + word.start, length: word.end - word.start },
+        displayParts: [{ text: `(column) ${word.word}: ${typeText}`, kind: 'text' }],
+      };
+    };
+
+    proxy.getQuickInfoAtPosition = getQuickInfoAtPosition;
 
     return proxy as unknown as ts.LanguageService;
   }

--- a/src/ts-plugin/schema.cts
+++ b/src/ts-plugin/schema.cts
@@ -26,4 +26,31 @@ function getColumnNames(
   return [...columnNames];
 }
 
-export = { getColumnNames };
+function getColumnType(
+  checker: ts.TypeChecker,
+  dbType: ts.Type,
+  node: ts.Node,
+  onlyTable: string | null,
+  columnName: string,
+): ts.Type | null {
+  const tableSymbols = dbType.getProperties();
+
+  const scopedTables = onlyTable
+    ? tableSymbols.filter((symbol) => symbol.getName() === onlyTable)
+    : tableSymbols;
+
+  const tables = scopedTables.length > 0 ? scopedTables : tableSymbols;
+
+  for (const tableSymbol of tables) {
+    const tableType = checker.getTypeOfSymbolAtLocation(tableSymbol, node);
+    for (const columnSymbol of tableType.getProperties()) {
+      if (columnSymbol.getName() === columnName) {
+        return checker.getTypeOfSymbolAtLocation(columnSymbol, node);
+      }
+    }
+  }
+
+  return null;
+}
+
+export = { getColumnNames, getColumnType };

--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -2,9 +2,17 @@ const SELECT_START = /^select\b/i;
 const HAS_FROM = /\bfrom\b/i;
 const TRAILING_WORD = /([A-Za-z_][A-Za-z0-9_]*)$/;
 const FROM_TABLE = /\bfrom\s+([A-Za-z_][A-Za-z0-9_]*)/i;
+const WORD_CHAR = /[A-Za-z0-9_]/;
+const WORD_START_CHAR = /[A-Za-z_]/;
 
 interface SelectListContext {
   prefix: string;
+}
+
+interface WordAtOffset {
+  word: string;
+  start: number;
+  end: number;
 }
 
 function getSelectListContext(textBeforeCursor: string): SelectListContext | null {
@@ -27,4 +35,31 @@ function findFromTable(fullLiteralText: string): string | null {
   return match?.[1] ?? null;
 }
 
-export = { getSelectListContext, findFromTable };
+function getWordAtOffset(text: string, offset: number): WordAtOffset | null {
+  if (offset < 0 || offset > text.length) {
+    return null;
+  }
+
+  let start = offset;
+  while (start > 0 && WORD_CHAR.test(text[start - 1] ?? '')) {
+    start -= 1;
+  }
+
+  let end = offset;
+  while (end < text.length && WORD_CHAR.test(text[end] ?? '')) {
+    end += 1;
+  }
+
+  if (start === end) {
+    return null;
+  }
+
+  const word = text.slice(start, end);
+  if (!WORD_START_CHAR.test(word[0] ?? '')) {
+    return null;
+  }
+
+  return { word, start, end };
+}
+
+export = { getSelectListContext, findFromTable, getWordAtOffset };

--- a/tests/ts-plugin-hover.test.ts
+++ b/tests/ts-plugin-hover.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import ts from 'typescript';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { matchQueryLiteral } from '../src/ts-plugin/detect.cts';
+import { getColumnType } from '../src/ts-plugin/schema.cts';
+import { findFromTable, getWordAtOffset } from '../src/ts-plugin/sql-context.cts';
+
+const FIXTURE = `
+interface TypedDb<DB> {
+  query(sql: string): Promise<unknown>;
+}
+
+interface DB {
+  users: { id: number; name: string; email: string | null };
+  posts: { id: number; title: string };
+}
+
+declare const db: TypedDb<DB>;
+
+db.query(\`select id, name from users\`);
+db.query(\`select id from posts\`);
+`;
+
+function buildProgram(source: string): { program: ts.Program; sourceFile: ts.SourceFile; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-hover-'));
+  const filePath = join(dir, 'fixture.ts');
+  writeFileSync(filePath, source, 'utf8');
+
+  const program = ts.createProgram([filePath], {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+  });
+
+  const sourceFile = program.getSourceFile(filePath);
+  if (!sourceFile) {
+    throw new Error('fixture source file was not found in the program');
+  }
+
+  return { program, sourceFile, dir };
+}
+
+describe('getWordAtOffset', () => {
+  it('finds the word the cursor sits inside', () => {
+    expect(getWordAtOffset('select id, name from users', 8)).toEqual({ word: 'id', start: 7, end: 9 });
+  });
+
+  it('finds the word when the cursor sits at its trailing edge', () => {
+    expect(getWordAtOffset('select id, name from users', 9)).toEqual({ word: 'id', start: 7, end: 9 });
+  });
+
+  it('returns null for a position that is not inside a word', () => {
+    expect(getWordAtOffset('select id,  name from users', 10)).toBeNull();
+  });
+
+  it('returns null for an out-of-range offset', () => {
+    expect(getWordAtOffset('select id', -1)).toBeNull();
+    expect(getWordAtOffset('select id', 100)).toBeNull();
+  });
+});
+
+describe('ts-plugin hover: getColumnType against a real ts.Program', () => {
+  let cleanupDir: string | null = null;
+
+  afterEach(() => {
+    if (cleanupDir) {
+      rmSync(cleanupDir, { recursive: true, force: true });
+      cleanupDir = null;
+    }
+  });
+
+  it('resolves the type of a column scoped to its FROM table', () => {
+    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+
+    const literalText = 'select id, name from users';
+    const literalStart = sourceFile.text.indexOf(`\`${literalText}\``) + 1;
+    const cursor = sourceFile.text.indexOf('name', literalStart) + 1;
+    const match = matchQueryLiteral(ts, checker, sourceFile, cursor);
+    expect(match).not.toBeNull();
+    if (!match) return;
+
+    const word = getWordAtOffset(match.literal.text, cursor - literalStart);
+    expect(word?.word).toBe('name');
+    if (!word) return;
+
+    const table = findFromTable(match.literal.text);
+    expect(table).toBe('users');
+
+    const columnType = getColumnType(checker, match.dbType, match.literal, table, word.word);
+    expect(columnType && checker.typeToString(columnType)).toBe('string');
+  });
+
+  it('resolves a nullable column type', () => {
+    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+
+    const literalText = 'select id, name from users';
+    const literalStart = sourceFile.text.indexOf(`\`${literalText}\``) + 1;
+    const cursor = literalStart + literalText.indexOf('users') + 1;
+    const match = matchQueryLiteral(ts, checker, sourceFile, cursor);
+    expect(match).not.toBeNull();
+    if (!match) return;
+
+    const table = findFromTable(match.literal.text);
+    const columnType = getColumnType(checker, match.dbType, match.literal, table, 'email');
+    expect(columnType && checker.typeToString(columnType)).toBe('string | null');
+  });
+
+  it('returns null for a word that is not a real column', () => {
+    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+
+    const literalText = 'select id from posts';
+    const literalStart = sourceFile.text.indexOf(`\`${literalText}\``) + 1;
+    const cursor = literalStart + 1;
+    const match = matchQueryLiteral(ts, checker, sourceFile, cursor);
+    expect(match).not.toBeNull();
+    if (!match) return;
+
+    const table = findFromTable(match.literal.text);
+    const columnType = getColumnType(checker, match.dbType, match.literal, table, 'nope');
+    expect(columnType).toBeNull();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,10 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "tests"],
-  "exclude": ["src/ts-plugin", "tests/ts-plugin-sql-context.test.ts", "tests/ts-plugin-completions.test.ts"]
+  "exclude": [
+    "src/ts-plugin",
+    "tests/ts-plugin-sql-context.test.ts",
+    "tests/ts-plugin-completions.test.ts",
+    "tests/ts-plugin-hover.test.ts"
+  ]
 }


### PR DESCRIPTION
Fixes #12 (hover info part - the issue explicitly invites picking one of three independent pieces; inline diagnostics and JOIN/alias-aware completions+hover remain open).

## What

Hovering a column name inside a `db.query(\`...\`)` template literal now shows its resolved type:

```ts
db.query(`select id, name from users`)
//                    ^ hovering shows (column) name: string
```

## How

Adds a `getQuickInfoAtPosition` override to `src/ts-plugin/index.cts`, alongside the existing `getCompletionsAtPosition` one:

- `sql-context.cts`: new `getWordAtOffset(text, offset)` - finds the identifier word under the cursor within the raw literal text (cursor at a word's trailing edge counts as inside it, matching how editors report hover positions).
- `schema.cts`: new `getColumnType(checker, dbType, node, table, name)` - same table-scoping logic as the existing `getColumnNames`, but resolves one specific column's type instead of listing all names.
- `index.cts`: `getQuickInfoAtPosition` finds the enclosing query literal via the existing `matchQueryLiteral`, locates the word under the cursor, resolves its type against the scoped table(s) (same "first `FROM <table>`, else union of all tables" rule completions already use), and returns a `QuickInfo` whose `textSpan` covers just that word. Falls through to TypeScript's own prior hover for anything that isn't a real column match (keywords, table names, values outside the literal).

## Test plan

- [x] `npm test` (types + runtime) green, 62/62
- [x] New `tests/ts-plugin-hover.test.ts`: `getWordAtOffset` unit cases, and `getColumnType` against a real `ts.Program` covering scoped resolution, a nullable column, and a non-existent column returning `null`
- [x] Added to `tsconfig.json`'s exclude list alongside the other two `.cts`-importing test files - the standing Bundler/ESM-importing-CJS-`.cts` limitation this repo already works around for `ts-plugin-completions.test.ts`/`ts-plugin-sql-context.test.ts`, verified via real vitest execution instead of static `tsc`

## Docs

README's "Editor autocomplete" section and ROADMAP's `ts-plugin` v2 item updated: hover moved from "does not do" to shipped.