### PR TITLE
fix: strip SQL comments during normalization

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -31,17 +31,51 @@ type SkipLiteralBody<S extends string> = S extends `${string}'${infer After}`
     : { rest: After }
   : never;
 
-export type MaskStringLiterals<
+type AfterLineComment<S extends string> = S extends `${string}
+${infer Rest}`
+  ? Rest
+  : '';
+
+type AfterBlockComment<S extends string> = S extends `${string}*/${infer Rest}` ? Rest : '';
+
+export type StripCommentsAndMaskLiterals<
   S extends string,
   Accumulated extends string = '',
-> = S extends `${infer Before}'${infer After}`
-  ? SkipLiteralBody<After> extends { rest: infer Rest extends string }
-    ? MaskStringLiterals<Rest, `${Accumulated}${Before}''`>
-    : `${Accumulated}${S}`
-  : `${Accumulated}${S}`;
+> = S extends `${infer BeforeQuote}'${infer AfterQuote}`
+  ? BeforeQuote extends `${infer BeforeDash}--${infer AfterDash}`
+    ? BeforeDash extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<`${AfterBlock}--${AfterDash}'${AfterQuote}`>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : StripCommentsAndMaskLiterals<
+          AfterLineComment<`${AfterDash}'${AfterQuote}`>,
+          `${Accumulated}${BeforeDash} `
+        >
+    : BeforeQuote extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<`${AfterBlock}'${AfterQuote}`>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : SkipLiteralBody<AfterQuote> extends { rest: infer Rest extends string }
+        ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${BeforeQuote}''`>
+        : `${Accumulated}${S}`
+  : S extends `${infer BeforeDash}--${infer AfterDash}`
+    ? BeforeDash extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<`${AfterBlock}--${AfterDash}`>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : StripCommentsAndMaskLiterals<AfterLineComment<AfterDash>, `${Accumulated}${BeforeDash} `>
+    : S extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<AfterBlock>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : `${Accumulated}${S}`;
 
 export type Normalize<S extends string> = Trim<
-  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<MaskStringLiterals<S>>>>
+  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<StripCommentsAndMaskLiterals<S>>>>
 >;
 
 export type Unquote<S extends string> = S extends `"${infer Inner}"`

--- a/tests/comments.test-d.ts
+++ b/tests/comments.test-d.ts
@@ -1,0 +1,105 @@
+import type { Query, StrictRow, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    note: string;
+  };
+}
+
+type LineCommentInsideSelectList = Expect<
+  Equal<
+    Query<
+      DB,
+      `select id, -- pick id
+name from users`
+    >,
+    { id: number; name: string }[]
+  >
+>;
+
+type LineCommentWithCommaDoesNotSplit = Expect<
+  Equal<
+    Query<
+      DB,
+      `select id, -- a, b
+name from users`
+    >,
+    { id: number; name: string }[]
+  >
+>;
+
+type TrailingLineCommentAfterTableIsNotAlias = Expect<
+  Equal<
+    Query<
+      DB,
+      `select u.id from users u -- note
+`
+    >,
+    { id: number }[]
+  >
+>;
+
+type BlockCommentStripped = Expect<
+  Equal<Query<DB, 'select /* pick */ id from users'>, { id: number }[]>
+>;
+
+type BlockCommentWithQuoteStripped = Expect<
+  Equal<Query<DB, "select id /* don't */ from users">, { id: number }[]>
+>;
+
+type LineCommentWithQuoteStripped = Expect<
+  Equal<
+    Query<
+      DB,
+      `select id -- don't pick more
+from users`
+    >,
+    { id: number }[]
+  >
+>;
+
+type LiteralContainingCommentMarkersSurvives = Expect<
+  Equal<Query<DB, "select id from users where note = '-- /* x */'">, { id: number }[]>
+>;
+
+type PlaceholderInsideCommentIgnored = Expect<
+  Equal<
+    Params<
+      DB,
+      `select id from users where id = $1 -- and name = $2
+`
+    >,
+    [number]
+  >
+>;
+
+type StrictModeUnaffectedByComments = Expect<
+  Equal<
+    StrictRow<
+      DB,
+      `select id, /* keep */ name from users`
+    >,
+    { id: number; name: string }
+  >
+>;
+
+export type Assertions = [
+  LineCommentInsideSelectList,
+  LineCommentWithCommaDoesNotSplit,
+  TrailingLineCommentAfterTableIsNotAlias,
+  BlockCommentStripped,
+  BlockCommentWithQuoteStripped,
+  LineCommentWithQuoteStripped,
+  LiteralContainingCommentMarkersSurvives,
+  PlaceholderInsideCommentIgnored,
+  StrictModeUnaffectedByComments,
+];


### PR DESCRIPTION
## Problem

`Normalize` collapsed whitespace only; `--` and `/* */` comments survived into the token stream (#51):

- `select id, -- pick id` + newline + `name from users` inferred `{ id: number; 'pick id name': unknown }` — the comment text became a phantom column and `name` disappeared.
- A trailing `-- comment` after a table name became the source alias.
- Placeholders inside comments produced phantom params.

## Fix

The literal-masking pass introduced for #48 is now a combined scanner (`StripCommentsAndMaskLiterals`) that walks the text once, always honoring whichever marker comes first:

- `'...'` opens a literal (masked as before; comment markers inside stay literal text),
- `--` strips to end of line,
- `/* */` strips to the closing marker (quotes inside comments cannot open a literal).

Each stripped comment is replaced by a space so token boundaries survive; an unterminated block comment strips to end of string.

## Tests

`tests/comments.test-d.ts` covers line/block comments in the select list, comment-with-comma, trailing comment after table name, quotes inside comments, comment markers inside literals, placeholders inside comments, and a strict-mode probe. Full suite passes.

Closes #51