### PR TITLE
fix: support SELECT DISTINCT, ALL and DISTINCT ON

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -55,6 +55,20 @@ type StripTopClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'top'> ext
     : S
   : S;
 
+type StripDistinctOn<S extends string> = IsKeyword<FirstWord<S>, 'on'> extends true
+  ? Trim<DropFirstWord<S>> extends `(${infer AfterOpen}`
+    ? ExtractParenGroup<AfterOpen> extends { rest: infer Rest extends string }
+      ? Trim<Rest>
+      : S
+    : S
+  : S;
+
+type StripDistinctClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'distinct'> extends true
+  ? StripDistinctOn<Trim<DropFirstWord<Trim<S>>>>
+  : IsKeyword<FirstWord<Trim<S>>, 'all'> extends true
+    ? Trim<DropFirstWord<Trim<S>>>
+    : S;
+
 type ColumnsBeforeFrom<
   S extends string,
   Depth extends unknown[] = [],
@@ -135,7 +149,7 @@ export interface ParsedStatement {
 
 type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer Body
   ? Body extends string
-    ? ColumnsBeforeFrom<StripTopClause<Body>> extends {
+    ? ColumnsBeforeFrom<StripTopClause<StripDistinctClause<Body>>> extends {
         columns: infer Columns extends string;
         afterFrom: infer AfterFrom;
       }

--- a/src/string.ts
+++ b/src/string.ts
@@ -31,17 +31,51 @@ type SkipLiteralBody<S extends string> = S extends `${string}'${infer After}`
     : { rest: After }
   : never;
 
-export type MaskStringLiterals<
+type AfterLineComment<S extends string> = S extends `${string}
+${infer Rest}`
+  ? Rest
+  : '';
+
+type AfterBlockComment<S extends string> = S extends `${string}*/${infer Rest}` ? Rest : '';
+
+export type StripCommentsAndMaskLiterals<
   S extends string,
   Accumulated extends string = '',
-> = S extends `${infer Before}'${infer After}`
-  ? SkipLiteralBody<After> extends { rest: infer Rest extends string }
-    ? MaskStringLiterals<Rest, `${Accumulated}${Before}''`>
-    : `${Accumulated}${S}`
-  : `${Accumulated}${S}`;
+> = S extends `${infer BeforeQuote}'${infer AfterQuote}`
+  ? BeforeQuote extends `${infer BeforeDash}--${infer AfterDash}`
+    ? BeforeDash extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<`${AfterBlock}--${AfterDash}'${AfterQuote}`>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : StripCommentsAndMaskLiterals<
+          AfterLineComment<`${AfterDash}'${AfterQuote}`>,
+          `${Accumulated}${BeforeDash} `
+        >
+    : BeforeQuote extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<`${AfterBlock}'${AfterQuote}`>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : SkipLiteralBody<AfterQuote> extends { rest: infer Rest extends string }
+        ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${BeforeQuote}''`>
+        : `${Accumulated}${S}`
+  : S extends `${infer BeforeDash}--${infer AfterDash}`
+    ? BeforeDash extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<`${AfterBlock}--${AfterDash}`>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : StripCommentsAndMaskLiterals<AfterLineComment<AfterDash>, `${Accumulated}${BeforeDash} `>
+    : S extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<AfterBlock>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : `${Accumulated}${S}`;
 
 export type Normalize<S extends string> = Trim<
-  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<MaskStringLiterals<S>>>>
+  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<StripCommentsAndMaskLiterals<S>>>>
 >;
 
 export type Unquote<S extends string> = S extends `"${infer Inner}"`

--- a/tests/comments.test-d.ts
+++ b/tests/comments.test-d.ts
@@ -1,0 +1,105 @@
+import type { Query, StrictRow, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    note: string;
+  };
+}
+
+type LineCommentInsideSelectList = Expect<
+  Equal<
+    Query<
+      DB,
+      `select id, -- pick id
+name from users`
+    >,
+    { id: number; name: string }[]
+  >
+>;
+
+type LineCommentWithCommaDoesNotSplit = Expect<
+  Equal<
+    Query<
+      DB,
+      `select id, -- a, b
+name from users`
+    >,
+    { id: number; name: string }[]
+  >
+>;
+
+type TrailingLineCommentAfterTableIsNotAlias = Expect<
+  Equal<
+    Query<
+      DB,
+      `select u.id from users u -- note
+`
+    >,
+    { id: number }[]
+  >
+>;
+
+type BlockCommentStripped = Expect<
+  Equal<Query<DB, 'select /* pick */ id from users'>, { id: number }[]>
+>;
+
+type BlockCommentWithQuoteStripped = Expect<
+  Equal<Query<DB, "select id /* don't */ from users">, { id: number }[]>
+>;
+
+type LineCommentWithQuoteStripped = Expect<
+  Equal<
+    Query<
+      DB,
+      `select id -- don't pick more
+from users`
+    >,
+    { id: number }[]
+  >
+>;
+
+type LiteralContainingCommentMarkersSurvives = Expect<
+  Equal<Query<DB, "select id from users where note = '-- /* x */'">, { id: number }[]>
+>;
+
+type PlaceholderInsideCommentIgnored = Expect<
+  Equal<
+    Params<
+      DB,
+      `select id from users where id = $1 -- and name = $2
+`
+    >,
+    [number]
+  >
+>;
+
+type StrictModeUnaffectedByComments = Expect<
+  Equal<
+    StrictRow<
+      DB,
+      `select id, /* keep */ name from users`
+    >,
+    { id: number; name: string }
+  >
+>;
+
+export type Assertions = [
+  LineCommentInsideSelectList,
+  LineCommentWithCommaDoesNotSplit,
+  TrailingLineCommentAfterTableIsNotAlias,
+  BlockCommentStripped,
+  BlockCommentWithQuoteStripped,
+  LineCommentWithQuoteStripped,
+  LiteralContainingCommentMarkersSurvives,
+  PlaceholderInsideCommentIgnored,
+  StrictModeUnaffectedByComments,
+];

--- a/tests/distinct.test-d.ts
+++ b/tests/distinct.test-d.ts
@@ -1,0 +1,63 @@
+import type { Query, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    team_id: number;
+  };
+}
+
+type DistinctColumnsResolve = Expect<
+  Equal<
+    Query<DB, 'select distinct id, name from users'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type DistinctUppercaseResolves = Expect<
+  Equal<Query<DB, 'SELECT DISTINCT id FROM users'>, { id: number }[]>
+>;
+
+type AllKeywordStripped = Expect<
+  Equal<Query<DB, 'select all id from users'>, { id: number }[]>
+>;
+
+type DistinctOnGroupStripped = Expect<
+  Equal<
+    Query<DB, 'select distinct on (team_id) id, name from users'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type DistinctCombinesWithTop = Expect<
+  Equal<Query<DB, 'select distinct top 5 id from users'>, { id: number }[]>
+>;
+
+type DistinctStar = Expect<
+  Equal<
+    Query<DB, 'select distinct * from users'>,
+    { id: number; name: string; team_id: number }[]
+  >
+>;
+
+type StrictDistinctResolves = Expect<
+  Equal<StrictRow<DB, 'select distinct id from users'>, { id: number }>
+>;
+
+export type Assertions = [
+  DistinctColumnsResolve,
+  DistinctUppercaseResolves,
+  AllKeywordStripped,
+  DistinctOnGroupStripped,
+  DistinctCombinesWithTop,
+  DistinctStar,
+  StrictDistinctResolves,
+];


### PR DESCRIPTION
## Problem

`ParseSelectBody` stripped `TOP` but never `DISTINCT`/`ALL` (#50). `select distinct id, name from users` parsed `distinct` as an expression with implicit alias `id`, inferring `{ id: unknown; name: string }`; strict mode errored with `unknown column: distinct` on valid SQL.

## Fix

A `StripDistinctClause` pass now removes a leading `DISTINCT`, `ALL` or `DISTINCT ON (...)` (pg) before `TOP` stripping, mirroring how `TOP` is handled. `SELECT DISTINCT TOP n` (T-SQL order) works since DISTINCT is stripped first.

## Tests

`tests/distinct.test-d.ts`: multi-column DISTINCT, uppercase, `ALL`, `DISTINCT ON (expr)`, `DISTINCT TOP n`, `DISTINCT *`, and a strict-mode probe. Full suite passes.

Closes #50