### PR TITLE
fix: master is broken — duplicate IsDistinctFromParam/IsNotDistinctFromParam

### DIFF
--- a/tests/where.test-d.ts
+++ b/tests/where.test-d.ts
@@ -50,34 +50,6 @@ type IsNotDistinctFromParam = Expect<
   >
 >;
 
-type IsNullDoesNotAffectArity = Expect<
-  Equal<
-    Params<DB, 'select id from users where deleted_at is null and id = $1'>,
-    [number]
-  >
->;
-
-type IsNotNullDoesNotAffectArity = Expect<
-  Equal<
-    Params<DB, 'select id from users where deleted_at is not null and id = $1'>,
-    [number]
-  >
->;
-
-type IsDistinctFromParam = Expect<
-  Equal<
-    Params<DB, 'select id from users where deleted_at is distinct from $1'>,
-    [string | null]
-  >
->;
-
-type IsNotDistinctFromParam = Expect<
-  Equal<
-    Params<DB, 'select id from users where deleted_at is not distinct from $1'>,
-    [string | null]
-  >
->;
-
 type IsDistinctFromCombinedWithAnotherCondition = Expect<
   Equal<
     Params<DB, 'select id from users where deleted_at is distinct from $1 and id = $2'>,
@@ -91,6 +63,20 @@ type MakingFromTransparentDoesNotBreakJoinParams = Expect<
       DB,
       'select u.name from users u join orders o on u.id = o.user_id where o.price > $1'
     >,
+    [number]
+  >
+>;
+
+type IsNullDoesNotAffectArity = Expect<
+  Equal<
+    Params<DB, 'select id from users where deleted_at is null and id = $1'>,
+    [number]
+  >
+>;
+
+type IsNotNullDoesNotAffectArity = Expect<
+  Equal<
+    Params<DB, 'select id from users where deleted_at is not null and id = $1'>,
     [number]
   >
 >;
@@ -118,12 +104,10 @@ export type WhereLock = [
   BetweenParams,
   IsDistinctFromParam,
   IsNotDistinctFromParam,
-  IsNullDoesNotAffectArity,
-  IsNotNullDoesNotAffectArity,
-  IsDistinctFromParam,
-  IsNotDistinctFromParam,
   IsDistinctFromCombinedWithAnotherCondition,
   MakingFromTransparentDoesNotBreakJoinParams,
+  IsNullDoesNotAffectArity,
+  IsNotNullDoesNotAffectArity,
   MultipleAndConditions,
   OrConditions,
 ];


### PR DESCRIPTION
**master currently fails \`tsc --noEmit\`** with:

\`\`\`
tests/where.test-d.ts(39,6): error TS2300: Duplicate identifier 'IsDistinctFromParam'.
tests/where.test-d.ts(46,6): error TS2300: Duplicate identifier 'IsNotDistinctFromParam'.
tests/where.test-d.ts(67,6): error TS2300: Duplicate identifier 'IsDistinctFromParam'.
tests/where.test-d.ts(74,6): error TS2300: Duplicate identifier 'IsNotDistinctFromParam'.
\`\`\`

## Root cause

Two independent PRs landed for issue #10 - my own #42, then a second, independent one (#43) - both adding the same two test cases (\`IsDistinctFromParam\`/\`IsNotDistinctFromParam\`) in slightly different positions in \`tests/where.test-d.ts\`. Merging #43 on top of #42 kept both copies instead of recognizing them as duplicates - also duplicated the corresponding \`WhereLock\` array entries.

\`src/params.ts\` merged cleanly (both PRs converged on identical \`WordOperator\`/\`IsTransparentToken\` changes, so git's merge produced one copy correctly) - only the test file needed manual deduplication.

## Fix

Kept one copy of each test case plus everything else that had accumulated in the file since (the JOIN-param regression lock, the combined AND-condition case), removed the duplicate \`WhereLock\` entries.

## Verification

- \`npm test\` (types + runtime) green, 69/69 - was failing at \`test:types\` before this fix

This should merge ASAP since it blocks CI/type-checking for every other open PR against \`master\` right now.