### PR TITLE
fix: type params in parenthesized WHERE groups, multi-row VALUES and ON CONFLICT

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -38,15 +38,21 @@ type StripTrailingListPunctuation<S extends string> = S extends `${infer Rest})`
     ? StripTrailingListPunctuation<Rest>
     : S;
 
-type CleanPlaceholderToken<S extends string> = StripTrailingListPunctuation<StripLeadingParens<S>>;
+type CleanScanToken<S extends string> = StripTrailingListPunctuation<StripLeadingParens<S>>;
 
-type IsPlaceholder<Token extends string> = CleanPlaceholderToken<Token> extends '?'
+type CleanColumnToken<S extends string> = StripLeadingParens<S> extends infer Stripped extends string
+  ? Stripped extends `${string}(${string}`
+    ? Stripped
+    : StripTrailingListPunctuation<Stripped>
+  : never;
+
+type IsPlaceholder<Token extends string> = CleanScanToken<Token> extends '?'
   ? true
-  : CleanPlaceholderToken<Token> extends `$$${string}` | `@@${string}` | '$' | '@'
+  : CleanScanToken<Token> extends `$$${string}` | `@@${string}` | '$' | '@'
     ? false
-    : CleanPlaceholderToken<Token> extends `$${string}`
+    : CleanScanToken<Token> extends `$${string}`
       ? true
-      : CleanPlaceholderToken<Token> extends `@${string}`
+      : CleanScanToken<Token> extends `@${string}`
         ? true
         : false;
 
@@ -86,7 +92,7 @@ type DigitsToCounter<S extends string, Accumulated extends unknown[] = []> =
     : Accumulated;
 
 type PlaceholderPosition<Token extends string> =
-  CleanPlaceholderToken<Token> extends `$${infer Digits}`
+  CleanScanToken<Token> extends `$${infer Digits}`
     ? DigitsToCounter<Digits> extends [unknown, ...infer Position extends unknown[]]
       ? Position
       : never
@@ -146,7 +152,7 @@ type ScanParams<
       : never
     : IsTransparentToken<Head> extends true
       ? ScanParams<Tail, DB, Sources, PrevPrev, Prev, Indexed, Sequential>
-      : ScanParams<Tail, DB, Sources, Prev, Head, Indexed, Sequential>
+      : ScanParams<Tail, DB, Sources, Prev, CleanColumnToken<Head>, Indexed, Sequential>
   : S extends ''
     ? [...Indexed, ...Sequential]
     : IsPlaceholder<S> extends true
@@ -166,14 +172,6 @@ type InsertColumnList<S extends string> = AfterKeyword<S, 'into'> extends infer 
     : never
   : never;
 
-type InsertValuesGroup<S extends string> = AfterKeyword<S, 'values'> extends infer AfterValues extends string
-  ? Trim<AfterValues> extends `(${infer AfterOpen}`
-    ? ExtractParenGroup<AfterOpen> extends { inner: infer Vals extends string }
-      ? Vals
-      : never
-    : never
-  : never;
-
 type ColumnTypeAt<DB extends SchemaLike, Table extends string, Column extends string> =
   Table extends keyof DB
     ? Column extends keyof DB[Table]
@@ -181,13 +179,13 @@ type ColumnTypeAt<DB extends SchemaLike, Table extends string, Column extends st
       : unknown
     : unknown;
 
-type MatchInsertValueTypes<
+type MatchInsertValues<
   DB extends SchemaLike,
   Table extends string,
   Columns extends string[],
   Values extends string[],
-  Indexed extends unknown[] = [],
-  Sequential extends unknown[] = [],
+  Indexed extends unknown[],
+  Sequential extends unknown[],
 > = Values extends [infer Head extends string, ...infer ValuesTail extends string[]]
   ? Columns extends [infer ColumnHead extends string, ...infer ColumnsTail extends string[]]
     ? IsPlaceholder<Trim<Head>> extends true
@@ -195,11 +193,31 @@ type MatchInsertValueTypes<
           indexed: infer NextIndexed extends unknown[];
           sequential: infer NextSequential extends unknown[];
         }
-        ? MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail, NextIndexed, NextSequential>
+        ? MatchInsertValues<DB, Table, ColumnsTail, ValuesTail, NextIndexed, NextSequential>
         : never
-      : MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail, Indexed, Sequential>
-    : [...Indexed, ...Sequential]
-  : [...Indexed, ...Sequential];
+      : MatchInsertValues<DB, Table, ColumnsTail, ValuesTail, Indexed, Sequential>
+    : { indexed: Indexed; sequential: Sequential }
+  : { indexed: Indexed; sequential: Sequential };
+
+type ScanValuesGroups<
+  S extends string,
+  DB extends SchemaLike,
+  Table extends string,
+  Columns extends string[],
+  Indexed extends unknown[],
+  Sequential extends unknown[],
+> = Trim<S> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends { inner: infer Vals extends string; rest: infer Rest extends string }
+    ? MatchInsertValues<DB, Table, Columns, SplitColumnList<Vals>, Indexed, Sequential> extends {
+        indexed: infer NextIndexed extends unknown[];
+        sequential: infer NextSequential extends unknown[];
+      }
+      ? Trim<Rest> extends `,${infer NextGroup}`
+        ? ScanValuesGroups<NextGroup, DB, Table, Columns, NextIndexed, NextSequential>
+        : { indexed: NextIndexed; sequential: NextSequential; rest: Trim<Rest> }
+      : never
+    : { indexed: Indexed; sequential: Sequential; rest: Trim<S> }
+  : { indexed: Indexed; sequential: Sequential; rest: Trim<S> };
 
 type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<Q> extends {
   sources: [infer Src extends Source];
@@ -207,11 +225,19 @@ type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<
   ? [InsertColumnList<Q>] extends [never]
     ? unknown[]
     : InsertColumnList<Q> extends { columns: infer Columns extends string[]; rest: infer AfterColumns extends string }
-      ? [InsertValuesGroup<AfterColumns>] extends [never]
-        ? unknown[]
-        : MatchInsertValueTypes<DB, Src['table'], Columns, SplitColumnList<InsertValuesGroup<AfterColumns>>>
+      ? AfterKeyword<AfterColumns, 'values'> extends infer AfterValues
+        ? AfterValues extends string
+          ? ScanValuesGroups<AfterValues, DB, Src['table'], Columns, [], []> extends {
+              indexed: infer Indexed extends unknown[];
+              sequential: infer Sequential extends unknown[];
+              rest: infer Rest extends string;
+            }
+            ? ScanParams<Rest, DB, [Src], '', '', Indexed, Sequential>
+            : unknown[]
+          : unknown[]
+        : unknown[]
       : unknown[]
-    : unknown[];
+  : unknown[];
 
 type ContainsPlaceholderLikeChar<S extends string> = S extends
   | `${string}$${string}`

--- a/tests/params-groups.test-d.ts
+++ b/tests/params-groups.test-d.ts
@@ -1,0 +1,79 @@
+import type { Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; active: boolean };
+}
+
+type ParenthesizedWhereGroupResolvesColumns = Expect<
+  Equal<
+    Params<DB, 'select id from users where (id = $1 or name = $2)'>,
+    [number, string]
+  >
+>;
+
+type NestedParenGroupsResolveColumns = Expect<
+  Equal<
+    Params<DB, 'select id from users where ((id = $1) and (name = $2))'>,
+    [number, string]
+  >
+>;
+
+type OnConflictUpdatePlaceholderTyped = Expect<
+  Equal<
+    Params<
+      DB,
+      'insert into users (name) values ($1) on conflict (name) do update set name = $2'
+    >,
+    [string, string]
+  >
+>;
+
+type MultiRowValuesAllTyped = Expect<
+  Equal<
+    Params<DB, 'insert into users (id, name) values ($1, $2), ($3, $4)'>,
+    [number, string, number, string]
+  >
+>;
+
+type MultiRowValuesOutOfOrderBindByIndex = Expect<
+  Equal<
+    Params<DB, 'insert into users (id, name) values ($3, $4), ($1, $2)'>,
+    [number, string, number, string]
+  >
+>;
+
+type MultiRowSequentialPlaceholders = Expect<
+  Equal<
+    Params<DB, 'insert into users (id, name) values (?, ?), (?, ?)'>,
+    [number, string, number, string]
+  >
+>;
+
+type SingleGroupControlUnchanged = Expect<
+  Equal<Params<DB, 'insert into users (name) values ($1) returning id'>, [string]>
+>;
+
+type MixedLiteralAndPlaceholderRows = Expect<
+  Equal<
+    Params<DB, "insert into users (id, name) values (1, $1), (2, $2)">,
+    [string, string]
+  >
+>;
+
+export type Assertions = [
+  ParenthesizedWhereGroupResolvesColumns,
+  NestedParenGroupsResolveColumns,
+  OnConflictUpdatePlaceholderTyped,
+  MultiRowValuesAllTyped,
+  MultiRowValuesOutOfOrderBindByIndex,
+  MultiRowSequentialPlaceholders,
+  SingleGroupControlUnchanged,
+  MixedLiteralAndPlaceholderRows,
+];


### PR DESCRIPTION
## Problem (#56)

1. **Parenthesized WHERE groups** — `Params<DB, 'select id from users where (id = $1 or name = $2)'>` inferred `[unknown, string]`: the placeholder token was cleaned but the *column* token `(id` was not, so column resolution failed.
2. **Placeholders outside the first VALUES group were dropped**:
   - `insert into users (name) values ($1) on conflict (name) do update set name = $2` → `[string]` (1-tuple)
   - `insert into users (id, name) values ($1, $2), ($3, $4)` → `[number, string]`

   Because `InferParams` produces a fixed-length tuple, passing the **correct** number of runtime arguments was a **compile error**.

## Fix

- Column tokens in the scanner are cleaned of leading grouping parens and trailing list punctuation, while function-call tokens (`count(*)`) are preserved intact.
- Every `VALUES` group is scanned (not just the first), each mapping placeholders to the column list positionally — with $n indexed placement from #95, out-of-order multi-row groups bind correctly too.
- The statement tail after the VALUES groups (`ON CONFLICT ... DO UPDATE SET`, `WHERE`, etc.) flows through the generic param scanner, so its placeholders are typed from their column context.

## Tests

`tests/params-groups.test-d.ts`: paren/nested-paren WHERE groups, ON CONFLICT DO UPDATE, multi-row VALUES (in-order, out-of-order $n, sequential `?`, mixed literal+placeholder rows), single-group control. Full suite passes.

Closes #56