### PR TITLE
fix: mask string literals so quoted text cannot corrupt type inference

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -25,8 +25,23 @@ type RemoveSemicolons<S extends string> = S extends `${infer Before};${infer Aft
   ? RemoveSemicolons<`${Before} ${After}`>
   : S;
 
+type SkipLiteralBody<S extends string> = S extends `${string}'${infer After}`
+  ? After extends `'${infer Rest}`
+    ? SkipLiteralBody<Rest>
+    : { rest: After }
+  : never;
+
+export type MaskStringLiterals<
+  S extends string,
+  Accumulated extends string = '',
+> = S extends `${infer Before}'${infer After}`
+  ? SkipLiteralBody<After> extends { rest: infer Rest extends string }
+    ? MaskStringLiterals<Rest, `${Accumulated}${Before}''`>
+    : `${Accumulated}${S}`
+  : `${Accumulated}${S}`;
+
 export type Normalize<S extends string> = Trim<
-  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<S>>>
+  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<MaskStringLiterals<S>>>>
 >;
 
 export type Unquote<S extends string> = S extends `"${infer Inner}"`

--- a/tests/string-literal.test-d.ts
+++ b/tests/string-literal.test-d.ts
@@ -1,0 +1,89 @@
+import type { Query, StrictRow, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    email: string;
+    note: string;
+  };
+}
+
+type UnbalancedParenInsideLiteral = Expect<
+  Equal<
+    Query<DB, "select coalesce(name, ':(') as n, id from users">,
+    { n: unknown; id: number }[]
+  >
+>;
+
+type CommaInsideLiteral = Expect<
+  Equal<
+    Query<DB, "select 'a, b' as label, id from users">,
+    { label: unknown; id: number }[]
+  >
+>;
+
+type EscapedQuoteInsideLiteral = Expect<
+  Equal<
+    Query<DB, "select 'it''s, fine' as label, id from users">,
+    { label: unknown; id: number }[]
+  >
+>;
+
+type DollarInsideLiteralIsNotPlaceholder = Expect<
+  Equal<Params<DB, "select id from users where note = 'costs $5 today'">, []>
+>;
+
+type QuestionMarkInsideLiteralIsNotPlaceholder = Expect<
+  Equal<Params<DB, "select id from users where note = 'why?'">, []>
+>;
+
+type AtInsideCteLiteralKeepsParamTyping = Expect<
+  Equal<
+    Params<
+      DB,
+      "with t as (select id from users where email like '%@%') select id from t where id = $1"
+    >,
+    [number]
+  >
+>;
+
+type SemicolonInsideLiteralDoesNotSplit = Expect<
+  Equal<
+    Query<DB, "select id from users where note = 'a;b'">,
+    { id: number }[]
+  >
+>;
+
+type KeywordInsideLiteralIgnored = Expect<
+  Equal<
+    Query<DB, "select id, 'from users where' as fragment from users">,
+    { id: number; fragment: unknown }[]
+  >
+>;
+
+type StrictStillResolvesRealColumns = Expect<
+  Equal<
+    StrictRow<DB, "select id from users where note = 'x, (y'">,
+    { id: number }
+  >
+>;
+
+export type Assertions = [
+  UnbalancedParenInsideLiteral,
+  CommaInsideLiteral,
+  EscapedQuoteInsideLiteral,
+  DollarInsideLiteralIsNotPlaceholder,
+  QuestionMarkInsideLiteralIsNotPlaceholder,
+  AtInsideCteLiteralKeepsParamTyping,
+  SemicolonInsideLiteralDoesNotSplit,
+  KeywordInsideLiteralIgnored,
+  StrictStillResolvesRealColumns,
+];


### PR DESCRIPTION
## Problem

Every type-level scanner (paren counting, comma splitting, keyword detection, placeholder detection) ignored `'...'` string literals (#48). Valid SQL produced silently wrong row shapes:

- `select coalesce(name, ':(') as n, id from users` — the unbalanced `(` inside the literal kept paren depth > 0, so comma split, `AS` detection and `FROM` split all failed.
- `select 'a, b' as label, id from users` — the comma inside the literal split the column list.
- `where note = 'costs $5 today'` — `$5` inside the literal passed `IsPlaceholder`, demanding a param the SQL doesn't have.
- `like '%@%'` inside a CTE body tripped `ContainsPlaceholderLikeChar` and dropped all param typing.
- `RemoveSemicolons` rewrote semicolons inside literals to spaces.

## Fix

`Normalize` now runs a `MaskStringLiterals` pass first: each `'...'` body (with `''` escape handling) is replaced by a neutral empty literal `''` before any scanner sees the text. Literal detection for CASE-branch typing still works (`''` matches the `'${string}'` literal pattern), while parens, commas, semicolons, placeholder-like chars and keywords inside literals can no longer corrupt inference.

Unterminated literals leave the text untouched (previous behavior).

## Tests

`tests/string-literal.test-d.ts` locks all five failure modes from the issue plus escaped-quote, keyword-in-literal and strict-mode probes. Full suite: 84 runtime + type tests pass.

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SQL string literals during query parsing.
  * Characters such as parentheses, commas, quotes, dollar signs, question marks, and semicolons within literals are now preserved and no longer interpreted as placeholders.
  * Maintained accurate column selection and strict result typing for queries containing string literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->