### PR TITLE
fix: resolve comma-separated FROM lists as multiple sources

### DIFF
--- a/src/from.ts
+++ b/src/from.ts
@@ -7,6 +7,7 @@ import type {
   StripQualifier,
   ExtractParenGroup,
   ApplyParenDelta,
+  SplitColumnList,
 } from './string.js';
 
 export interface Source {
@@ -149,6 +150,18 @@ type SegmentToSource<Segment extends string, Nullable extends boolean> = Trim<Se
       }
     : never;
 
+type PartsToSources<Parts extends string[], Nullable extends boolean> = Parts extends [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? [SegmentToSource<Head, Nullable>, ...PartsToSources<Tail, Nullable>]
+  : [];
+
+type SegmentToSources<Segment extends string, Nullable extends boolean> = PartsToSources<
+  SplitColumnList<Segment>,
+  Nullable
+>;
+
 type MarkNullable<Sources extends Source[]> = {
   [Index in keyof Sources]: Sources[Index] extends { derivedQuery: infer Q extends string }
     ? { table: Sources[Index]['table']; alias: Sources[Index]['alias']; nullable: true; derivedQuery: Q }
@@ -161,7 +174,7 @@ type CollectSources<
   Accumulated extends Source[] = [],
 > = SplitAtFirstJoin<S> extends infer Split
   ? [Split] extends [never]
-    ? [...Accumulated, SegmentToSource<S, Nullable>]
+    ? [...Accumulated, ...SegmentToSources<S, Nullable>]
     : Split extends {
           before: infer Before extends string;
           joined: infer Joined extends boolean;
@@ -172,10 +185,10 @@ type CollectSources<
         ? CollectSources<
             After,
             Joined,
-            [...MarkNullable<Accumulated>, SegmentToSource<Before, true>]
+            [...MarkNullable<Accumulated>, ...SegmentToSources<Before, true>]
           >
-        : CollectSources<After, Joined, [...Accumulated, SegmentToSource<Before, Nullable>]>
-      : [...Accumulated, SegmentToSource<S, Nullable>]
+        : CollectSources<After, Joined, [...Accumulated, ...SegmentToSources<Before, Nullable>]>
+      : [...Accumulated, ...SegmentToSources<S, Nullable>]
   : never;
 
 export type ParseFromClause<AfterFrom extends string> = CollectSources<

--- a/src/params.ts
+++ b/src/params.ts
@@ -38,15 +38,21 @@ type StripTrailingListPunctuation<S extends string> = S extends `${infer Rest})`
     ? StripTrailingListPunctuation<Rest>
     : S;
 
-type CleanPlaceholderToken<S extends string> = StripTrailingListPunctuation<StripLeadingParens<S>>;
+type CleanScanToken<S extends string> = StripTrailingListPunctuation<StripLeadingParens<S>>;
 
-type IsPlaceholder<Token extends string> = CleanPlaceholderToken<Token> extends '?'
+type CleanColumnToken<S extends string> = StripLeadingParens<S> extends infer Stripped extends string
+  ? Stripped extends `${string}(${string}`
+    ? Stripped
+    : StripTrailingListPunctuation<Stripped>
+  : never;
+
+type IsPlaceholder<Token extends string> = CleanScanToken<Token> extends '?'
   ? true
-  : CleanPlaceholderToken<Token> extends `$$${string}` | `@@${string}` | '$' | '@'
+  : CleanScanToken<Token> extends `$$${string}` | `@@${string}` | '$' | '@'
     ? false
-    : CleanPlaceholderToken<Token> extends `$${string}`
+    : CleanScanToken<Token> extends `$${string}`
       ? true
-      : CleanPlaceholderToken<Token> extends `@${string}`
+      : CleanScanToken<Token> extends `@${string}`
         ? true
         : false;
 
@@ -86,7 +92,7 @@ type DigitsToCounter<S extends string, Accumulated extends unknown[] = []> =
     : Accumulated;
 
 type PlaceholderPosition<Token extends string> =
-  CleanPlaceholderToken<Token> extends `$${infer Digits}`
+  CleanScanToken<Token> extends `$${infer Digits}`
     ? DigitsToCounter<Digits> extends [unknown, ...infer Position extends unknown[]]
       ? Position
       : never
@@ -146,7 +152,7 @@ type ScanParams<
       : never
     : IsTransparentToken<Head> extends true
       ? ScanParams<Tail, DB, Sources, PrevPrev, Prev, Indexed, Sequential>
-      : ScanParams<Tail, DB, Sources, Prev, Head, Indexed, Sequential>
+      : ScanParams<Tail, DB, Sources, Prev, CleanColumnToken<Head>, Indexed, Sequential>
   : S extends ''
     ? [...Indexed, ...Sequential]
     : IsPlaceholder<S> extends true
@@ -166,14 +172,6 @@ type InsertColumnList<S extends string> = AfterKeyword<S, 'into'> extends infer 
     : never
   : never;
 
-type InsertValuesGroup<S extends string> = AfterKeyword<S, 'values'> extends infer AfterValues extends string
-  ? Trim<AfterValues> extends `(${infer AfterOpen}`
-    ? ExtractParenGroup<AfterOpen> extends { inner: infer Vals extends string }
-      ? Vals
-      : never
-    : never
-  : never;
-
 type ColumnTypeAt<DB extends SchemaLike, Table extends string, Column extends string> =
   Table extends keyof DB
     ? Column extends keyof DB[Table]
@@ -181,13 +179,13 @@ type ColumnTypeAt<DB extends SchemaLike, Table extends string, Column extends st
       : unknown
     : unknown;
 
-type MatchInsertValueTypes<
+type MatchInsertValues<
   DB extends SchemaLike,
   Table extends string,
   Columns extends string[],
   Values extends string[],
-  Indexed extends unknown[] = [],
-  Sequential extends unknown[] = [],
+  Indexed extends unknown[],
+  Sequential extends unknown[],
 > = Values extends [infer Head extends string, ...infer ValuesTail extends string[]]
   ? Columns extends [infer ColumnHead extends string, ...infer ColumnsTail extends string[]]
     ? IsPlaceholder<Trim<Head>> extends true
@@ -195,11 +193,31 @@ type MatchInsertValueTypes<
           indexed: infer NextIndexed extends unknown[];
           sequential: infer NextSequential extends unknown[];
         }
-        ? MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail, NextIndexed, NextSequential>
+        ? MatchInsertValues<DB, Table, ColumnsTail, ValuesTail, NextIndexed, NextSequential>
         : never
-      : MatchInsertValueTypes<DB, Table, ColumnsTail, ValuesTail, Indexed, Sequential>
-    : [...Indexed, ...Sequential]
-  : [...Indexed, ...Sequential];
+      : MatchInsertValues<DB, Table, ColumnsTail, ValuesTail, Indexed, Sequential>
+    : { indexed: Indexed; sequential: Sequential }
+  : { indexed: Indexed; sequential: Sequential };
+
+type ScanValuesGroups<
+  S extends string,
+  DB extends SchemaLike,
+  Table extends string,
+  Columns extends string[],
+  Indexed extends unknown[],
+  Sequential extends unknown[],
+> = Trim<S> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends { inner: infer Vals extends string; rest: infer Rest extends string }
+    ? MatchInsertValues<DB, Table, Columns, SplitColumnList<Vals>, Indexed, Sequential> extends {
+        indexed: infer NextIndexed extends unknown[];
+        sequential: infer NextSequential extends unknown[];
+      }
+      ? Trim<Rest> extends `,${infer NextGroup}`
+        ? ScanValuesGroups<NextGroup, DB, Table, Columns, NextIndexed, NextSequential>
+        : { indexed: NextIndexed; sequential: NextSequential; rest: Trim<Rest> }
+      : never
+    : { indexed: Indexed; sequential: Sequential; rest: Trim<S> }
+  : { indexed: Indexed; sequential: Sequential; rest: Trim<S> };
 
 type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<Q> extends {
   sources: [infer Src extends Source];
@@ -207,11 +225,19 @@ type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<
   ? [InsertColumnList<Q>] extends [never]
     ? unknown[]
     : InsertColumnList<Q> extends { columns: infer Columns extends string[]; rest: infer AfterColumns extends string }
-      ? [InsertValuesGroup<AfterColumns>] extends [never]
-        ? unknown[]
-        : MatchInsertValueTypes<DB, Src['table'], Columns, SplitColumnList<InsertValuesGroup<AfterColumns>>>
+      ? AfterKeyword<AfterColumns, 'values'> extends infer AfterValues
+        ? AfterValues extends string
+          ? ScanValuesGroups<AfterValues, DB, Src['table'], Columns, [], []> extends {
+              indexed: infer Indexed extends unknown[];
+              sequential: infer Sequential extends unknown[];
+              rest: infer Rest extends string;
+            }
+            ? ScanParams<Rest, DB, [Src], '', '', Indexed, Sequential>
+            : unknown[]
+          : unknown[]
+        : unknown[]
       : unknown[]
-    : unknown[];
+  : unknown[];
 
 type ContainsPlaceholderLikeChar<S extends string> = S extends
   | `${string}$${string}`

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -204,14 +204,32 @@ type OutputName<Expression extends string> = IsFunctionCall<Expression> extends 
   ? FunctionOutputName<Expression>
   : Unquote<StripQualifier<Expression>>;
 
+type OverAttachedParen<Token extends string> = Token extends `${infer Word}(${infer AfterOpen}`
+  ? IsKeyword<Word, 'over'> extends true
+    ? AfterOpen
+    : never
+  : never;
+
 type FindOverKeyword<S extends string, Accumulated extends string = ''> =
   S extends `${infer Head} ${infer Tail}`
     ? IsKeyword<Head, 'over'> extends true
       ? IsFunctionCall<Trim<Accumulated>> extends true
         ? { expr: Trim<Accumulated>; rest: Tail }
         : FindOverKeyword<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
-      : FindOverKeyword<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
-    : never;
+      : OverAttachedParen<Head> extends infer AfterOpen extends string
+        ? [AfterOpen] extends [never]
+          ? FindOverKeyword<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+          : IsFunctionCall<Trim<Accumulated>> extends true
+            ? { expr: Trim<Accumulated>; rest: `(${AfterOpen} ${Tail}` }
+            : FindOverKeyword<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+        : never
+    : OverAttachedParen<S> extends infer AfterOpen extends string
+      ? [AfterOpen] extends [never]
+        ? never
+        : IsFunctionCall<Trim<Accumulated>> extends true
+          ? { expr: Trim<Accumulated>; rest: `(${AfterOpen}` }
+          : never
+      : never;
 
 type StripLeadingOpenParen<S extends string> = Trim<S> extends `(${infer Rest}` ? Rest : never;
 
@@ -278,7 +296,9 @@ type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends tr
         : [Trim<Entry>, Trim<Entry>]
       : [FindTopLevelAsKeyword<Entry>] extends [never]
       ? Entry extends `${infer Expression} ${infer Alias}`
-        ? [Unquote<Trim<Alias>>, Trim<Expression>]
+        ? IsOperatorExpression<Alias> extends true
+          ? [Trim<Entry>, Trim<Entry>]
+          : [Unquote<Trim<Alias>>, Trim<Expression>]
         : [OutputName<Trim<Entry>>, Trim<Entry>]
       : FindTopLevelAsKeyword<Entry> extends { expr: infer Expr extends string; alias: infer Alias extends string }
         ? [Unquote<Trim<Alias>>, Expr]
@@ -383,6 +403,19 @@ type QualifiedColumnType<
       : never
   : never;
 
+type OperatorChar = '*' | '+' | '-' | '/' | '%' | '|' | '<' | '>' | '=' | '^';
+
+type ContainsOperatorChar<S extends string> = S extends `${string}${OperatorChar}${string}`
+  ? true
+  : false;
+
+type IsOperatorExpression<S extends string> = S extends
+  | `${string}"${string}`
+  | `${string}[${string}`
+  | `${string}\`${string}`
+  ? false
+  : ContainsOperatorChar<S>;
+
 export type LiteralType<Expression extends string> = Trim<Expression> extends `'${string}'`
   ? string
   : Trim<Expression> extends `${number}`
@@ -432,15 +465,17 @@ export type ResolveColumnType<
     ? IsFunctionCall<Expression> extends true
       ? FunctionReturnType<Expression>
       : [LiteralType<Expression>] extends [never]
-        ? Qualifier<Expression> extends ''
-          ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
-          : QualifiedColumnType<
-              DB,
-              Sources,
-              Unquote<Qualifier<Expression>>,
-              Unquote<StripQualifier<Expression>>,
-              Strict
-            >
+        ? IsOperatorExpression<Expression> extends true
+          ? unknown
+          : Qualifier<Expression> extends ''
+            ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
+            : QualifiedColumnType<
+                DB,
+                Sources,
+                Unquote<Qualifier<Expression>>,
+                Unquote<StripQualifier<Expression>>,
+                Strict
+              >
         : LiteralType<Expression>
     : ScalarSubqueryType<DB, ScalarSubqueryInner<Expression>, Strict>;
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -9,6 +9,7 @@ import type {
   Unquote,
   ExtractParenGroup,
   ApplyParenDelta,
+  SplitColumnList,
 } from './string.js';
 import type {
   IsFunctionCall,
@@ -180,25 +181,7 @@ export type ParseStatement<S extends string> = ParseStatementNormalized<Normaliz
 
 export type ParseSelect<S extends string> = ParseSelectBody<Normalize<S>>;
 
-type ScanColumnList<
-  S extends string,
-  Depth extends unknown[],
-  Current extends string,
-> = S extends `${infer Char}${infer Rest}`
-  ? Char extends '('
-    ? ScanColumnList<Rest, [...Depth, unknown], `${Current}${Char}`>
-    : Char extends ')'
-      ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
-        ? ScanColumnList<Rest, DepthRest, `${Current}${Char}`>
-        : ScanColumnList<Rest, Depth, `${Current}${Char}`>
-      : Char extends ','
-        ? Depth extends []
-          ? [Trim<Current>, ...ScanColumnList<Rest, Depth, ''>]
-          : ScanColumnList<Rest, Depth, `${Current}${Char}`>
-        : ScanColumnList<Rest, Depth, `${Current}${Char}`>
-  : [Trim<Current>];
-
-export type SplitColumnList<S extends string> = ScanColumnList<S, [], ''>;
+export type { SplitColumnList } from './string.js';
 
 type OutputName<Expression extends string> = IsFunctionCall<Expression> extends true
   ? FunctionOutputName<Expression>

--- a/src/string.ts
+++ b/src/string.ts
@@ -119,6 +119,26 @@ type ScanParenGroup<
 
 export type ExtractParenGroup<S extends string> = ScanParenGroup<S, [], ''>;
 
+type ScanColumnList<
+  S extends string,
+  Depth extends unknown[],
+  Current extends string,
+> = S extends `${infer Char}${infer Rest}`
+  ? Char extends '('
+    ? ScanColumnList<Rest, [...Depth, unknown], `${Current}${Char}`>
+    : Char extends ')'
+      ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
+        ? ScanColumnList<Rest, DepthRest, `${Current}${Char}`>
+        : ScanColumnList<Rest, Depth, `${Current}${Char}`>
+      : Char extends ','
+        ? Depth extends []
+          ? [Trim<Current>, ...ScanColumnList<Rest, Depth, ''>]
+          : ScanColumnList<Rest, Depth, `${Current}${Char}`>
+        : ScanColumnList<Rest, Depth, `${Current}${Char}`>
+  : [Trim<Current>];
+
+export type SplitColumnList<S extends string> = ScanColumnList<S, [], ''>;
+
 export type OpenCount<
   S extends string,
   Accumulated extends unknown[] = [],

--- a/tests/comma-from.test-d.ts
+++ b/tests/comma-from.test-d.ts
@@ -1,0 +1,68 @@
+import type { Query, StrictQuery, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  posts: { title: string; user_id: number };
+  tags: { label: string };
+}
+
+type CommaJoinResolvesBothTables = Expect<
+  Equal<
+    Query<DB, 'select name, title from users, posts'>,
+    { name: string; title: string }[]
+  >
+>;
+
+type CommaJoinWithAliasesResolves = Expect<
+  Equal<
+    Query<DB, 'select u.name, p.title from users u, posts p'>,
+    { name: string; title: string }[]
+  >
+>;
+
+type ThreeTableCommaListResolves = Expect<
+  Equal<
+    Query<DB, 'select u.name, p.title, t.label from users u, posts p, tags t'>,
+    { name: string; title: string; label: string }[]
+  >
+>;
+
+type CommaListMixedWithJoinResolves = Expect<
+  Equal<
+    Query<
+      DB,
+      'select u.name, p.title, t.label from users u, posts p join tags t on t.label = p.title'
+    >,
+    { name: string; title: string; label: string }[]
+  >
+>;
+
+type CommaJoinStarMergesAllTables = Expect<
+  Equal<
+    Query<DB, 'select * from users, tags'>,
+    { id: number; name: string; label: string }[]
+  >
+>;
+
+type StrictUnknownTableInCommaListSurfaces = Expect<
+  Equal<
+    StrictQuery<DB, 'select * from users, ghosts'>,
+    QueryTypeError<'unknown table: ghosts'>[]
+  >
+>;
+
+export type Assertions = [
+  CommaJoinResolvesBothTables,
+  CommaJoinWithAliasesResolves,
+  ThreeTableCommaListResolves,
+  CommaListMixedWithJoinResolves,
+  CommaJoinStarMergesAllTables,
+  StrictUnknownTableInCommaListSurfaces,
+];

--- a/tests/expression-columns.test-d.ts
+++ b/tests/expression-columns.test-d.ts
@@ -1,0 +1,79 @@
+import type { Query, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    email: string;
+  };
+}
+
+type UnaliasedArithmeticKeepsFullText = Expect<
+  Equal<Query<DB, 'select id * 2 from users'>, { 'id * 2': unknown }[]>
+>;
+
+type UnaliasedArithmeticStrictHasNoFalsePositive = Expect<
+  Equal<StrictRow<DB, 'select id * 2 from users'>, { 'id * 2': unknown }>
+>;
+
+type AliasedArithmeticUsesAlias = Expect<
+  Equal<Query<DB, 'select id * 2 as doubled from users'>, { doubled: unknown }[]>
+>;
+
+type ConcatExpressionKeepsFullText = Expect<
+  Equal<
+    Query<DB, 'select name || email from users'>,
+    { 'name || email': unknown }[]
+  >
+>;
+
+type WindowFunctionWithAttachedParenResolves = Expect<
+  Equal<
+    Query<DB, 'select row_number() over(order by id) from users'>,
+    { row_number: number }[]
+  >
+>;
+
+type WindowFunctionWithAttachedParenAndAlias = Expect<
+  Equal<
+    Query<DB, 'select row_number() over(order by id) as rn from users'>,
+    { rn: number }[]
+  >
+>;
+
+type WindowFunctionWithAttachedParenImplicitAlias = Expect<
+  Equal<
+    Query<DB, 'select row_number() over(partition by name) rn from users'>,
+    { rn: number }[]
+  >
+>;
+
+type SpacedOverStillResolves = Expect<
+  Equal<
+    Query<DB, 'select row_number() over (order by id) as rn from users'>,
+    { rn: number }[]
+  >
+>;
+
+type ImplicitAliasStillWorks = Expect<
+  Equal<Query<DB, 'select name handle from users'>, { handle: string }[]>
+>;
+
+export type Assertions = [
+  UnaliasedArithmeticKeepsFullText,
+  UnaliasedArithmeticStrictHasNoFalsePositive,
+  AliasedArithmeticUsesAlias,
+  ConcatExpressionKeepsFullText,
+  WindowFunctionWithAttachedParenResolves,
+  WindowFunctionWithAttachedParenAndAlias,
+  WindowFunctionWithAttachedParenImplicitAlias,
+  SpacedOverStillResolves,
+  ImplicitAliasStillWorks,
+];

--- a/tests/params-groups.test-d.ts
+++ b/tests/params-groups.test-d.ts
@@ -1,0 +1,79 @@
+import type { Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; active: boolean };
+}
+
+type ParenthesizedWhereGroupResolvesColumns = Expect<
+  Equal<
+    Params<DB, 'select id from users where (id = $1 or name = $2)'>,
+    [number, string]
+  >
+>;
+
+type NestedParenGroupsResolveColumns = Expect<
+  Equal<
+    Params<DB, 'select id from users where ((id = $1) and (name = $2))'>,
+    [number, string]
+  >
+>;
+
+type OnConflictUpdatePlaceholderTyped = Expect<
+  Equal<
+    Params<
+      DB,
+      'insert into users (name) values ($1) on conflict (name) do update set name = $2'
+    >,
+    [string, string]
+  >
+>;
+
+type MultiRowValuesAllTyped = Expect<
+  Equal<
+    Params<DB, 'insert into users (id, name) values ($1, $2), ($3, $4)'>,
+    [number, string, number, string]
+  >
+>;
+
+type MultiRowValuesOutOfOrderBindByIndex = Expect<
+  Equal<
+    Params<DB, 'insert into users (id, name) values ($3, $4), ($1, $2)'>,
+    [number, string, number, string]
+  >
+>;
+
+type MultiRowSequentialPlaceholders = Expect<
+  Equal<
+    Params<DB, 'insert into users (id, name) values (?, ?), (?, ?)'>,
+    [number, string, number, string]
+  >
+>;
+
+type SingleGroupControlUnchanged = Expect<
+  Equal<Params<DB, 'insert into users (name) values ($1) returning id'>, [string]>
+>;
+
+type MixedLiteralAndPlaceholderRows = Expect<
+  Equal<
+    Params<DB, "insert into users (id, name) values (1, $1), (2, $2)">,
+    [string, string]
+  >
+>;
+
+export type Assertions = [
+  ParenthesizedWhereGroupResolvesColumns,
+  NestedParenGroupsResolveColumns,
+  OnConflictUpdatePlaceholderTyped,
+  MultiRowValuesAllTyped,
+  MultiRowValuesOutOfOrderBindByIndex,
+  MultiRowSequentialPlaceholders,
+  SingleGroupControlUnchanged,
+  MixedLiteralAndPlaceholderRows,
+];


### PR DESCRIPTION
## Problem (#57)

`TakeFromClause` never split on `,`. `select id from users, posts` parsed the table as the literal `'users,'` (comma retained), the schema lookup failed silently, and strict mode reported a misleading `unknown table: users,`. Old-style comma joins are common and this wasn't documented as a limitation.

## Fix

Each FROM segment (per join-split) is now split on top-level commas — reusing the paren-aware `SplitColumnList` scanner, so derived tables containing commas are unaffected — and every part becomes its own non-nullable source with the usual alias handling. This gives comma lists proper cross-join semantics: bare and qualified columns resolve across all listed tables, `select *` merges them, and strict mode reports genuinely unknown tables by their clean names.

`SplitColumnList` moved from `parse.ts` to `string.ts` (re-exported from `parse.ts`) so `from.ts` can use it without a circular import.

## Tests

`tests/comma-from.test-d.ts`: two-table, aliased, three-table, comma list mixed with an explicit JOIN, `select *` merge, strict unknown-table probe. Full suite passes.

Closes #57