### PR TITLE
fix: stop ts-plugin from silently guessing on unknown FROM tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,11 @@ otherwise).
 - No `JOIN`/alias awareness — only the first `FROM <table>` in the string is
   used to scope both completions and hover; a second table from a `JOIN` is
   not offered.
+- No table-name completions after `FROM`/`JOIN` — only column names, after
+  `SELECT`/`WHERE`, are suggested.
+- The first `FROM <table>` is found with a regex, not a real SQL parser: a
+  `FROM (subquery)` can make it lock onto a table name from inside the
+  subquery instead of recognizing there's no real outer table yet.
 - Only plain string/template literals with **no interpolation**
   (`` db.query(`select ...`) ``) are recognized — which is the only form the
   library ever expects you to write, since parameters are SQL placeholders

--- a/src/ts-plugin/schema.cts
+++ b/src/ts-plugin/schema.cts
@@ -1,18 +1,23 @@
 import type * as ts from 'typescript';
 
+function scopeToTable(
+  tableSymbols: ts.Symbol[],
+  onlyTable: string | null,
+): ts.Symbol[] {
+  if (!onlyTable) {
+    return tableSymbols;
+  }
+
+  return tableSymbols.filter((symbol) => symbol.getName() === onlyTable);
+}
+
 function getColumnNames(
   checker: ts.TypeChecker,
   dbType: ts.Type,
   node: ts.Node,
   onlyTable: string | null,
 ): string[] {
-  const tableSymbols = dbType.getProperties();
-
-  const scopedTables = onlyTable
-    ? tableSymbols.filter((symbol) => symbol.getName() === onlyTable)
-    : tableSymbols;
-
-  const tables = scopedTables.length > 0 ? scopedTables : tableSymbols;
+  const tables = scopeToTable(dbType.getProperties(), onlyTable);
 
   const columnNames = new Set<string>();
 
@@ -33,24 +38,28 @@ function getColumnType(
   onlyTable: string | null,
   columnName: string,
 ): ts.Type | null {
-  const tableSymbols = dbType.getProperties();
+  const tables = scopeToTable(dbType.getProperties(), onlyTable);
 
-  const scopedTables = onlyTable
-    ? tableSymbols.filter((symbol) => symbol.getName() === onlyTable)
-    : tableSymbols;
-
-  const tables = scopedTables.length > 0 ? scopedTables : tableSymbols;
+  const matches: ts.Type[] = [];
 
   for (const tableSymbol of tables) {
     const tableType = checker.getTypeOfSymbolAtLocation(tableSymbol, node);
     for (const columnSymbol of tableType.getProperties()) {
       if (columnSymbol.getName() === columnName) {
-        return checker.getTypeOfSymbolAtLocation(columnSymbol, node);
+        matches.push(checker.getTypeOfSymbolAtLocation(columnSymbol, node));
       }
     }
   }
 
-  return null;
+  if (matches.length === 0) {
+    return null;
+  }
+
+  const [first, ...rest] = matches;
+  const firstText = checker.typeToString(first as ts.Type);
+  const isUnambiguous = rest.every((type) => checker.typeToString(type) === firstText);
+
+  return isUnambiguous ? (first as ts.Type) : null;
 }
 
 export = { getColumnNames, getColumnType };

--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -2,7 +2,7 @@ const SELECT_START = /^select\b/i;
 const HAS_FROM = /\bfrom\b/i;
 const HAS_WHERE = /\bwhere\b/i;
 const TRAILING_WORD = /([A-Za-z_][A-Za-z0-9_]*)$/;
-const FROM_TABLE = /\bfrom\s+([A-Za-z_][A-Za-z0-9_]*)/i;
+const FROM_TABLE = /\bfrom\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)/i;
 const WORD_CHAR = /[A-Za-z0-9_]/;
 const WORD_START_CHAR = /[A-Za-z_]/;
 

--- a/tests/ts-plugin-schema.test.ts
+++ b/tests/ts-plugin-schema.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { rmSync } from 'node:fs';
+import ts from 'typescript';
+import schemaModule from '../src/ts-plugin/schema.cts';
+import { buildProgram } from './ts-plugin-test-helpers.js';
+
+const { getColumnNames, getColumnType } = schemaModule;
+
+describe('getColumnNames / getColumnType scoping', () => {
+  let cleanupDir: string | null = null;
+
+  afterEach(() => {
+    if (cleanupDir) {
+      rmSync(cleanupDir, { recursive: true, force: true });
+      cleanupDir = null;
+    }
+  });
+
+  function buildDbType(source: string): { checker: ts.TypeChecker; dbType: ts.Type; node: ts.Node } {
+    const { program, sourceFile, dir } = buildProgram(`${source}\ndbValue;\n`, 'owlsql-ts-plugin-schema-');
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+
+    const lastStatement = sourceFile.statements[sourceFile.statements.length - 1];
+    if (!lastStatement || !ts.isExpressionStatement(lastStatement) || !ts.isIdentifier(lastStatement.expression)) {
+      throw new Error('expected a trailing `dbValue;` reference statement in the fixture');
+    }
+
+    const node = lastStatement.expression;
+    return { checker, dbType: checker.getTypeAtLocation(node), node };
+  }
+
+  it('scopes to a named table', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB { users: { id: number; name: string }; posts: { id: number; title: string } }
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnNames(checker, dbType, node, 'users').sort()).toEqual(['id', 'name']);
+  });
+
+  it('returns no columns for a FROM table that does not exist in the schema, instead of falling back to all tables', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB { users: { id: number; name: string }; posts: { id: number; title: string } }
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnNames(checker, dbType, node, 'userz')).toEqual([]);
+    expect(getColumnType(checker, dbType, node, 'userz', 'title')).toBeNull();
+  });
+
+  it('unions columns across all tables when no FROM table is given', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB { users: { id: number; name: string }; posts: { id: number; title: string } }
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnNames(checker, dbType, node, null).sort()).toEqual(['id', 'name', 'title']);
+  });
+
+  it('resolves a column type unambiguously when every table agrees on it, even with no FROM scoping', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB { users: { id: number; name: string }; posts: { id: number; title: string } }
+      declare const dbValue: DB;
+    `);
+
+    const columnType = getColumnType(checker, dbType, node, null, 'id');
+    expect(columnType && checker.typeToString(columnType)).toBe('number');
+  });
+
+  it('refuses to guess a column type when tables disagree on it and there is no FROM scoping', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB { users: { id: number }; accounts: { id: string } }
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnType(checker, dbType, node, null, 'id')).toBeNull();
+  });
+});

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -67,4 +67,12 @@ describe('findFromTable', () => {
   it('returns null when there is no FROM clause yet', () => {
     expect(findFromTable('select id, na')).toBeNull();
   });
+
+  it('strips a schema qualifier instead of capturing it as the table name', () => {
+    expect(findFromTable('select id from public.users')).toBe('users');
+  });
+
+  it('finds the table name when an alias follows it', () => {
+    expect(findFromTable('select u.id from users u where u.name = 1')).toBe('users');
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "tests/ts-plugin-sql-context.test.ts",
     "tests/ts-plugin-completions.test.ts",
     "tests/ts-plugin-hover.test.ts",
-    "tests/ts-plugin-detect.test.ts"
+    "tests/ts-plugin-detect.test.ts",
+    "tests/ts-plugin-schema.test.ts"
   ]
 }

--- a/tsconfig.ts-plugin-tests.json
+++ b/tsconfig.ts-plugin-tests.json
@@ -20,6 +20,7 @@
     "tests/ts-plugin-completions.test.ts",
     "tests/ts-plugin-hover.test.ts",
     "tests/ts-plugin-detect.test.ts",
+    "tests/ts-plugin-schema.test.ts",
     "tests/ts-plugin-test-helpers.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- `schema.cts` scoped completions/hover to a FROM table with `scopedTables.length > 0 ? scopedTables : tableSymbols` — if the typed table didn't match the schema (typo, or a schema-qualified name the regex mis-captured), scoping silently fell back to *every* table instead of returning nothing. Hover could then confidently assert a column/type for a table that doesn't actually have it.
- `getColumnNames`/`getColumnType` now return empty/null when a FROM table was named but isn't found in the schema, instead of falling back to the union of all tables.
- `getColumnType`, when there's genuinely no FROM scoping (not a lookup miss) and multiple tables share the requested column name, now returns the type only if every candidate agrees on it — otherwise `null`. A confidently-wrong single-table guess is worse than no hover.
- `sql-context.cts`'s `FROM_TABLE` regex captured the schema in `from public.users` (`'public'`) instead of the table (`'users'`) — the main real-world trigger for the all-tables fallback. It now skips an optional `schema.` prefix.
- README documents the two gaps this PR doesn't attempt: no table-name completion after `FROM`/`JOIN`, and FROM-table detection is regex-based (not a real parser), so `FROM (subquery)` can lock onto a table name from inside the subquery. JOIN/alias-column awareness was already documented.

## Test plan
- [x] `npm run test:types` — clean
- [x] `npm run test:runtime` — 84/84 passing
- [x] New `tests/ts-plugin-schema.test.ts` exercises `getColumnNames`/`getColumnType` directly against a real `ts.Program`: named-table scoping, unknown-table → empty/null (not all-tables fallback), no-FROM union of names, no-FROM type resolution when tables agree, no-FROM refusal to guess when tables disagree
- [x] New regex regression tests in `ts-plugin-sql-context.test.ts`: schema-qualified `from public.users` → `users`, aliased `from users u` → `users`

Fixes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved SQL editor autocomplete handling for schema-qualified table references and table aliases.
  - Column suggestions now correctly combine results across available tables when no table scope is specified.
  - Ambiguous column types are no longer presented as a definitive type.

- **Documentation**
  - Documented current autocomplete limitations, including table-name completion and subquery scoping behavior.

- **Tests**
  - Added coverage for table scoping, schema-qualified names, aliases, and ambiguous column types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->