### PR TITLE
fix: type SELECT-list literals instead of rejecting them in strict mode

### DIFF
--- a/src/case.ts
+++ b/src/case.ts
@@ -50,27 +50,6 @@ type HasElseBranch<Segments extends CaseSegment[]> = Segments extends [
     : HasElseBranch<Tail>
   : false;
 
-type LiteralType<Expr extends string> = Trim<Expr> extends `'${string}'`
-  ? string
-  : Trim<Expr> extends `${number}`
-    ? number
-    : Lowercase<Trim<Expr>> extends 'true' | 'false'
-      ? boolean
-      : Lowercase<Trim<Expr>> extends 'null'
-        ? null
-        : never;
-
-type BranchValueType<
-  DB extends SchemaLike,
-  Sources extends Source[],
-  Expr extends string,
-  Strict extends boolean,
-> = LiteralType<Expr> extends infer Literal
-  ? [Literal] extends [never]
-    ? ResolveColumnType<DB, Sources, Trim<Expr>, Strict>
-    : Literal
-  : never;
-
 type BranchUnion<
   DB extends SchemaLike,
   Sources extends Source[],
@@ -78,7 +57,7 @@ type BranchUnion<
   Strict extends boolean,
 > = Segments extends [infer Head extends CaseSegment, ...infer Tail extends CaseSegment[]]
   ? Head['kind'] extends 'then' | 'else'
-    ? BranchValueType<DB, Sources, Head['text'], Strict> | BranchUnion<DB, Sources, Tail, Strict>
+    ? ResolveColumnType<DB, Sources, Trim<Head['text']>, Strict> | BranchUnion<DB, Sources, Tail, Strict>
     : BranchUnion<DB, Sources, Tail, Strict>
   : never;
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -55,6 +55,20 @@ type StripTopClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'top'> ext
     : S
   : S;
 
+type StripDistinctOn<S extends string> = IsKeyword<FirstWord<S>, 'on'> extends true
+  ? Trim<DropFirstWord<S>> extends `(${infer AfterOpen}`
+    ? ExtractParenGroup<AfterOpen> extends { rest: infer Rest extends string }
+      ? Trim<Rest>
+      : S
+    : S
+  : S;
+
+type StripDistinctClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'distinct'> extends true
+  ? StripDistinctOn<Trim<DropFirstWord<Trim<S>>>>
+  : IsKeyword<FirstWord<Trim<S>>, 'all'> extends true
+    ? Trim<DropFirstWord<Trim<S>>>
+    : S;
+
 type ColumnsBeforeFrom<
   S extends string,
   Depth extends unknown[] = [],
@@ -135,7 +149,7 @@ export interface ParsedStatement {
 
 type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer Body
   ? Body extends string
-    ? ColumnsBeforeFrom<StripTopClause<Body>> extends {
+    ? ColumnsBeforeFrom<StripTopClause<StripDistinctClause<Body>>> extends {
         columns: infer Columns extends string;
         afterFrom: infer AfterFrom;
       }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -379,6 +379,16 @@ type QualifiedColumnType<
       : never
   : never;
 
+export type LiteralType<Expression extends string> = Trim<Expression> extends `'${string}'`
+  ? string
+  : Trim<Expression> extends `${number}`
+    ? number
+    : Lowercase<Trim<Expression>> extends 'true' | 'false'
+      ? boolean
+      : Lowercase<Trim<Expression>> extends 'null'
+        ? null
+        : never;
+
 type ScalarSubqueryInner<Expression extends string> = Trim<Expression> extends `(${infer AfterOpen}`
   ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string; rest: infer Rest extends string }
     ? Trim<Rest> extends ''
@@ -417,15 +427,17 @@ export type ResolveColumnType<
   : [ScalarSubqueryInner<Expression>] extends [never]
     ? IsFunctionCall<Expression> extends true
       ? FunctionReturnType<Expression>
-      : Qualifier<Expression> extends ''
-        ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
-        : QualifiedColumnType<
-            DB,
-            Sources,
-            Unquote<Qualifier<Expression>>,
-            Unquote<StripQualifier<Expression>>,
-            Strict
-          >
+      : [LiteralType<Expression>] extends [never]
+        ? Qualifier<Expression> extends ''
+          ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
+          : QualifiedColumnType<
+              DB,
+              Sources,
+              Unquote<Qualifier<Expression>>,
+              Unquote<StripQualifier<Expression>>,
+              Strict
+            >
+        : LiteralType<Expression>
     : ScalarSubqueryType<DB, ScalarSubqueryInner<Expression>, Strict>;
 
 export type ResolveColumnLoose<

--- a/src/string.ts
+++ b/src/string.ts
@@ -31,17 +31,51 @@ type SkipLiteralBody<S extends string> = S extends `${string}'${infer After}`
     : { rest: After }
   : never;
 
-export type MaskStringLiterals<
+type AfterLineComment<S extends string> = S extends `${string}
+${infer Rest}`
+  ? Rest
+  : '';
+
+type AfterBlockComment<S extends string> = S extends `${string}*/${infer Rest}` ? Rest : '';
+
+export type StripCommentsAndMaskLiterals<
   S extends string,
   Accumulated extends string = '',
-> = S extends `${infer Before}'${infer After}`
-  ? SkipLiteralBody<After> extends { rest: infer Rest extends string }
-    ? MaskStringLiterals<Rest, `${Accumulated}${Before}''`>
-    : `${Accumulated}${S}`
-  : `${Accumulated}${S}`;
+> = S extends `${infer BeforeQuote}'${infer AfterQuote}`
+  ? BeforeQuote extends `${infer BeforeDash}--${infer AfterDash}`
+    ? BeforeDash extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<`${AfterBlock}--${AfterDash}'${AfterQuote}`>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : StripCommentsAndMaskLiterals<
+          AfterLineComment<`${AfterDash}'${AfterQuote}`>,
+          `${Accumulated}${BeforeDash} `
+        >
+    : BeforeQuote extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<`${AfterBlock}'${AfterQuote}`>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : SkipLiteralBody<AfterQuote> extends { rest: infer Rest extends string }
+        ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${BeforeQuote}''`>
+        : `${Accumulated}${S}`
+  : S extends `${infer BeforeDash}--${infer AfterDash}`
+    ? BeforeDash extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<`${AfterBlock}--${AfterDash}`>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : StripCommentsAndMaskLiterals<AfterLineComment<AfterDash>, `${Accumulated}${BeforeDash} `>
+    : S extends `${infer BeforeBlock}/*${infer AfterBlock}`
+      ? StripCommentsAndMaskLiterals<
+          AfterBlockComment<AfterBlock>,
+          `${Accumulated}${BeforeBlock} `
+        >
+      : `${Accumulated}${S}`;
 
 export type Normalize<S extends string> = Trim<
-  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<MaskStringLiterals<S>>>>
+  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<StripCommentsAndMaskLiterals<S>>>>
 >;
 
 export type Unquote<S extends string> = S extends `"${infer Inner}"`

--- a/tests/comments.test-d.ts
+++ b/tests/comments.test-d.ts
@@ -1,0 +1,105 @@
+import type { Query, StrictRow, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    note: string;
+  };
+}
+
+type LineCommentInsideSelectList = Expect<
+  Equal<
+    Query<
+      DB,
+      `select id, -- pick id
+name from users`
+    >,
+    { id: number; name: string }[]
+  >
+>;
+
+type LineCommentWithCommaDoesNotSplit = Expect<
+  Equal<
+    Query<
+      DB,
+      `select id, -- a, b
+name from users`
+    >,
+    { id: number; name: string }[]
+  >
+>;
+
+type TrailingLineCommentAfterTableIsNotAlias = Expect<
+  Equal<
+    Query<
+      DB,
+      `select u.id from users u -- note
+`
+    >,
+    { id: number }[]
+  >
+>;
+
+type BlockCommentStripped = Expect<
+  Equal<Query<DB, 'select /* pick */ id from users'>, { id: number }[]>
+>;
+
+type BlockCommentWithQuoteStripped = Expect<
+  Equal<Query<DB, "select id /* don't */ from users">, { id: number }[]>
+>;
+
+type LineCommentWithQuoteStripped = Expect<
+  Equal<
+    Query<
+      DB,
+      `select id -- don't pick more
+from users`
+    >,
+    { id: number }[]
+  >
+>;
+
+type LiteralContainingCommentMarkersSurvives = Expect<
+  Equal<Query<DB, "select id from users where note = '-- /* x */'">, { id: number }[]>
+>;
+
+type PlaceholderInsideCommentIgnored = Expect<
+  Equal<
+    Params<
+      DB,
+      `select id from users where id = $1 -- and name = $2
+`
+    >,
+    [number]
+  >
+>;
+
+type StrictModeUnaffectedByComments = Expect<
+  Equal<
+    StrictRow<
+      DB,
+      `select id, /* keep */ name from users`
+    >,
+    { id: number; name: string }
+  >
+>;
+
+export type Assertions = [
+  LineCommentInsideSelectList,
+  LineCommentWithCommaDoesNotSplit,
+  TrailingLineCommentAfterTableIsNotAlias,
+  BlockCommentStripped,
+  BlockCommentWithQuoteStripped,
+  LineCommentWithQuoteStripped,
+  LiteralContainingCommentMarkersSurvives,
+  PlaceholderInsideCommentIgnored,
+  StrictModeUnaffectedByComments,
+];

--- a/tests/distinct.test-d.ts
+++ b/tests/distinct.test-d.ts
@@ -1,0 +1,63 @@
+import type { Query, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    team_id: number;
+  };
+}
+
+type DistinctColumnsResolve = Expect<
+  Equal<
+    Query<DB, 'select distinct id, name from users'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type DistinctUppercaseResolves = Expect<
+  Equal<Query<DB, 'SELECT DISTINCT id FROM users'>, { id: number }[]>
+>;
+
+type AllKeywordStripped = Expect<
+  Equal<Query<DB, 'select all id from users'>, { id: number }[]>
+>;
+
+type DistinctOnGroupStripped = Expect<
+  Equal<
+    Query<DB, 'select distinct on (team_id) id, name from users'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type DistinctCombinesWithTop = Expect<
+  Equal<Query<DB, 'select distinct top 5 id from users'>, { id: number }[]>
+>;
+
+type DistinctStar = Expect<
+  Equal<
+    Query<DB, 'select distinct * from users'>,
+    { id: number; name: string; team_id: number }[]
+  >
+>;
+
+type StrictDistinctResolves = Expect<
+  Equal<StrictRow<DB, 'select distinct id from users'>, { id: number }>
+>;
+
+export type Assertions = [
+  DistinctColumnsResolve,
+  DistinctUppercaseResolves,
+  AllKeywordStripped,
+  DistinctOnGroupStripped,
+  DistinctCombinesWithTop,
+  DistinctStar,
+  StrictDistinctResolves,
+];

--- a/tests/literal-columns.test-d.ts
+++ b/tests/literal-columns.test-d.ts
@@ -1,0 +1,56 @@
+import type { Query, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+  };
+}
+
+type StrictNumericLiteral = Expect<
+  Equal<StrictRow<DB, 'select 1 as one from users'>, { one: number }>
+>;
+
+type StrictStringLiteral = Expect<
+  Equal<StrictRow<DB, "select 'x' as tag from users">, { tag: string }>
+>;
+
+type StrictBooleanLiteral = Expect<
+  Equal<StrictRow<DB, 'select true as flag from users'>, { flag: boolean }>
+>;
+
+type StrictNullLiteral = Expect<
+  Equal<StrictRow<DB, 'select null as nothing from users'>, { nothing: null }>
+>;
+
+type StrictMixedLiteralsAndColumns = Expect<
+  Equal<
+    StrictRow<DB, "select id, 1 as flag, 'label' as kind from users">,
+    { id: number; flag: number; kind: string }
+  >
+>;
+
+type LooseNumericLiteral = Expect<
+  Equal<Query<DB, 'select 2.5 as ratio from users'>, { ratio: number }[]>
+>;
+
+type NegativeNumericLiteral = Expect<
+  Equal<Query<DB, 'select -1 as neg from users'>, { neg: number }[]>
+>;
+
+export type Assertions = [
+  StrictNumericLiteral,
+  StrictStringLiteral,
+  StrictBooleanLiteral,
+  StrictNullLiteral,
+  StrictMixedLiteralsAndColumns,
+  LooseNumericLiteral,
+  NegativeNumericLiteral,
+];

--- a/tests/select-without-from.test-d.ts
+++ b/tests/select-without-from.test-d.ts
@@ -1,4 +1,4 @@
-import type { Query, StrictQuery, QueryTypeError } from '../src/index.js';
+import type { Query, StrictQuery } from '../src/index.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -12,18 +12,15 @@ interface DB {
 }
 
 type LiteralAliasResolvesKey = Expect<
-  Equal<Query<DB, 'select 1 as one'>, { one: unknown }[]>
+  Equal<Query<DB, 'select 1 as one'>, { one: number }[]>
 >;
 
 type FunctionCallWithNoFromResolvesKey = Expect<
   Equal<Query<DB, 'select random_seed() as seed'>, { seed: unknown }[]>
 >;
 
-type StrictModeReportsNoFromClauseInsteadOfEmptyTableName = Expect<
-  Equal<
-    StrictQuery<DB, 'select 1 as one'>,
-    QueryTypeError<'no FROM clause: cannot resolve column "1"'>[]
-  >
+type StrictLiteralWithoutFromResolves = Expect<
+  Equal<StrictQuery<DB, 'select 1 as one'>, { one: number }[]>
 >;
 
 type OrdinaryFromQueryIsUnaffected = Expect<
@@ -37,7 +34,7 @@ type OrdinaryFromQueryStrictModeIsUnaffected = Expect<
 export type BehaviorLock = [
   LiteralAliasResolvesKey,
   FunctionCallWithNoFromResolvesKey,
-  StrictModeReportsNoFromClauseInsteadOfEmptyTableName,
+  StrictLiteralWithoutFromResolves,
   OrdinaryFromQueryIsUnaffected,
   OrdinaryFromQueryStrictModeIsUnaffected,
 ];

--- a/tests/string-literal.test-d.ts
+++ b/tests/string-literal.test-d.ts
@@ -26,14 +26,14 @@ type UnbalancedParenInsideLiteral = Expect<
 type CommaInsideLiteral = Expect<
   Equal<
     Query<DB, "select 'a, b' as label, id from users">,
-    { label: unknown; id: number }[]
+    { label: string; id: number }[]
   >
 >;
 
 type EscapedQuoteInsideLiteral = Expect<
   Equal<
     Query<DB, "select 'it''s, fine' as label, id from users">,
-    { label: unknown; id: number }[]
+    { label: string; id: number }[]
   >
 >;
 
@@ -65,7 +65,7 @@ type SemicolonInsideLiteralDoesNotSplit = Expect<
 type KeywordInsideLiteralIgnored = Expect<
   Equal<
     Query<DB, "select id, 'from users where' as fragment from users">,
-    { id: number; fragment: unknown }[]
+    { id: number; fragment: string }[]
   >
 >;
 


### PR DESCRIPTION
## Problem

`ResolveColumnType` had no literal handling (#53), so strict mode treated literals as unknown columns:

- `StrictRow<DB, 'select 1 as one from users'>` → `QueryTypeError<'unknown column: 1'>`
- `select 'x' as tag from users` (strict) → `QueryTypeError<"unknown column: 'x'">`

This made strict mode unusable for the very common `select id, 1 as flag, 'label' as kind from t`.

## Fix

`LiteralType` (previously private to CASE-branch typing in `src/case.ts`) now lives in `src/parse.ts` and is consulted by `ResolveColumnType` before column resolution: number, `'...'` string, `true`/`false` and `null` literals type as `number`/`string`/`boolean`/`null` in both loose and strict mode. CASE branch typing now delegates to `ResolveColumnType` instead of duplicating the literal logic.

Behavior change locked in existing tests: `select 1 as one` (no FROM) previously inferred `{ one: unknown }` loose / `no FROM clause` error strict — both now resolve `{ one: number }`; string-literal columns like `'a, b' as label` now type `string` instead of `unknown`.

## Tests

`tests/literal-columns.test-d.ts`: strict numeric/string/boolean/null literals, mixed literals+columns, decimals, negatives. Updated `select-without-from` and `string-literal` locks. Full suite passes.

Closes #53