### PR TITLE
fix: bind $n placeholders by index instead of textual occurrence

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -42,11 +42,67 @@ type CleanPlaceholderToken<S extends string> = StripTrailingListPunctuation<Stri
 
 type IsPlaceholder<Token extends string> = CleanPlaceholderToken<Token> extends '?'
   ? true
-  : CleanPlaceholderToken<Token> extends `$${string}`
-    ? true
-    : CleanPlaceholderToken<Token> extends `@${string}`
+  : CleanPlaceholderToken<Token> extends `$$${string}` | `@@${string}` | '$' | '@'
+    ? false
+    : CleanPlaceholderToken<Token> extends `$${string}`
       ? true
-      : false;
+      : CleanPlaceholderToken<Token> extends `@${string}`
+        ? true
+        : false;
+
+type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+
+interface DigitCounters {
+  '0': [];
+  '1': [unknown];
+  '2': [unknown, unknown];
+  '3': [unknown, unknown, unknown];
+  '4': [unknown, unknown, unknown, unknown];
+  '5': [unknown, unknown, unknown, unknown, unknown];
+  '6': [unknown, unknown, unknown, unknown, unknown, unknown];
+  '7': [unknown, unknown, unknown, unknown, unknown, unknown, unknown];
+  '8': [unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown];
+  '9': [unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown];
+}
+
+type TimesTen<Counter extends unknown[]> = [
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+];
+
+type DigitsToCounter<S extends string, Accumulated extends unknown[] = []> =
+  S extends `${infer Head}${infer Rest}`
+    ? Head extends Digit
+      ? DigitsToCounter<Rest, [...TimesTen<Accumulated>, ...DigitCounters[Head & keyof DigitCounters]]>
+      : never
+    : Accumulated;
+
+type PlaceholderPosition<Token extends string> =
+  CleanPlaceholderToken<Token> extends `$${infer Digits}`
+    ? DigitsToCounter<Digits> extends [unknown, ...infer Position extends unknown[]]
+      ? Position
+      : never
+    : never;
+
+type SetSlot<
+  Tuple extends unknown[],
+  Position extends unknown[],
+  Type,
+> = Position extends [unknown, ...infer PositionRest extends unknown[]]
+  ? Tuple extends [infer Head, ...infer TupleRest extends unknown[]]
+    ? [Head, ...SetSlot<TupleRest, PositionRest, Type>]
+    : [unknown, ...SetSlot<[], PositionRest, Type>]
+  : Tuple extends [infer Head, ...infer TupleRest extends unknown[]]
+    ? [Head & Type, ...TupleRest]
+    : [Type];
 
 type ParamType<
   DB extends SchemaLike,
@@ -59,31 +115,48 @@ type ParamType<
     ? ResolveColumnLoose<DB, Sources, Column>
     : unknown;
 
+type AddParam<
+  Token extends string,
+  Type,
+  Indexed extends unknown[],
+  Sequential extends unknown[],
+> = PlaceholderPosition<Token> extends infer Position
+  ? [Position] extends [never]
+    ? { indexed: Indexed; sequential: [...Sequential, Type] }
+    : Position extends unknown[]
+      ? { indexed: SetSlot<Indexed, Position, Type>; sequential: Sequential }
+      : never
+  : never;
+
 type ScanParams<
   S extends string,
   DB extends SchemaLike,
   Sources extends Source[],
   PrevPrev extends string = '',
   Prev extends string = '',
-  Accumulated extends unknown[] = [],
+  Indexed extends unknown[] = [],
+  Sequential extends unknown[] = [],
 > = S extends `${infer Head} ${infer Tail}`
   ? IsPlaceholder<Head> extends true
-    ? ScanParams<
-        Tail,
-        DB,
-        Sources,
-        PrevPrev,
-        Prev,
-        [...Accumulated, ParamType<DB, Sources, PrevPrev, Prev>]
-      >
+    ? AddParam<Head, ParamType<DB, Sources, PrevPrev, Prev>, Indexed, Sequential> extends {
+        indexed: infer NextIndexed extends unknown[];
+        sequential: infer NextSequential extends unknown[];
+      }
+      ? ScanParams<Tail, DB, Sources, PrevPrev, Prev, NextIndexed, NextSequential>
+      : never
     : IsTransparentToken<Head> extends true
-      ? ScanParams<Tail, DB, Sources, PrevPrev, Prev, Accumulated>
-      : ScanParams<Tail, DB, Sources, Prev, Head, Accumulated>
+      ? ScanParams<Tail, DB, Sources, PrevPrev, Prev, Indexed, Sequential>
+      : ScanParams<Tail, DB, Sources, Prev, Head, Indexed, Sequential>
   : S extends ''
-    ? Accumulated
+    ? [...Indexed, ...Sequential]
     : IsPlaceholder<S> extends true
-      ? [...Accumulated, ParamType<DB, Sources, PrevPrev, Prev>]
-      : Accumulated;
+      ? AddParam<S, ParamType<DB, Sources, PrevPrev, Prev>, Indexed, Sequential> extends {
+          indexed: infer NextIndexed extends unknown[];
+          sequential: infer NextSequential extends unknown[];
+        }
+        ? [...NextIndexed, ...NextSequential]
+        : never
+      : [...Indexed, ...Sequential];
 
 type InsertColumnList<S extends string> = AfterKeyword<S, 'into'> extends infer AfterInto extends string
   ? Trim<DropFirstWord<AfterInto>> extends `(${infer AfterOpen}`
@@ -113,13 +186,20 @@ type MatchInsertValueTypes<
   Table extends string,
   Columns extends string[],
   Values extends string[],
+  Indexed extends unknown[] = [],
+  Sequential extends unknown[] = [],
 > = Values extends [infer Head extends string, ...infer ValuesTail extends string[]]
   ? Columns extends [infer ColumnHead extends string, ...infer ColumnsTail extends string[]]
     ? IsPlaceholder<Trim<Head>> extends true
-      ? [ColumnTypeAt<DB, Table, ColumnHead>, ...MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail>]
-      : MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail>
-    : []
-  : [];
+      ? AddParam<Trim<Head>, ColumnTypeAt<DB, Table, ColumnHead>, Indexed, Sequential> extends {
+          indexed: infer NextIndexed extends unknown[];
+          sequential: infer NextSequential extends unknown[];
+        }
+        ? MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail, NextIndexed, NextSequential>
+        : never
+      : MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail, Indexed, Sequential>
+    : [...Indexed, ...Sequential]
+  : [...Indexed, ...Sequential];
 
 type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<Q> extends {
   sources: [infer Src extends Source];

--- a/tests/params-index.test-d.ts
+++ b/tests/params-index.test-d.ts
@@ -1,0 +1,84 @@
+import type { Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; parent_id: number };
+}
+
+type OutOfOrderPlaceholdersBindByIndex = Expect<
+  Equal<
+    Params<DB, 'select id from users where name = $2 and id = $1'>,
+    [number, string]
+  >
+>;
+
+type RepeatedPlaceholderOccupiesOneSlot = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = $1 or parent_id = $1'>,
+    [number]
+  >
+>;
+
+type GapLeavesUnknownSlot = Expect<
+  Equal<Params<DB, 'select id from users where name = $2'>, [unknown, string]>
+>;
+
+type DoubleDigitIndexResolves = Expect<
+  Equal<
+    Params<
+      DB,
+      'select id from users where id = $10 and name = $1'
+    >['length'],
+    10
+  >
+>;
+
+type QuestionMarksStaySequential = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = ? and name = ?'>,
+    [number, string]
+  >
+>;
+
+type NamedAtParamsStaySequential = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = @id and name = @name'>,
+    [number, string]
+  >
+>;
+
+type SystemVariableIsNotPlaceholder = Expect<
+  Equal<Params<DB, 'select id from users where id = @@rowcount'>, []>
+>;
+
+type InsertOutOfOrderPlaceholdersBindByIndex = Expect<
+  Equal<
+    Params<DB, 'insert into users (id, name) values ($2, $1)'>,
+    [string, number]
+  >
+>;
+
+type InsertInOrderStillWorks = Expect<
+  Equal<
+    Params<DB, 'insert into users (id, name) values ($1, $2)'>,
+    [number, string]
+  >
+>;
+
+export type Assertions = [
+  OutOfOrderPlaceholdersBindByIndex,
+  RepeatedPlaceholderOccupiesOneSlot,
+  GapLeavesUnknownSlot,
+  DoubleDigitIndexResolves,
+  QuestionMarksStaySequential,
+  NamedAtParamsStaySequential,
+  SystemVariableIsNotPlaceholder,
+  InsertOutOfOrderPlaceholdersBindByIndex,
+  InsertInOrderStillWorks,
+];


### PR DESCRIPTION
## Problem

`IsPlaceholder` matched any `$...` token and never parsed the digit; `ScanParams` appended one tuple slot per occurrence in scan order (#55):

- **Out of order:** `where name = $2 and id = $1` inferred `[string, number]`, but pg binds `params[0]→$1`, `params[1]→$2` — wrong values bind silently when types happen to be compatible.
- **Repeated:** `where id = $1 or parent_id = $1` inferred two required args; the driver wants one → runtime bind error on a query the compiler blessed.

## Fix

- `$n` digits are parsed at the type level (decimal counter, supports multi-digit) and the param type lands at index `n-1` of the tuple.
- Repeated `$n` merges into a single slot via intersection (conflicting column types surface as `never` instead of silently picking one).
- Unreferenced lower indices stay `unknown` slots so arity still matches the driver.
- `?`, `@name` and `$name` (non-numeric) placeholders keep occurrence-order semantics.
- Related false positives fixed: `@@ROWCOUNT`-style system variables and `$$` tokens are no longer placeholders.
- The INSERT `VALUES` matcher applies the same indexed placement, so `insert into users (id, name) values ($2, $1)` now infers `[string, number]`.

## Tests

`tests/params-index.test-d.ts`: out-of-order, repeated, gap, double-digit `$10`, sequential `?`/`@name` controls, `@@rowcount`, and INSERT out-of-order/in-order probes. Full suite passes.

Closes #55