### PR TITLE
ts-plugin: column completions after WHERE

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,9 @@ db.query(`
 
 db.query(`select id, name from users`)
 //                    ^ hovering shows (column) name: string
+
+db.query(`select id from users where na`)
+//                                    ^ autocomplete suggests `name`
 ```
 
 Want to see it running for yourself before there's a recorded demo here?
@@ -618,13 +621,16 @@ is the #1 reason this kind of plugin appears to do nothing. Other editors
 that talk to `tsserver` (Cursor, some Neovim/Sublime LSP setups) generally
 pick up `tsconfig.json` plugins automatically.
 
-**What it does:** suggests column names right after `SELECT` or a comma in
-the column list, and shows a column's resolved type on hover, for
-`db.query(...)` calls made through a client built with `createTypedDb<DB>`.
-If a `FROM <table>` is already present anywhere later in the same string,
-both completions and hover are scoped to that table; otherwise completions
-fall back to the deduplicated union of every table's columns in `DB` — which
-is exactly what covers the example above before you've typed `FROM` at all.
+**What it does:** suggests column names right after `SELECT`/a comma in the
+column list or after `WHERE`/`AND`/`OR`, and shows a column's resolved type
+on hover, for `db.query(...)` calls made through a client built with
+`createTypedDb<DB>`. If a `FROM <table>` is already present anywhere later
+in the same string, completions and hover are scoped to that table;
+otherwise `SELECT`-list completions fall back to the deduplicated union of
+every table's columns in `DB` — which is exactly what covers the example
+above before you've typed `FROM` at all. `WHERE`-position completions
+require a `FROM` to already be present (there's no table to scope to
+otherwise).
 
 **What it does not do** (documented scope, not bugs):
 
@@ -638,8 +644,8 @@ is exactly what covers the example above before you've typed `FROM` at all.
   (`` db.query(`select ...`) ``) are recognized — which is the only form the
   library ever expects you to write, since parameters are SQL placeholders
   (`$1`/`?`/`@name`), never JS template interpolation.
-- Completions after `WHERE`/`ORDER BY`/etc. aren't offered yet — only the
-  `SELECT` column list.
+- Completions after `ORDER BY`/`GROUP BY`/`HAVING`/etc. aren't offered yet —
+  only the `SELECT` column list and `WHERE` clause.
 - **Requires TypeScript < 7.** TypeScript 7's native (Go-based) compiler
   removed the classic JS Compiler API (`ts.Node`, `ts.forEachChild`,
   `ts.createProgram`, ...) that this plugin — and, as of this writing, every

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -3,7 +3,7 @@ import sqlContext = require('./sql-context.cjs');
 import schemaModule = require('./schema.cjs');
 import detectModule = require('./detect.cjs');
 
-const { getSelectListContext, findFromTable, getWordAtOffset } = sqlContext;
+const { getSelectListContext, getWhereClauseContext, findFromTable, getWordAtOffset } = sqlContext;
 const { getColumnNames, getColumnType } = schemaModule;
 const { matchQueryLiteral } = detectModule;
 
@@ -41,7 +41,7 @@ function init(modules: { typescript: typeof ts }) {
 
       const literalStart = match.literal.getStart(sourceFile) + 1;
       const textBeforeCursor = sourceFile.text.slice(literalStart, position);
-      const context = getSelectListContext(textBeforeCursor);
+      const context = getSelectListContext(textBeforeCursor) ?? getWhereClauseContext(textBeforeCursor);
       if (!context) {
         return prior;
       }

--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -1,5 +1,6 @@
 const SELECT_START = /^select\b/i;
 const HAS_FROM = /\bfrom\b/i;
+const HAS_WHERE = /\bwhere\b/i;
 const TRAILING_WORD = /([A-Za-z_][A-Za-z0-9_]*)$/;
 const FROM_TABLE = /\bfrom\s+([A-Za-z_][A-Za-z0-9_]*)/i;
 const WORD_CHAR = /[A-Za-z0-9_]/;
@@ -23,6 +24,19 @@ function getSelectListContext(textBeforeCursor: string): SelectListContext | nul
   }
 
   if (HAS_FROM.test(textBeforeCursor)) {
+    return null;
+  }
+
+  const match = TRAILING_WORD.exec(textBeforeCursor);
+  return { prefix: match?.[1] ?? '' };
+}
+
+function getWhereClauseContext(textBeforeCursor: string): SelectListContext | null {
+  if (!HAS_FROM.test(textBeforeCursor)) {
+    return null;
+  }
+
+  if (!HAS_WHERE.test(textBeforeCursor)) {
     return null;
   }
 
@@ -62,4 +76,4 @@ function getWordAtOffset(text: string, offset: number): WordAtOffset | null {
   return { word, start, end };
 }
 
-export = { getSelectListContext, findFromTable, getWordAtOffset };
+export = { getSelectListContext, getWhereClauseContext, findFromTable, getWordAtOffset };

--- a/tests/ts-plugin-completions.test.ts
+++ b/tests/ts-plugin-completions.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { matchQueryLiteral } from '../src/ts-plugin/detect.cts';
 import { getColumnNames } from '../src/ts-plugin/schema.cts';
-import { getSelectListContext, findFromTable } from '../src/ts-plugin/sql-context.cts';
+import { getSelectListContext, getWhereClauseContext, findFromTable } from '../src/ts-plugin/sql-context.cts';
 
 const FIXTURE = `
 interface TypedDb<DB> {
@@ -21,6 +21,7 @@ declare const db: TypedDb<DB>;
 
 db.query(\`select id, na\`);
 db.query(\`select id, na from posts\`);
+db.query(\`select id from users where na\`);
 `;
 
 function buildProgram(source: string): { program: ts.Program; sourceFile: ts.SourceFile; filePath: string; dir: string } {
@@ -108,5 +109,31 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
     expect(columns.sort()).toEqual(['id', 'title']);
     expect(columns).not.toContain('name');
     expect(columns).not.toContain('email');
+  });
+
+  it('suggests columns after WHERE, scoped to the FROM table', () => {
+    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+
+    const queryText = 'select id from users where na';
+    const literalStart = sourceFile.text.indexOf(`\`${queryText}\``) + 1;
+    const cursor = sourceFile.text.indexOf(queryText) + queryText.length;
+    const match = matchQueryLiteral(ts, checker, sourceFile, cursor);
+    expect(match).not.toBeNull();
+    if (!match) return;
+
+    const textBeforeCursor = sourceFile.text.slice(literalStart, cursor);
+    const context = getSelectListContext(textBeforeCursor) ?? getWhereClauseContext(textBeforeCursor);
+    expect(context).toEqual({ prefix: 'na' });
+    if (!context) return;
+
+    const table = findFromTable(match.literal.text);
+    expect(table).toBe('users');
+
+    const columns = getColumnNames(checker, match.dbType, match.literal, table);
+    const filtered = columns.filter((name) => name.startsWith(context.prefix));
+
+    expect(filtered).toEqual(['name']);
   });
 });

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getSelectListContext, findFromTable } from '../src/ts-plugin/sql-context.cts';
+import { getSelectListContext, getWhereClauseContext, findFromTable } from '../src/ts-plugin/sql-context.cts';
 
 describe('getSelectListContext', () => {
   it('extracts the partial word being typed in a SELECT list', () => {
@@ -22,6 +22,34 @@ describe('getSelectListContext', () => {
 
   it('is case-insensitive on the SELECT keyword', () => {
     expect(getSelectListContext('SELECT id, na')).toEqual({ prefix: 'na' });
+  });
+});
+
+describe('getWhereClauseContext', () => {
+  it('extracts the partial word being typed after WHERE', () => {
+    expect(getWhereClauseContext('select id from users where na')).toEqual({ prefix: 'na' });
+  });
+
+  it('extracts the partial word being typed after AND/OR', () => {
+    expect(getWhereClauseContext('select id from users where active = true and na')).toEqual({
+      prefix: 'na',
+    });
+  });
+
+  it('returns an empty prefix right after WHERE', () => {
+    expect(getWhereClauseContext('select id from users where ')).toEqual({ prefix: '' });
+  });
+
+  it('returns null when there is no FROM clause yet', () => {
+    expect(getWhereClauseContext('select id where na')).toBeNull();
+  });
+
+  it('returns null when there is no WHERE clause yet', () => {
+    expect(getWhereClauseContext('select id from na')).toBeNull();
+  });
+
+  it('is case-insensitive on the WHERE keyword', () => {
+    expect(getWhereClauseContext('select id from users WHERE na')).toEqual({ prefix: 'na' });
   });
 });
 


### PR DESCRIPTION
Fixes #9.

## What

```ts
db.query(`select id from users where na`)
//                                    ^ now suggests `name`
```

`sql-context.cts` only offered completions right after `SELECT`/a comma in the column list.

## Fix

Added `getWhereClauseContext`, mirroring `getSelectListContext`'s shape exactly: requires both a `FROM` and a `WHERE` already typed, then extracts the trailing partial word the same way via `TRAILING_WORD`. Wired into `index.cts`'s `getCompletionsAtPosition` as a fallback after `getSelectListContext` - whichever context matches drives the same column-name filtering/lookup that already existed, unchanged.

`getColumnNames` didn't need any change - it already scopes by whatever table `findFromTable` resolves, which works identically for a `WHERE`-position completion.

## Test plan

- [x] `npm test` (types + runtime) green, 69/69
- [x] New pure-function cases in `tests/ts-plugin-sql-context.test.ts`, mirroring the existing `getSelectListContext` tests
- [x] New real-`ts.Program` end-to-end case in `tests/ts-plugin-completions.test.ts` confirming `select id from users where na` suggests `name`
- [x] Existing `SELECT`-list behavior unaffected (additive `??` fallback)

## Docs

README's "Editor autocomplete" section updated with a `WHERE`-completion example and scope note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SQL editor autocomplete suggestions within `WHERE` clauses.
  - Added support for suggestions after `AND` and `OR` conditions.
  - Improved column completion and hover behavior based on available query context.

- **Documentation**
  - Updated autocomplete examples, scoping behavior, and current clause limitations.

- **Tests**
  - Added coverage for `WHERE`-clause completion, prefix detection, and case-insensitive SQL keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->