### PR TITLE
Type IS DISTINCT FROM / IS NOT DISTINCT FROM as a WHERE operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ this.**
 | Trailing semicolon | `select id from users;` |
 | Typed parameters | `where id = $1` → `query(sql, id: number)` |
 | Strict mode | `{ strict: true }` → unknown column becomes a `QueryTypeError` |
-| `WHERE` operators | `=`, `<>`, comparisons, `LIKE`/`ILIKE`, `IN (...)`, `BETWEEN ... AND ...`, `IS [NOT] NULL`, `AND`/`OR` |
+| `WHERE` operators | `=`, `<>`, comparisons, `LIKE`/`ILIKE`, `IN (...)`, `BETWEEN ... AND ...`, `IS [NOT] NULL`, `IS [NOT] DISTINCT FROM`, `AND`/`OR` |
 | `GROUP BY` / `HAVING` / `ORDER BY` / `LIMIT` / `OFFSET` | parsed and skipped; output shape follows the `SELECT` list, `HAVING`/`LIMIT`/`OFFSET` placeholders are typed |
 | `UNION` / `UNION ALL` | result shape is inferred from the first branch |
 | `CASE WHEN ... THEN ... [ELSE ...] END` | branch types are unioned (`\| null` added when there is no `ELSE`) |

--- a/src/params.ts
+++ b/src/params.ts
@@ -12,7 +12,7 @@ import type { ParseWithClause } from './cte.js';
 
 type Operator = '=' | '<>' | '!=' | '<' | '>' | '<=' | '>=';
 
-type WordOperator = 'like' | 'ilike' | 'in' | 'between';
+type WordOperator = 'like' | 'ilike' | 'in' | 'between' | 'distinct';
 
 type ForcedNumberKeyword = 'limit' | 'offset';
 
@@ -24,7 +24,7 @@ type IsOperator<Token extends string> = Token extends Operator
 
 type IsTransparentToken<Token extends string> = Token extends '(' | ')' | ','
   ? true
-  : Lowercase<Token> extends 'and' | 'or' | 'not'
+  : Lowercase<Token> extends 'and' | 'or' | 'not' | 'is' | 'from'
     ? true
     : false;
 

--- a/tests/where.test-d.ts
+++ b/tests/where.test-d.ts
@@ -9,6 +9,7 @@ type Expect<T extends true> = T;
 
 interface DB {
   users: { id: number; name: string; age: number; active: boolean; deleted_at: string | null };
+  orders: { id: number; user_id: number; price: number };
 }
 
 type LikeParam = Expect<
@@ -49,6 +50,37 @@ type IsNotNullDoesNotAffectArity = Expect<
   >
 >;
 
+type IsDistinctFromParam = Expect<
+  Equal<
+    Params<DB, 'select id from users where deleted_at is distinct from $1'>,
+    [string | null]
+  >
+>;
+
+type IsNotDistinctFromParam = Expect<
+  Equal<
+    Params<DB, 'select id from users where deleted_at is not distinct from $1'>,
+    [string | null]
+  >
+>;
+
+type IsDistinctFromCombinedWithAnotherCondition = Expect<
+  Equal<
+    Params<DB, 'select id from users where deleted_at is distinct from $1 and id = $2'>,
+    [string | null, number]
+  >
+>;
+
+type MakingFromTransparentDoesNotBreakJoinParams = Expect<
+  Equal<
+    Params<
+      DB,
+      'select u.name from users u join orders o on u.id = o.user_id where o.price > $1'
+    >,
+    [number]
+  >
+>;
+
 type MultipleAndConditions = Expect<
   Equal<
     Params<DB, 'select id from users where active = $1 and age > $2 and name = $3'>,
@@ -72,6 +104,10 @@ export type WhereLock = [
   BetweenParams,
   IsNullDoesNotAffectArity,
   IsNotNullDoesNotAffectArity,
+  IsDistinctFromParam,
+  IsNotDistinctFromParam,
+  IsDistinctFromCombinedWithAnotherCondition,
+  MakingFromTransparentDoesNotBreakJoinParams,
   MultipleAndConditions,
   OrConditions,
 ];


### PR DESCRIPTION
Fixes #10.

## What

```ts
Params<DB, 'select id from users where deleted_at is distinct from $1'>
// before: unknown[]
// after:  [string | null]  (matching deleted_at's own type)
```

`is`/`distinct`/`from` weren't recognized by `ScanParams`'s operator/transparent-token lookback in `src/params.ts`, so the param fell through to `unknown`.

## Fix

- Added `is` and `from` to `IsTransparentToken` (don't shift the column/operator lookback window).
- Added `distinct` to `WordOperator` (becomes the recognized operator token via the normal shift, the same way `between` does for its own multi-word phrase).
- `not` was already transparent, so `IS NOT DISTINCT FROM` works with no extra change.

## The `from` concern

The issue flagged this explicitly: `from` is the single most common word in any query, appearing in every `FROM` clause regardless of `WHERE` content. Traced through several cases by hand before trusting it globally-transparent (a plain `FROM` clause, a `JOIN` with a `WHERE` param afterward) - concluded it's safe since nothing in this scanner's design depends on `from` shifting the window (no placeholder legitimately follows it in valid SQL). Confirmed empirically too: full `npm test` stayed green, and added a dedicated regression case for a `JOIN` query's `WHERE` param specifically because the issue called that scenario out.

## Test plan

- [x] `npm test` (types + runtime) green, 62/62
- [x] New in `tests/where.test-d.ts`: `IS DISTINCT FROM`, `IS NOT DISTINCT FROM`, combined with a second `AND` condition, and the `JOIN`-query regression lock
- [x] README's `WHERE` operators row updated