### PR TITLE
Type single-column scalar subqueries in the SELECT list

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,10 +735,13 @@ this.**
 
 This is a focused tool for the common read path, not a full SQL grammar:
 
-- **Scalar subqueries are not typed.** A subquery used as a value inside the
-  `SELECT` list or `WHERE` (`select (select count(*) from posts) from users`)
-  resolves to `unknown`. Only `WITH` CTEs and derived tables in `FROM` are
-  parsed.
+- **Scalar subqueries in the `SELECT` list are typed for the simple case** —
+  a single-column, non-nested subquery (`select (select count(*) from posts
+  where posts.user_id = users.id) as post_count from users`) resolves to
+  that column's type. A subquery selecting more than one column resolves to
+  `unknown` rather than picking one arbitrarily. Subqueries used as a value
+  inside `WHERE` are not typed at all (`WHERE` isn't part of the typed
+  structure — only scanned for parameter placeholders).
 - **`CASE` does not support nested `CASE`.** The parser looks for the first
   top-level `END`; a `CASE` nested inside another `CASE`'s branch is not
   supported.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,10 +28,11 @@ the editor tooling, not a promise of dates.
 Bigger pieces that need real parser or compiler-API design work — not
 first-timer-sized, but open if you want to dig in:
 
-- **Scalar subqueries in `SELECT`/`WHERE`** (currently resolve to `unknown`
-  by design — see [Limitations](README.md#limitations)). Needs the same
-  balanced-paren extraction used for CTEs/derived tables, applied at an
-  arbitrary expression position instead of only in `FROM`.
+- **Scalar subqueries in `WHERE`** (still resolve to `unknown` — `WHERE`
+  isn't part of the typed structure at all right now, only scanned for
+  parameter placeholders). Single-column `SELECT`-list scalar subqueries are
+  typed now — see [README limitations](README.md#limitations). Multi-column
+  `SELECT`-list subqueries still resolve to `unknown` too, by design.
 - **`ts-plugin` v2**: inline diagnostics for unknown columns/tables (reusing
   strict-mode's `QueryTypeError` logic but surfaced as a `tsserver`
   diagnostic instead of a type), and `JOIN`/alias-aware completions and

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -359,6 +359,32 @@ type QualifiedColumnType<
       : never
   : never;
 
+type ScalarSubqueryInner<Expression extends string> = Trim<Expression> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string; rest: infer Rest extends string }
+    ? Trim<Rest> extends ''
+      ? IsKeyword<FirstWord<Trim<Inner>>, 'select'> extends true
+        ? Trim<Inner>
+        : never
+      : never
+    : never
+  : never;
+
+type IsUnion<T, U = T> = T extends U ? ([U] extends [T] ? false : true) : never;
+
+type ScalarSubqueryType<
+  DB extends SchemaLike,
+  Q extends string,
+  Strict extends boolean,
+> = InferRowWith<DB, Q, Strict> extends infer Row
+  ? [Row] extends [never]
+    ? unknown
+    : Row extends QueryTypeError<string>
+      ? Row
+      : IsUnion<keyof Row> extends true
+        ? unknown
+        : Row[keyof Row]
+  : unknown;
+
 export type ResolveColumnType<
   DB extends SchemaLike,
   Sources extends Source[],
@@ -368,17 +394,19 @@ export type ResolveColumnType<
   ? SplitCaseExpression<Expression> extends { body: infer Body extends string }
     ? CaseExpressionType<DB, Sources, Body, Strict>
     : unknown
-  : IsFunctionCall<Expression> extends true
-    ? FunctionReturnType<Expression>
-    : Qualifier<Expression> extends ''
-      ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
-      : QualifiedColumnType<
-          DB,
-          Sources,
-          Unquote<Qualifier<Expression>>,
-          Unquote<StripQualifier<Expression>>,
-          Strict
-        >;
+  : [ScalarSubqueryInner<Expression>] extends [never]
+    ? IsFunctionCall<Expression> extends true
+      ? FunctionReturnType<Expression>
+      : Qualifier<Expression> extends ''
+        ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
+        : QualifiedColumnType<
+            DB,
+            Sources,
+            Unquote<Qualifier<Expression>>,
+            Unquote<StripQualifier<Expression>>,
+            Strict
+          >
+    : ScalarSubqueryType<DB, ScalarSubqueryInner<Expression>, Strict>;
 
 export type ResolveColumnLoose<
   DB extends SchemaLike,

--- a/tests/paren-boundary.test-d.ts
+++ b/tests/paren-boundary.test-d.ts
@@ -15,14 +15,14 @@ interface DB {
 type ScalarSubqueryKeepsSiblingColumns = Expect<
   Equal<
     Query<DB, 'select (select max(id) from orders) as m, name from users'>,
-    { m: unknown; name: string }[]
+    { m: number; name: string }[]
   >
 >;
 
-type ScalarSubqueryNoAliasFallsBackToRawText = Expect<
+type ScalarSubqueryNoAliasFallsBackToRawTextKey = Expect<
   Equal<
     Query<DB, 'select (select max(id) from orders), name from users'>,
-    { '(select max(id) from orders)': unknown; name: string }[]
+    { '(select max(id) from orders)': number; name: string }[]
   >
 >;
 
@@ -42,7 +42,7 @@ type FunctionArgWithFromKeywordResolvesAlias = Expect<
 
 export type BehaviorLock = [
   ScalarSubqueryKeepsSiblingColumns,
-  ScalarSubqueryNoAliasFallsBackToRawText,
+  ScalarSubqueryNoAliasFallsBackToRawTextKey,
   ParenthesizedArithmeticGroupResolvesAlias,
   FunctionArgWithFromKeywordResolvesAlias,
 ];

--- a/tests/scalar-subquery.test-d.ts
+++ b/tests/scalar-subquery.test-d.ts
@@ -1,0 +1,64 @@
+import type { Query, StrictQuery, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  posts: { id: number; user_id: number; views: number };
+}
+
+type ScalarSubqueryFromTheIssueExample = Expect<
+  Equal<
+    Query<
+      DB,
+      'select (select count(*) from posts where posts.user_id = users.id) as post_count from users'
+    >,
+    { post_count: number }[]
+  >
+>;
+
+type ScalarSubqueryAliasedColumnFromInnerTable = Expect<
+  Equal<
+    Query<DB, 'select id, (select views from posts) as v from users'>,
+    { id: number; v: number }[]
+  >
+>;
+
+type ScalarSubqueryNoAliasKeysByRawText = Expect<
+  Equal<
+    Query<DB, 'select (select count(*) from posts) from users'>,
+    { '(select count(*) from posts)': number }[]
+  >
+>;
+
+type MultiColumnSubqueryFallsBackToUnknown = Expect<
+  Equal<
+    Query<DB, 'select (select id, views from posts) as bad from users'>,
+    { bad: unknown }[]
+  >
+>;
+
+type StrictModeSurfacesTheInnerColumnError = Expect<
+  Equal<
+    StrictQuery<DB, 'select (select nope from posts) as x from users'>,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+type PlainParenthesizedExpressionIsUnaffected = Expect<
+  Equal<Query<DB, 'select (views * 2) as total, id from posts'>, { total: unknown; id: number }[]>
+>;
+
+export type ScalarSubqueryLock = [
+  ScalarSubqueryFromTheIssueExample,
+  ScalarSubqueryAliasedColumnFromInnerTable,
+  ScalarSubqueryNoAliasKeysByRawText,
+  MultiColumnSubqueryFallsBackToUnknown,
+  StrictModeSurfacesTheInnerColumnError,
+  PlainParenthesizedExpressionIsUnaffected,
+];


### PR DESCRIPTION
Fixes #11 (SELECT-list half, per the issue's own suggested v1 scope). WHERE-position subqueries remain untyped - called out in the issue as a separate, harder problem since WHERE isn't part of the typed structure at all right now.

## What

```ts
Query<DB, 'select (select count(*) from posts where posts.user_id = users.id) as post_count from users'>
// before: { post_count: unknown }[]
// after:  { post_count: number }[]
```

The entry's alias was already parsed correctly (via #17's `IsParenthesizedEntry`), but `ResolveColumnType` had nothing that recognized `"(select ...)"` text as anything other than an empty-named, always-`unknown` function call.

## Fix

- `ScalarSubqueryInner<Expression>`: detects an expression that is *exactly* one balanced-paren group whose content starts with `select`, reusing `ExtractParenGroup` the same way CTEs/derived tables already do.
- `ScalarSubqueryType<DB, Q, Strict>`: resolves the subquery's own row shape recursively via the existing `InferRowWith`. If that row has exactly one column, its type becomes the scalar value. A subquery selecting more than one column falls back to `unknown` rather than arbitrarily picking one - matches the issue's stated v1 scope.
- Wired into `ResolveColumnType` before the existing function-call/bare-column/qualified-column branches.
- Strict-mode errors from inside the subquery (e.g. an unknown column in its own `SELECT` list) propagate up as the `QueryTypeError` for the outer column, same as every other nested construct in this parser (`CASE`, `JOIN`, ...).

## Bonus fix

Two existing `tests/paren-boundary.test-d.ts` locks from #17 had hardcoded the old "always unknown" value for a parenthesized `max(id)` subquery - now correctly typed as `number`. Updated them.

## Test plan

- [x] `npm test` (types + runtime) green, 62/62
- [x] New `tests/scalar-subquery.test-d.ts`: the issue's own example, an aliased inner-table column, the no-alias raw-text-key fallback, multi-column-falls-back-to-unknown, strict-mode error surfacing, and a regression lock confirming plain parenthesized (non-subquery) expressions are unaffected

## Docs

README's scalar-subquery limitation bullet and ROADMAP's help-wanted item both rewritten to describe the narrower remaining gap (`WHERE`-position and multi-column `SELECT`-list subqueries only).