### PR TITLE
fix: make table, CTE and column lookups case-insensitive

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -5,6 +5,7 @@ import type {
   ParseStatement,
   ResolveColumnLoose,
   ResolveCteContext,
+  ResolveKey,
   AfterKeyword,
   SplitColumnList,
 } from './parse.js';
@@ -172,11 +173,16 @@ type InsertColumnList<S extends string> = AfterKeyword<S, 'into'> extends infer 
     : never
   : never;
 
-type ColumnTypeAt<DB extends SchemaLike, Table extends string, Column extends string> =
-  Table extends keyof DB
-    ? Column extends keyof DB[Table]
-      ? DB[Table][Column]
-      : unknown
+type ColumnTypeAt<DB extends SchemaLike, Table extends string, Column extends string> = [
+  ResolveKey<DB, Table>,
+] extends [never]
+  ? unknown
+  : ResolveKey<DB, Table> extends infer TableKey extends keyof DB
+    ? [ResolveKey<DB[TableKey], Column>] extends [never]
+      ? unknown
+      : ResolveKey<DB[TableKey], Column> extends infer ColumnKey extends keyof DB[TableKey]
+        ? DB[TableKey][ColumnKey]
+        : unknown
     : unknown;
 
 type MatchInsertValues<

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -30,6 +30,18 @@ export type QueryTypeError<Message extends string> = {
   readonly __sqlTypeError: Message;
 };
 
+type CaseInsensitiveKey<T, Name extends string> = {
+  [Key in keyof T]: Key extends string
+    ? Lowercase<Key> extends Lowercase<Name>
+      ? Key
+      : never
+    : never;
+}[keyof T];
+
+export type ResolveKey<T, Name extends string> = Name extends keyof T
+  ? Name
+  : CaseInsensitiveKey<T, Name>;
+
 type StatementAfterSelect<S extends string> = S extends `${infer Keyword} ${infer Rest}`
   ? IsKeyword<Keyword, 'select'> extends true
     ? Rest
@@ -297,10 +309,18 @@ type SourceColumnType<
   DB extends SchemaLike,
   S extends Source,
   Column extends string,
-> = S['table'] extends keyof DB
-  ? Column extends keyof DB[S['table']]
-    ? ApplyNull<DB[S['table']][Column], S['nullable']>
-    : never
+> = ResolveKey<DB, S['table']> extends infer TableKey
+  ? [TableKey] extends [never]
+    ? never
+    : TableKey extends keyof DB
+      ? ResolveKey<DB[TableKey], Column> extends infer ColumnKey
+        ? [ColumnKey] extends [never]
+          ? never
+          : ColumnKey extends keyof DB[TableKey]
+            ? ApplyNull<DB[TableKey][ColumnKey], S['nullable']>
+            : never
+        : never
+      : never
   : never;
 
 type ResolveBareAcross<
@@ -317,16 +337,16 @@ type ResolveBareAcross<
 
 type AnyKnownTable<DB extends SchemaLike, Sources extends Source[]> =
   Sources extends [infer Head extends Source, ...infer Tail extends Source[]]
-    ? Head['table'] extends keyof DB
-      ? true
-      : AnyKnownTable<DB, Tail>
+    ? [ResolveKey<DB, Head['table']>] extends [never]
+      ? AnyKnownTable<DB, Tail>
+      : true
     : false;
 
 type FirstUnknownTable<DB extends SchemaLike, Sources extends Source[]> =
   Sources extends [infer Head extends Source, ...infer Tail extends Source[]]
-    ? Head['table'] extends keyof DB
-      ? FirstUnknownTable<DB, Tail>
-      : Head['table']
+    ? [ResolveKey<DB, Head['table']>] extends [never]
+      ? Head['table']
+      : FirstUnknownTable<DB, Tail>
     : '';
 
 type FirstSourceTable<Sources extends Source[]> = Sources extends [
@@ -374,15 +394,19 @@ type QualifiedColumnType<
       ? QueryTypeError<`unknown alias: ${Name}`>
       : unknown
     : Found extends Source
-      ? Found['table'] extends keyof DB
-        ? Column extends keyof DB[Found['table']]
-          ? ApplyNull<DB[Found['table']][Column], Found['nullable']>
-          : Strict extends true
-            ? QueryTypeError<`unknown column: ${Column}`>
-            : unknown
-        : Strict extends true
+      ? [ResolveKey<DB, Found['table']>] extends [never]
+        ? Strict extends true
           ? QueryTypeError<`unknown table: ${Found['table']}`>
           : unknown
+        : ResolveKey<DB, Found['table']> extends infer TableKey extends keyof DB
+          ? [ResolveKey<DB[TableKey], Column>] extends [never]
+            ? Strict extends true
+              ? QueryTypeError<`unknown column: ${Column}`>
+              : unknown
+            : ResolveKey<DB[TableKey], Column> extends infer ColumnKey extends keyof DB[TableKey]
+              ? ApplyNull<DB[TableKey][ColumnKey], Found['nullable']>
+              : never
+          : never
       : never
   : never;
 
@@ -476,9 +500,13 @@ type CollectRowErrors<Row> = {
 
 type SurfaceErrors<Row> = [CollectRowErrors<Row>] extends [never] ? Row : CollectRowErrors<Row>;
 
-type MergeSourceColumns<DB extends SchemaLike, S extends Source> = S['table'] extends keyof DB
-  ? { [Column in keyof DB[S['table']]]: ApplyNull<DB[S['table']][Column], S['nullable']> }
-  : unknown;
+type MergeSourceColumns<DB extends SchemaLike, S extends Source> = [
+  ResolveKey<DB, S['table']>,
+] extends [never]
+  ? unknown
+  : ResolveKey<DB, S['table']> extends infer TableKey extends keyof DB
+    ? { [Column in keyof DB[TableKey]]: ApplyNull<DB[TableKey][Column], S['nullable']> }
+    : unknown;
 
 type MergedStarColumns<DB extends SchemaLike, Sources extends Source[]> = Sources extends [
   infer Head extends Source,
@@ -493,9 +521,9 @@ type AllKnownTables<DB extends SchemaLike, Sources extends Source[]> = Sources e
   infer Head extends Source,
   ...infer Tail extends Source[],
 ]
-  ? Head['table'] extends keyof DB
-    ? AllKnownTables<DB, Tail>
-    : false
+  ? [ResolveKey<DB, Head['table']>] extends [never]
+    ? false
+    : AllKnownTables<DB, Tail>
   : true;
 
 type StarRow<

--- a/tests/case-insensitive.test-d.ts
+++ b/tests/case-insensitive.test-d.ts
@@ -1,0 +1,66 @@
+import type { Query, StrictQuery, Params, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+type UppercaseTableAndColumnResolve = Expect<
+  Equal<Query<DB, 'SELECT ID FROM USERS'>, { ID: number }[]>
+>;
+
+type MixedCaseTableResolves = Expect<
+  Equal<Query<DB, 'select id, NAME from Users'>, { id: number; NAME: string }[]>
+>;
+
+type MixedCaseCteResolves = Expect<
+  Equal<
+    Query<DB, 'with Totals as (select id from users) select id from totals'>,
+    { id: number }[]
+  >
+>;
+
+type QualifiedUppercaseColumnResolves = Expect<
+  Equal<Query<DB, 'select U.ID from users U'>, { ID: number }[]>
+>;
+
+type StarOnUppercaseTableUsesSchemaKeys = Expect<
+  Equal<Query<DB, 'select * from USERS'>, { id: number; name: string }[]>
+>;
+
+type StrictUppercaseResolves = Expect<
+  Equal<StrictQuery<DB, 'SELECT ID FROM USERS'>, { ID: number }[]>
+>;
+
+type StrictStillRejectsTrulyUnknownColumn = Expect<
+  Equal<
+    StrictQuery<DB, 'SELECT MISSING FROM USERS'>,
+    QueryTypeError<'unknown column: MISSING'>[]
+  >
+>;
+
+type UppercaseParamColumnResolves = Expect<
+  Equal<Params<DB, 'select id from USERS where ID = $1'>, [number]>
+>;
+
+type UppercaseInsertParamsResolve = Expect<
+  Equal<Params<DB, 'INSERT INTO USERS (NAME) VALUES ($1)'>, [string]>
+>;
+
+export type Assertions = [
+  UppercaseTableAndColumnResolve,
+  MixedCaseTableResolves,
+  MixedCaseCteResolves,
+  QualifiedUppercaseColumnResolves,
+  StarOnUppercaseTableUsesSchemaKeys,
+  StrictUppercaseResolves,
+  StrictStillRejectsTrulyUnknownColumn,
+  UppercaseParamColumnResolves,
+  UppercaseInsertParamsResolve,
+];


### PR DESCRIPTION
## Problem (#58)

SQL folds unquoted identifiers case-insensitively; the type engine was inconsistent:

- `SourceColumnType`: exact `keyof` match — case-sensitive
- `FindSourceByName`: case-insensitive
- CTE map keys: exact-case

Probes: `SELECT ID FROM USERS` → `{ ID: unknown }`; `with Totals as (...) select id from totals` → `{ id: unknown }`; `from users U` worked while `FROM Users` failed.

## Fix

A shared `ResolveKey<T, Name>` resolves schema keys with an exact-match fast path and a case-insensitive fallback (`Lowercase` comparison over `keyof T`). Wired through every lookup path:

- bare and qualified column resolution (including strict-mode unknown-table/column reporting, which keeps the query's spelling in the error)
- star expansion (`select * from USERS` emits schema-cased keys)
- known-table checks (`AnyKnownTable`/`AllKnownTables`/`FirstUnknownTable`)
- CTE-name lookups (the CTE map is consulted through the same table path)
- param typing and INSERT column mapping (`ColumnTypeAt`)

Result keys keep the query's spelling (`SELECT ID` → key `ID`), matching how engines label result columns.

## Tests

`tests/case-insensitive.test-d.ts`: uppercase table+column, mixed case, CTE, qualified, star, strict positive + strict still rejects truly unknown columns, params and INSERT probes. Full suite passes.

Closes #58