### PR TITLE
fix: detect TypedDb structurally instead of by bare name

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,9 @@ otherwise).
 - Only plain string/template literals with **no interpolation**
   (`` db.query(`select ...`) ``) are recognized — which is the only form the
   library ever expects you to write, since parameters are SQL placeholders
-  (`$1`/`?`/`@name`), never JS template interpolation.
+  (`$1`/`?`/`@name`), never JS template interpolation. Interpolating
+  (`` db.query(`select ... ${x}`) ``) silently turns completions/hover off
+  for that call — there's no squiggle or warning telling you why.
 - Completions after `ORDER BY`/`GROUP BY`/`HAVING`/etc. aren't offered yet —
   only the `SELECT` column list and `WHERE` clause.
 - **Requires TypeScript < 7.** TypeScript 7's native (Go-based) compiler

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export interface TypedDbOptions {
 }
 
 export interface TypedDb<DB extends SchemaLike, Strict extends boolean = false> {
+  readonly __owlsqlTypedDb?: true;
   query<Q extends string>(
     sql: Q,
     ...params: InferParams<DB, Q>

--- a/src/ts-plugin/detect.cts
+++ b/src/ts-plugin/detect.cts
@@ -2,6 +2,8 @@ import type * as ts from 'typescript';
 
 type TypeScript = typeof import('typescript');
 
+const TYPED_DB_BRAND_PROPERTY = '__owlsqlTypedDb';
+
 interface QueryLiteralMatch {
   literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral;
   dbType: ts.Type;
@@ -30,20 +32,49 @@ function isSqlLiteral(
   return typescript.isStringLiteral(node) || typescript.isNoSubstitutionTemplateLiteral(node);
 }
 
+function getQueryPropertyName(typescript: TypeScript, expression: ts.LeftHandSideExpression): string | null {
+  if (typescript.isPropertyAccessExpression(expression)) {
+    return expression.name.text;
+  }
+
+  if (
+    typescript.isElementAccessExpression(expression) &&
+    typescript.isStringLiteralLike(expression.argumentExpression)
+  ) {
+    return expression.argumentExpression.text;
+  }
+
+  return null;
+}
+
+function getReceiverExpression(typescript: TypeScript, call: ts.CallExpression): ts.Expression | null {
+  const expression = call.expression;
+  return typescript.isPropertyAccessExpression(expression) || typescript.isElementAccessExpression(expression)
+    ? expression.expression
+    : null;
+}
+
 function findEnclosingQueryCall(
   typescript: TypeScript,
   literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral,
 ): ts.CallExpression | null {
-  const call = literal.parent;
-  if (!call || !typescript.isCallExpression(call) || call.arguments[0] !== literal) {
+  let argumentNode: ts.Expression = literal;
+  let parent = argumentNode.parent;
+
+  while (parent && typescript.isParenthesizedExpression(parent)) {
+    argumentNode = parent;
+    parent = argumentNode.parent;
+  }
+
+  if (!parent || !typescript.isCallExpression(parent) || parent.arguments[0] !== argumentNode) {
     return null;
   }
 
-  if (!typescript.isPropertyAccessExpression(call.expression) || call.expression.name.text !== 'query') {
+  if (getQueryPropertyName(typescript, parent.expression) !== 'query') {
     return null;
   }
 
-  return call;
+  return parent;
 }
 
 function isTypeReference(typescript: TypeScript, type: ts.Type): type is ts.TypeReference {
@@ -53,11 +84,29 @@ function isTypeReference(typescript: TypeScript, type: ts.Type): type is ts.Type
   );
 }
 
-function isTypedDbQueryMethod(checker: ts.TypeChecker, call: ts.CallExpression): boolean {
-  const signature = checker.getResolvedSignature(call);
-  const declaration = signature?.declaration;
-  const parent = declaration?.parent;
-  return parent !== undefined && 'name' in parent && (parent as { name?: ts.Identifier }).name?.text === 'TypedDb';
+function hasTypedDbBrand(checker: ts.TypeChecker, type: ts.Type): boolean {
+  return checker.getPropertyOfType(type, TYPED_DB_BRAND_PROPERTY) !== undefined;
+}
+
+function findTypedDbTypeReference(
+  typescript: TypeScript,
+  checker: ts.TypeChecker,
+  type: ts.Type,
+): ts.TypeReference | null {
+  if (isTypeReference(typescript, type) && hasTypedDbBrand(checker, type)) {
+    return type;
+  }
+
+  if (type.isIntersection()) {
+    for (const constituent of type.types) {
+      const found = findTypedDbTypeReference(typescript, checker, constituent);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  return null;
 }
 
 function matchQueryLiteral(
@@ -72,16 +121,22 @@ function matchQueryLiteral(
   }
 
   const call = findEnclosingQueryCall(typescript, node);
-  if (!call || !isTypedDbQueryMethod(checker, call)) {
+  if (!call) {
     return null;
   }
 
-  const objectExpression = (call.expression as ts.PropertyAccessExpression).expression;
-  const objectType = checker.getTypeAtLocation(objectExpression);
-  const dbType = isTypeReference(typescript, objectType)
-    ? checker.getTypeArguments(objectType)[0]
-    : undefined;
+  const receiver = getReceiverExpression(typescript, call);
+  if (!receiver) {
+    return null;
+  }
 
+  const receiverType = checker.getTypeAtLocation(receiver);
+  const typedDbRef = findTypedDbTypeReference(typescript, checker, receiverType);
+  if (!typedDbRef) {
+    return null;
+  }
+
+  const dbType = checker.getTypeArguments(typedDbRef)[0];
   if (!dbType) {
     return null;
   }

--- a/tests/ts-plugin-completions.test.ts
+++ b/tests/ts-plugin-completions.test.ts
@@ -1,20 +1,17 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { rmSync } from 'node:fs';
 import ts from 'typescript';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 import detectModule from '../src/ts-plugin/detect.cts';
 import schemaModule from '../src/ts-plugin/schema.cts';
 import sqlContext from '../src/ts-plugin/sql-context.cts';
+import { buildProgram } from './ts-plugin-test-helpers.js';
 
 const { matchQueryLiteral } = detectModule;
 const { getColumnNames } = schemaModule;
 const { getSelectListContext, getWhereClauseContext, findFromTable } = sqlContext;
 
 const FIXTURE = `
-interface TypedDb<DB> {
-  query(sql: string): Promise<unknown>;
-}
+import type { TypedDb } from '@owlsql/core';
 
 interface DB {
   users: { id: number; name: string; email: string };
@@ -28,26 +25,6 @@ db.query(\`select id, na from posts\`);
 db.query(\`select id from users where na\`);
 `;
 
-function buildProgram(source: string): { program: ts.Program; sourceFile: ts.SourceFile; filePath: string; dir: string } {
-  const dir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-'));
-  const filePath = join(dir, 'fixture.ts');
-  writeFileSync(filePath, source, 'utf8');
-
-  const program = ts.createProgram([filePath], {
-    target: ts.ScriptTarget.ES2022,
-    module: ts.ModuleKind.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.Bundler,
-    strict: true,
-  });
-
-  const sourceFile = program.getSourceFile(filePath);
-  if (!sourceFile) {
-    throw new Error('fixture source file was not found in the program');
-  }
-
-  return { program, sourceFile, filePath, dir };
-}
-
 describe('ts-plugin: detect + schema against a real ts.Program', () => {
   let cleanupDir: string | null = null;
 
@@ -59,7 +36,7 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
   });
 
   it('detects a db.query(...) call and resolves its DB type argument', () => {
-    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    const { program, sourceFile, dir } = buildProgram(FIXTURE, 'owlsql-ts-plugin-completions-');
     cleanupDir = dir;
     const checker = program.getTypeChecker();
 
@@ -70,7 +47,7 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
   });
 
   it('suggests columns from the union of all tables when no FROM is typed yet', () => {
-    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    const { program, sourceFile, dir } = buildProgram(FIXTURE, 'owlsql-ts-plugin-completions-');
     cleanupDir = dir;
     const checker = program.getTypeChecker();
 
@@ -95,7 +72,7 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
   });
 
   it('scopes columns to the FROM table once one is present', () => {
-    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    const { program, sourceFile, dir } = buildProgram(FIXTURE, 'owlsql-ts-plugin-completions-');
     cleanupDir = dir;
     const checker = program.getTypeChecker();
 
@@ -116,7 +93,7 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
   });
 
   it('suggests columns after WHERE, scoped to the FROM table', () => {
-    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    const { program, sourceFile, dir } = buildProgram(FIXTURE, 'owlsql-ts-plugin-completions-');
     cleanupDir = dir;
     const checker = program.getTypeChecker();
 

--- a/tests/ts-plugin-detect.test.ts
+++ b/tests/ts-plugin-detect.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { rmSync } from 'node:fs';
+import ts from 'typescript';
+import detectModule from '../src/ts-plugin/detect.cts';
+import { buildProgram } from './ts-plugin-test-helpers.js';
+
+const { matchQueryLiteral } = detectModule;
+
+describe('matchQueryLiteral', () => {
+  let cleanupDir: string | null = null;
+
+  afterEach(() => {
+    if (cleanupDir) {
+      rmSync(cleanupDir, { recursive: true, force: true });
+      cleanupDir = null;
+    }
+  });
+
+  function run(source: string, cursorMarker = 'select 1') {
+    const { program, sourceFile, dir } = buildProgram(source, 'owlsql-ts-plugin-detect-');
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+    const cursor = sourceFile.text.indexOf(cursorMarker) + cursorMarker.length;
+    return matchQueryLiteral(ts, checker, sourceFile, cursor);
+  }
+
+  it('detects a real TypedDb receiver', () => {
+    const match = run(`
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      declare const db: TypedDb<DB>;
+      db.query(\`select 1\`);
+    `);
+
+    expect(match).not.toBeNull();
+  });
+
+  it('does not activate on an unrelated interface that happens to be named TypedDb', () => {
+    const match = run(`
+      interface TypedDb<DB> {
+        query(sql: string): Promise<unknown>;
+      }
+      interface DB { users: { id: number } }
+      declare const db: TypedDb<DB>;
+      db.query(\`select 1\`);
+    `);
+
+    expect(match).toBeNull();
+  });
+
+  it('does not activate on a non-query method with the same string-literal argument shape', () => {
+    const match = run(`
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      interface Logger { log(sql: string): void }
+      declare const db: TypedDb<DB>;
+      declare const logger: Logger;
+      logger.log(\`select 1\`);
+    `);
+
+    expect(match).toBeNull();
+  });
+
+  it('does not activate when the literal is not the first call argument', () => {
+    const match = run(`
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      declare const db: TypedDb<DB>;
+      function run(label: string, sql: string) {}
+      run('label', \`select 1\`);
+    `);
+
+    expect(match).toBeNull();
+  });
+
+  it('does not activate on a receiver with no TypedDb brand at all', () => {
+    const match = run(`
+      interface DB { users: { id: number } }
+      declare const db: { query(sql: string): Promise<unknown> };
+      db.query(\`select 1\`);
+    `);
+
+    expect(match).toBeNull();
+  });
+
+  it('activates through an intersection with the real TypedDb', () => {
+    const match = run(`
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      declare const db: TypedDb<DB> & { close(): void };
+      db.query(\`select 1\`);
+    `);
+
+    expect(match).not.toBeNull();
+  });
+
+  it('activates on element-access call syntax', () => {
+    const match = run(`
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      declare const db: TypedDb<DB>;
+      db['query'](\`select 1\`);
+    `);
+
+    expect(match).not.toBeNull();
+  });
+
+  it('activates when the literal argument is parenthesized', () => {
+    const match = run(`
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      declare const db: TypedDb<DB>;
+      db.query((\`select 1\`));
+    `);
+
+    expect(match).not.toBeNull();
+  });
+});

--- a/tests/ts-plugin-hover.test.ts
+++ b/tests/ts-plugin-hover.test.ts
@@ -1,20 +1,17 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { rmSync } from 'node:fs';
 import ts from 'typescript';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 import detectModule from '../src/ts-plugin/detect.cts';
 import schemaModule from '../src/ts-plugin/schema.cts';
 import sqlContext from '../src/ts-plugin/sql-context.cts';
+import { buildProgram } from './ts-plugin-test-helpers.js';
 
 const { matchQueryLiteral } = detectModule;
 const { getColumnType } = schemaModule;
 const { findFromTable, getWordAtOffset } = sqlContext;
 
 const FIXTURE = `
-interface TypedDb<DB> {
-  query(sql: string): Promise<unknown>;
-}
+import type { TypedDb } from '@owlsql/core';
 
 interface DB {
   users: { id: number; name: string; email: string | null };
@@ -26,26 +23,6 @@ declare const db: TypedDb<DB>;
 db.query(\`select id, name from users\`);
 db.query(\`select id from posts\`);
 `;
-
-function buildProgram(source: string): { program: ts.Program; sourceFile: ts.SourceFile; dir: string } {
-  const dir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-hover-'));
-  const filePath = join(dir, 'fixture.ts');
-  writeFileSync(filePath, source, 'utf8');
-
-  const program = ts.createProgram([filePath], {
-    target: ts.ScriptTarget.ES2022,
-    module: ts.ModuleKind.ESNext,
-    moduleResolution: ts.ModuleResolutionKind.Bundler,
-    strict: true,
-  });
-
-  const sourceFile = program.getSourceFile(filePath);
-  if (!sourceFile) {
-    throw new Error('fixture source file was not found in the program');
-  }
-
-  return { program, sourceFile, dir };
-}
 
 describe('getWordAtOffset', () => {
   it('finds the word the cursor sits inside', () => {
@@ -77,7 +54,7 @@ describe('ts-plugin hover: getColumnType against a real ts.Program', () => {
   });
 
   it('resolves the type of a column scoped to its FROM table', () => {
-    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    const { program, sourceFile, dir } = buildProgram(FIXTURE, 'owlsql-ts-plugin-hover-');
     cleanupDir = dir;
     const checker = program.getTypeChecker();
 
@@ -100,7 +77,7 @@ describe('ts-plugin hover: getColumnType against a real ts.Program', () => {
   });
 
   it('resolves a nullable column type', () => {
-    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    const { program, sourceFile, dir } = buildProgram(FIXTURE, 'owlsql-ts-plugin-hover-');
     cleanupDir = dir;
     const checker = program.getTypeChecker();
 
@@ -117,7 +94,7 @@ describe('ts-plugin hover: getColumnType against a real ts.Program', () => {
   });
 
   it('returns null for a word that is not a real column', () => {
-    const { program, sourceFile, dir } = buildProgram(FIXTURE);
+    const { program, sourceFile, dir } = buildProgram(FIXTURE, 'owlsql-ts-plugin-hover-');
     cleanupDir = dir;
     const checker = program.getTypeChecker();
 

--- a/tests/ts-plugin-test-helpers.ts
+++ b/tests/ts-plugin-test-helpers.ts
@@ -1,0 +1,36 @@
+import ts from 'typescript';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+export interface BuiltProgram {
+  program: ts.Program;
+  sourceFile: ts.SourceFile;
+  filePath: string;
+  dir: string;
+}
+
+export function buildProgram(source: string, fixturePrefix: string): BuiltProgram {
+  const dir = mkdtempSync(join(tmpdir(), fixturePrefix));
+  const filePath = join(dir, 'fixture.ts');
+  writeFileSync(filePath, source, 'utf8');
+
+  const program = ts.createProgram([filePath], {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    baseUrl: REPO_ROOT,
+    paths: { '@owlsql/core': ['src/index.ts'] },
+  });
+
+  const sourceFile = program.getSourceFile(filePath);
+  if (!sourceFile) {
+    throw new Error('fixture source file was not found in the program');
+  }
+
+  return { program, sourceFile, filePath, dir };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "src/ts-plugin",
     "tests/ts-plugin-sql-context.test.ts",
     "tests/ts-plugin-completions.test.ts",
-    "tests/ts-plugin-hover.test.ts"
+    "tests/ts-plugin-hover.test.ts",
+    "tests/ts-plugin-detect.test.ts"
   ]
 }

--- a/tsconfig.ts-plugin-tests.json
+++ b/tsconfig.ts-plugin-tests.json
@@ -18,6 +18,8 @@
     "src/ts-plugin",
     "tests/ts-plugin-sql-context.test.ts",
     "tests/ts-plugin-completions.test.ts",
-    "tests/ts-plugin-hover.test.ts"
+    "tests/ts-plugin-hover.test.ts",
+    "tests/ts-plugin-detect.test.ts",
+    "tests/ts-plugin-test-helpers.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- `src/ts-plugin/detect.cts` activated the plugin via a name-based check: the resolved `query()` signature's declaration parent had to be literally named `TypedDb`. Fragile in both directions:
  - **False positive**: any unrelated interface/class named `TypedDb` from any package activated it — the existing test fixtures exploited exactly this, never touching the real exported type.
  - **Silent dropout**: a type-alias `TypedDb`, a class implementing it, or an intersection receiver (`TypedDb<DB> & { close(): void }`) have no matching declaration-parent name, so detection just goes dark. `db['query'](...)` (element access) and `db.query((`...`))` (parenthesized argument) weren't recognized either.
- Fix: brand `TypedDb` (`src/index.ts`) with a `readonly __owlsqlTypedDb?: true` marker and check for it structurally on the receiver's type via `checker.getPropertyOfType`, recursing into intersection constituents to locate the `DB` type argument. This is nominal-safe (an unrelated same-named interface won't also carry the exact marker) and survives aliasing, `implements`, and intersections since it's a type-shape check, not a declaration-syntax check. Also teaches call-site detection to unwrap parenthesized literal arguments and recognize element-access calls.
- Test fixtures (`ts-plugin-completions.test.ts`, `ts-plugin-hover.test.ts`) now import the real `TypedDb` from `@owlsql/core` (path-aliased to `src/index.ts` in an ad-hoc `ts.Program`, via new shared helper `tests/ts-plugin-test-helpers.ts`) instead of redeclaring their own — renaming the library interface would now break these tests instead of leaving them silently green.
- Adds `tests/ts-plugin-detect.test.ts` covering the negative/false-positive cases called out in the issue: unrelated same-named interface, non-`query` method, literal as a non-first argument, no-brand receiver, intersection receiver, element-access call, parenthesized literal.
- README: notes that interpolating into a query template silently disables completions/hover for that call, with no diagnostic (documented scope, not fixed — per the issue's "consider a note" suggestion).

## Test plan
- [x] `npm run test:types` — clean
- [x] `npm run test:runtime` — 77/77 passing, including the new detect suite (8 cases) and the rewired completions/hover suites against the real branded `TypedDb`

Fixes #77