### PR TITLE
fix: type-check ts-plugin test files against src/ts-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc -p tsconfig.ts-plugin.json",
     "typecheck": "tsc --noEmit",
-    "test:types": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.ts-plugin.json",
+    "test:types": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.ts-plugin.json && tsc --noEmit -p tsconfig.ts-plugin-tests.json",
     "test:runtime": "vitest run",
     "test": "npm run test:types && npm run test:runtime",
     "prepublishOnly": "npm run test && npm run build"

--- a/tests/ts-plugin-completions.test.ts
+++ b/tests/ts-plugin-completions.test.ts
@@ -3,9 +3,13 @@ import ts from 'typescript';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { matchQueryLiteral } from '../src/ts-plugin/detect.cts';
-import { getColumnNames } from '../src/ts-plugin/schema.cts';
-import { getSelectListContext, getWhereClauseContext, findFromTable } from '../src/ts-plugin/sql-context.cts';
+import detectModule from '../src/ts-plugin/detect.cts';
+import schemaModule from '../src/ts-plugin/schema.cts';
+import sqlContext from '../src/ts-plugin/sql-context.cts';
+
+const { matchQueryLiteral } = detectModule;
+const { getColumnNames } = schemaModule;
+const { getSelectListContext, getWhereClauseContext, findFromTable } = sqlContext;
 
 const FIXTURE = `
 interface TypedDb<DB> {

--- a/tests/ts-plugin-hover.test.ts
+++ b/tests/ts-plugin-hover.test.ts
@@ -3,9 +3,13 @@ import ts from 'typescript';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { matchQueryLiteral } from '../src/ts-plugin/detect.cts';
-import { getColumnType } from '../src/ts-plugin/schema.cts';
-import { findFromTable, getWordAtOffset } from '../src/ts-plugin/sql-context.cts';
+import detectModule from '../src/ts-plugin/detect.cts';
+import schemaModule from '../src/ts-plugin/schema.cts';
+import sqlContext from '../src/ts-plugin/sql-context.cts';
+
+const { matchQueryLiteral } = detectModule;
+const { getColumnType } = schemaModule;
+const { findFromTable, getWordAtOffset } = sqlContext;
 
 const FIXTURE = `
 interface TypedDb<DB> {

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { getSelectListContext, getWhereClauseContext, findFromTable } from '../src/ts-plugin/sql-context.cts';
+import sqlContext from '../src/ts-plugin/sql-context.cts';
+
+const { getSelectListContext, getWhereClauseContext, findFromTable } = sqlContext;
 
 describe('getSelectListContext', () => {
   it('extracts the partial word being typed in a SELECT list', () => {

--- a/tsconfig.ts-plugin-tests.json
+++ b/tsconfig.ts-plugin-tests.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "src/ts-plugin",
+    "tests/ts-plugin-sql-context.test.ts",
+    "tests/ts-plugin-completions.test.ts",
+    "tests/ts-plugin-hover.test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- `tests/ts-plugin-*.test.ts` were excluded from `tsconfig.json` (they import `.cts` modules, incompatible with `moduleResolution: "Bundler"`) and `tsconfig.ts-plugin.json` only covers `src/ts-plugin` — no config picked them up, so `test:types` never saw them and drifted signatures against the `.cts` exports could ship green
- Adds `tsconfig.ts-plugin-tests.json` (NodeNext, noEmit) covering `tests/ts-plugin-*.test.ts` + `src/ts-plugin`, wired into `test:types`
- Switches those tests' `.cts` imports from named destructuring to default-import + destructure — TS disallows named-import syntax against `export =` regardless of `esModuleInterop` (only default import is synthesized); this already matches the pattern `src/ts-plugin/index.cts` itself uses

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.ts-plugin-tests.json` — clean
- [x] `npm run test:types` — clean end-to-end
- [x] `npx vitest run tests/ts-plugin-*.test.ts` — all 25 tests still pass after the import rewrite
- [x] Regression check: temporarily changed a `.cts` function's parameter type — confirmed `test:types` now catches the drift across the test/src boundary (12 errors), then reverted

Fixes #79