### PR TITLE
fix: unquote and de-qualify INSERT/UPDATE/DELETE target tables

### DIFF
--- a/src/case.ts
+++ b/src/case.ts
@@ -50,27 +50,6 @@ type HasElseBranch<Segments extends CaseSegment[]> = Segments extends [
     : HasElseBranch<Tail>
   : false;
 
-type LiteralType<Expr extends string> = Trim<Expr> extends `'${string}'`
-  ? string
-  : Trim<Expr> extends `${number}`
-    ? number
-    : Lowercase<Trim<Expr>> extends 'true' | 'false'
-      ? boolean
-      : Lowercase<Trim<Expr>> extends 'null'
-        ? null
-        : never;
-
-type BranchValueType<
-  DB extends SchemaLike,
-  Sources extends Source[],
-  Expr extends string,
-  Strict extends boolean,
-> = LiteralType<Expr> extends infer Literal
-  ? [Literal] extends [never]
-    ? ResolveColumnType<DB, Sources, Trim<Expr>, Strict>
-    : Literal
-  : never;
-
 type BranchUnion<
   DB extends SchemaLike,
   Sources extends Source[],
@@ -78,7 +57,7 @@ type BranchUnion<
   Strict extends boolean,
 > = Segments extends [infer Head extends CaseSegment, ...infer Tail extends CaseSegment[]]
   ? Head['kind'] extends 'then' | 'else'
-    ? BranchValueType<DB, Sources, Head['text'], Strict> | BranchUnion<DB, Sources, Tail, Strict>
+    ? ResolveColumnType<DB, Sources, Trim<Head['text']>, Strict> | BranchUnion<DB, Sources, Tail, Strict>
     : BranchUnion<DB, Sources, Tail, Strict>
   : never;
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -55,6 +55,20 @@ type StripTopClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'top'> ext
     : S
   : S;
 
+type StripDistinctOn<S extends string> = IsKeyword<FirstWord<S>, 'on'> extends true
+  ? Trim<DropFirstWord<S>> extends `(${infer AfterOpen}`
+    ? ExtractParenGroup<AfterOpen> extends { rest: infer Rest extends string }
+      ? Trim<Rest>
+      : S
+    : S
+  : S;
+
+type StripDistinctClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'distinct'> extends true
+  ? StripDistinctOn<Trim<DropFirstWord<Trim<S>>>>
+  : IsKeyword<FirstWord<Trim<S>>, 'all'> extends true
+    ? Trim<DropFirstWord<Trim<S>>>
+    : S;
+
 type ColumnsBeforeFrom<
   S extends string,
   Depth extends unknown[] = [],
@@ -135,7 +149,7 @@ export interface ParsedStatement {
 
 type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer Body
   ? Body extends string
-    ? ColumnsBeforeFrom<StripTopClause<Body>> extends {
+    ? ColumnsBeforeFrom<StripTopClause<StripDistinctClause<Body>>> extends {
         columns: infer Columns extends string;
         afterFrom: infer AfterFrom;
       }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -379,6 +379,16 @@ type QualifiedColumnType<
       : never
   : never;
 
+export type LiteralType<Expression extends string> = Trim<Expression> extends `'${string}'`
+  ? string
+  : Trim<Expression> extends `${number}`
+    ? number
+    : Lowercase<Trim<Expression>> extends 'true' | 'false'
+      ? boolean
+      : Lowercase<Trim<Expression>> extends 'null'
+        ? null
+        : never;
+
 type ScalarSubqueryInner<Expression extends string> = Trim<Expression> extends `(${infer AfterOpen}`
   ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string; rest: infer Rest extends string }
     ? Trim<Rest> extends ''
@@ -417,15 +427,17 @@ export type ResolveColumnType<
   : [ScalarSubqueryInner<Expression>] extends [never]
     ? IsFunctionCall<Expression> extends true
       ? FunctionReturnType<Expression>
-      : Qualifier<Expression> extends ''
-        ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
-        : QualifiedColumnType<
-            DB,
-            Sources,
-            Unquote<Qualifier<Expression>>,
-            Unquote<StripQualifier<Expression>>,
-            Strict
-          >
+      : [LiteralType<Expression>] extends [never]
+        ? Qualifier<Expression> extends ''
+          ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
+          : QualifiedColumnType<
+              DB,
+              Sources,
+              Unquote<Qualifier<Expression>>,
+              Unquote<StripQualifier<Expression>>,
+              Strict
+            >
+        : LiteralType<Expression>
     : ScalarSubqueryType<DB, ScalarSubqueryInner<Expression>, Strict>;
 
 export type ResolveColumnLoose<

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -140,7 +140,11 @@ type ReturningOrOutputColumns<S extends string, StopKeyword extends string> = Re
   ? StripPseudoTableQualifiers<OutputClauseColumns<S, StopKeyword>>
   : ReturningColumns<S>;
 
-type SingleSource<Table extends string> = [{ table: Table; alias: Table; nullable: false }];
+type CleanTargetIdentifier<Raw extends string> = Unquote<StripQualifier<Raw>>;
+
+type SingleSource<Table extends string> = [
+  { table: CleanTargetIdentifier<Table>; alias: CleanTargetIdentifier<Table>; nullable: false },
+];
 
 export interface ParsedStatement {
   columns: string;

--- a/tests/distinct.test-d.ts
+++ b/tests/distinct.test-d.ts
@@ -1,0 +1,63 @@
+import type { Query, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    team_id: number;
+  };
+}
+
+type DistinctColumnsResolve = Expect<
+  Equal<
+    Query<DB, 'select distinct id, name from users'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type DistinctUppercaseResolves = Expect<
+  Equal<Query<DB, 'SELECT DISTINCT id FROM users'>, { id: number }[]>
+>;
+
+type AllKeywordStripped = Expect<
+  Equal<Query<DB, 'select all id from users'>, { id: number }[]>
+>;
+
+type DistinctOnGroupStripped = Expect<
+  Equal<
+    Query<DB, 'select distinct on (team_id) id, name from users'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type DistinctCombinesWithTop = Expect<
+  Equal<Query<DB, 'select distinct top 5 id from users'>, { id: number }[]>
+>;
+
+type DistinctStar = Expect<
+  Equal<
+    Query<DB, 'select distinct * from users'>,
+    { id: number; name: string; team_id: number }[]
+  >
+>;
+
+type StrictDistinctResolves = Expect<
+  Equal<StrictRow<DB, 'select distinct id from users'>, { id: number }>
+>;
+
+export type Assertions = [
+  DistinctColumnsResolve,
+  DistinctUppercaseResolves,
+  AllKeywordStripped,
+  DistinctOnGroupStripped,
+  DistinctCombinesWithTop,
+  DistinctStar,
+  StrictDistinctResolves,
+];

--- a/tests/dml-target.test-d.ts
+++ b/tests/dml-target.test-d.ts
@@ -1,0 +1,71 @@
+import type { Query, Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+  };
+}
+
+type SchemaQualifiedInsertResolvesReturning = Expect<
+  Equal<
+    Query<DB, 'insert into public.users (name) values ($1) returning id'>,
+    { id: number }[]
+  >
+>;
+
+type QuotedInsertTargetResolvesReturning = Expect<
+  Equal<
+    Query<DB, 'insert into "users" (name) values ($1) returning id'>,
+    { id: number }[]
+  >
+>;
+
+type QualifiedAndQuotedInsertTargetResolves = Expect<
+  Equal<
+    Query<DB, 'insert into "public"."users" (name) values ($1) returning id'>,
+    { id: number }[]
+  >
+>;
+
+type SchemaQualifiedUpdateResolvesReturning = Expect<
+  Equal<
+    Query<DB, 'update public.users set name = $1 where id = $2 returning id, name'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type SchemaQualifiedDeleteResolvesReturning = Expect<
+  Equal<
+    Query<DB, 'delete from "public".users where id = $1 returning name'>,
+    { name: string }[]
+  >
+>;
+
+type SchemaQualifiedInsertParamsResolve = Expect<
+  Equal<Params<DB, 'insert into public.users (name) values ($1)'>, [string]>
+>;
+
+type UnquotedInsertStillWorks = Expect<
+  Equal<
+    Query<DB, 'insert into users (name) values ($1) returning id'>,
+    { id: number }[]
+  >
+>;
+
+export type Assertions = [
+  SchemaQualifiedInsertResolvesReturning,
+  QuotedInsertTargetResolvesReturning,
+  QualifiedAndQuotedInsertTargetResolves,
+  SchemaQualifiedUpdateResolvesReturning,
+  SchemaQualifiedDeleteResolvesReturning,
+  SchemaQualifiedInsertParamsResolve,
+  UnquotedInsertStillWorks,
+];

--- a/tests/literal-columns.test-d.ts
+++ b/tests/literal-columns.test-d.ts
@@ -1,0 +1,56 @@
+import type { Query, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+  };
+}
+
+type StrictNumericLiteral = Expect<
+  Equal<StrictRow<DB, 'select 1 as one from users'>, { one: number }>
+>;
+
+type StrictStringLiteral = Expect<
+  Equal<StrictRow<DB, "select 'x' as tag from users">, { tag: string }>
+>;
+
+type StrictBooleanLiteral = Expect<
+  Equal<StrictRow<DB, 'select true as flag from users'>, { flag: boolean }>
+>;
+
+type StrictNullLiteral = Expect<
+  Equal<StrictRow<DB, 'select null as nothing from users'>, { nothing: null }>
+>;
+
+type StrictMixedLiteralsAndColumns = Expect<
+  Equal<
+    StrictRow<DB, "select id, 1 as flag, 'label' as kind from users">,
+    { id: number; flag: number; kind: string }
+  >
+>;
+
+type LooseNumericLiteral = Expect<
+  Equal<Query<DB, 'select 2.5 as ratio from users'>, { ratio: number }[]>
+>;
+
+type NegativeNumericLiteral = Expect<
+  Equal<Query<DB, 'select -1 as neg from users'>, { neg: number }[]>
+>;
+
+export type Assertions = [
+  StrictNumericLiteral,
+  StrictStringLiteral,
+  StrictBooleanLiteral,
+  StrictNullLiteral,
+  StrictMixedLiteralsAndColumns,
+  LooseNumericLiteral,
+  NegativeNumericLiteral,
+];

--- a/tests/select-without-from.test-d.ts
+++ b/tests/select-without-from.test-d.ts
@@ -1,4 +1,4 @@
-import type { Query, StrictQuery, QueryTypeError } from '../src/index.js';
+import type { Query, StrictQuery } from '../src/index.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -12,18 +12,15 @@ interface DB {
 }
 
 type LiteralAliasResolvesKey = Expect<
-  Equal<Query<DB, 'select 1 as one'>, { one: unknown }[]>
+  Equal<Query<DB, 'select 1 as one'>, { one: number }[]>
 >;
 
 type FunctionCallWithNoFromResolvesKey = Expect<
   Equal<Query<DB, 'select random_seed() as seed'>, { seed: unknown }[]>
 >;
 
-type StrictModeReportsNoFromClauseInsteadOfEmptyTableName = Expect<
-  Equal<
-    StrictQuery<DB, 'select 1 as one'>,
-    QueryTypeError<'no FROM clause: cannot resolve column "1"'>[]
-  >
+type StrictLiteralWithoutFromResolves = Expect<
+  Equal<StrictQuery<DB, 'select 1 as one'>, { one: number }[]>
 >;
 
 type OrdinaryFromQueryIsUnaffected = Expect<
@@ -37,7 +34,7 @@ type OrdinaryFromQueryStrictModeIsUnaffected = Expect<
 export type BehaviorLock = [
   LiteralAliasResolvesKey,
   FunctionCallWithNoFromResolvesKey,
-  StrictModeReportsNoFromClauseInsteadOfEmptyTableName,
+  StrictLiteralWithoutFromResolves,
   OrdinaryFromQueryIsUnaffected,
   OrdinaryFromQueryStrictModeIsUnaffected,
 ];

--- a/tests/string-literal.test-d.ts
+++ b/tests/string-literal.test-d.ts
@@ -26,14 +26,14 @@ type UnbalancedParenInsideLiteral = Expect<
 type CommaInsideLiteral = Expect<
   Equal<
     Query<DB, "select 'a, b' as label, id from users">,
-    { label: unknown; id: number }[]
+    { label: string; id: number }[]
   >
 >;
 
 type EscapedQuoteInsideLiteral = Expect<
   Equal<
     Query<DB, "select 'it''s, fine' as label, id from users">,
-    { label: unknown; id: number }[]
+    { label: string; id: number }[]
   >
 >;
 
@@ -65,7 +65,7 @@ type SemicolonInsideLiteralDoesNotSplit = Expect<
 type KeywordInsideLiteralIgnored = Expect<
   Equal<
     Query<DB, "select id, 'from users where' as fragment from users">,
-    { id: number; fragment: unknown }[]
+    { id: number; fragment: string }[]
   >
 >;
 


### PR DESCRIPTION
## Problem

The DML path used raw `WordAfterKeyword` output as the table name, while the SELECT path applies `Unquote<StripQualifier<...>>` (#54):

- `insert into public.users (name) values ($1) returning id` → `{ id: unknown }`
- `insert into "users" (name) values ($1) returning id` → `{ id: unknown }`

README explicitly claims schema-qualified and quoted identifiers are supported; the same SQL worked in `FROM` but failed in DML. Insert param inference was equally broken (`[unknown]` instead of `[string]`).

## Fix

`SingleSource` now runs the target through the same `Unquote<StripQualifier<...>>` cleaning the FROM path uses, covering INSERT/UPDATE/DELETE targets and insert param typing.

## Tests

`tests/dml-target.test-d.ts`: schema-qualified, quoted, qualified+quoted targets across INSERT/UPDATE/DELETE with RETURNING, insert params probe, unquoted control. Full suite passes.

Closes #54