### PR TITLE
Type IS [NOT] DISTINCT FROM as a null-safe WHERE operator

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -12,7 +12,7 @@ import type { ParseWithClause } from './cte.js';
 
 type Operator = '=' | '<>' | '!=' | '<' | '>' | '<=' | '>=';
 
-type WordOperator = 'like' | 'ilike' | 'in' | 'between';
+type WordOperator = 'like' | 'ilike' | 'in' | 'between' | 'distinct';
 
 type ForcedNumberKeyword = 'limit' | 'offset';
 
@@ -24,7 +24,7 @@ type IsOperator<Token extends string> = Token extends Operator
 
 type IsTransparentToken<Token extends string> = Token extends '(' | ')' | ','
   ? true
-  : Lowercase<Token> extends 'and' | 'or' | 'not'
+  : Lowercase<Token> extends 'and' | 'or' | 'not' | 'is' | 'from'
     ? true
     : false;
 

--- a/tests/where.test-d.ts
+++ b/tests/where.test-d.ts
@@ -35,6 +35,20 @@ type BetweenParams = Expect<
   Equal<Params<DB, 'select id from users where age between $1 and $2'>, [number, number]>
 >;
 
+type IsDistinctFromParam = Expect<
+  Equal<
+    Params<DB, 'select id from users where deleted_at is distinct from $1'>,
+    [string | null]
+  >
+>;
+
+type IsNotDistinctFromParam = Expect<
+  Equal<
+    Params<DB, 'select id from users where deleted_at is not distinct from $1'>,
+    [string | null]
+  >
+>;
+
 type IsNullDoesNotAffectArity = Expect<
   Equal<
     Params<DB, 'select id from users where deleted_at is null and id = $1'>,
@@ -70,6 +84,8 @@ export type WhereLock = [
   InListParams,
   NotInListParams,
   BetweenParams,
+  IsDistinctFromParam,
+  IsNotDistinctFromParam,
   IsNullDoesNotAffectArity,
   IsNotNullDoesNotAffectArity,
   MultipleAndConditions,


### PR DESCRIPTION
Closes #10.

Adds `IS DISTINCT FROM` / `IS NOT DISTINCT FROM` support to the `ScanParams` type-level scanner, so `where col is [not] distinct from $1` types `$1` as the column's type instead of falling through to `unknown`.

Following your spec, this mirrors the existing multi-word-operator handling rather than inventing a new mechanism:

- `distinct` is added to `WordOperator` — it lands in the operator slot exactly like `in`/`between`.
- `is` and `from` are added to `IsTransparentToken` — like `and`/`or`/`not`, they don't shift the column/operator lookback window.

So in `col IS [NOT] DISTINCT FROM $1` the window resolves to `(col, 'distinct')` and the placeholder is typed against the column. On the `from`-disambiguation you flagged: because a placeholder never immediately follows a bare `from` or `is` in a valid WHERE operator position (only in this phrase), making them transparent is safe — the pre-existing `is null` / `is not null` arity tests stay green.

### Tests (`tests/where.test-d.ts`)
- `IsDistinctFromParam` and `IsNotDistinctFromParam` assert `[string | null]` for `deleted_at is [not] distinct from $1`, matching the existing `LikeParam`/`BetweenParams` style, and wired into `WhereLock`.

### Verification
- `npm test` — `test:types` (`tsc --noEmit`, both tsconfigs) + `test:runtime` (vitest, 62 tests) all pass, including the bare `is null`/`is not null` cases.
- `npm run typecheck`, `npm run build` — both clean.
- Revert check: stashing the `src/params.ts` change makes exactly the two new cases fail (`TS2344`), confirming they exercise the new path; restoring goes green again.

Happy to adjust the null-union convention or naming if you'd prefer something different.

---
Generated by Claude Opus 4.8 (brief, review), Kimi K3 (implementation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `DISTINCT FROM` and `NOT DISTINCT FROM` SQL conditions.
  - Improved parameter type inference for nullable values used with these conditions.

- **Tests**
  - Added coverage validating correct parameter inference for both distinctness comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->