### PR TITLE
fix: import StrictQuery in playground demo

### DIFF
--- a/examples/playground/index.ts
+++ b/examples/playground/index.ts
@@ -1,4 +1,4 @@
-import { createTypedDb, ResultStatus, type Query } from '@owlsql/core';
+import { createTypedDb, ResultStatus, type Query, type StrictQuery } from '@owlsql/core';
 import type { DB } from './schema.js';
 
 // --- 1. Type-only usage: hover `Result` below to see the inferred row shape.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owlsql/core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owlsql/core",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "bin": {
         "owlsql": "dist/cli/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owlsql/core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Parse SQL in TypeScript template literal types and infer the result shape from your schema — no codegen, no ORM.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- examples/playground/index.ts:1 imported only `Query`, not `StrictQuery`
- Uncommenting the advertised demo line (line 31) threw `Cannot find name 'StrictQuery'` instead of surfacing the intended type error

## Test plan
- [x] Temporarily uncommented the demo line, ran `npm install && npx tsc --noEmit` in examples/playground — reproduced the exact reported error
- [x] Applied the import fix, reran tsc — clean, no errors
- [x] Re-commented the demo line back to its original state

Fixes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.1.5 to 0.1.6.
  * Refined the playground’s type usage for stricter query examples without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->