### PR TITLE
fix: close strict-mode blind spots for function args, x.* and ambiguous columns

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -356,6 +356,17 @@ type FirstSourceTable<Sources extends Source[]> = Sources extends [
   ? Head['table']
   : '';
 
+type CountBareMatches<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Column extends string,
+  Count extends unknown[] = [],
+> = Sources extends [infer Head extends Source, ...infer Tail extends Source[]]
+  ? [SourceColumnType<DB, Head, Column>] extends [never]
+    ? CountBareMatches<DB, Tail, Column, Count>
+    : CountBareMatches<DB, Tail, Column, [...Count, unknown]>
+  : Count;
+
 type BareColumnType<
   DB extends SchemaLike,
   Sources extends Source[],
@@ -370,7 +381,11 @@ type BareColumnType<
           ? QueryTypeError<`unknown column: ${Column}`>
           : QueryTypeError<`unknown table: ${FirstSourceTable<Sources>}`>
       : unknown
-    : Type
+    : Strict extends true
+      ? CountBareMatches<DB, Sources, Column> extends [unknown, unknown, ...unknown[]]
+        ? QueryTypeError<`ambiguous column: ${Column}`>
+        : Type
+      : Type
   : never;
 
 type FindSourceByName<Sources extends Source[], Name extends string> =
@@ -459,6 +474,62 @@ type ScalarSubqueryType<
         : Row[keyof Row]
   : unknown;
 
+type StripDistinctPrefix<Arg extends string> = IsKeyword<FirstWord<Arg>, 'distinct'> extends true
+  ? Trim<DropFirstWord<Arg>>
+  : Arg;
+
+type FunctionArgError<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Arg extends string,
+> = Arg extends '' | '*' | `${string} ${string}` | `$${string}` | `@${string}` | '?'
+  ? never
+  : StripQualifier<Arg> extends '*'
+    ? never
+    : [LiteralType<Arg>] extends [never]
+      ? IsFunctionCall<Arg> extends true
+        ? FunctionCallError<DB, Sources, Arg>
+        : IsOperatorExpression<Arg> extends true
+          ? never
+          : ResolveColumnType<DB, Sources, Arg, true> extends QueryTypeError<infer Message>
+            ? QueryTypeError<Message>
+            : never
+      : never;
+
+type FirstFunctionArgError<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Args extends string[],
+> = Args extends [infer Head extends string, ...infer Tail extends string[]]
+  ? FunctionArgError<DB, Sources, StripDistinctPrefix<Trim<Head>>> extends infer Error
+    ? [Error] extends [never]
+      ? FirstFunctionArgError<DB, Sources, Tail>
+      : Error
+    : never
+  : never;
+
+type FunctionCallError<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Expression extends string,
+> = Expression extends `${string}(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string }
+    ? Trim<Inner> extends ''
+      ? never
+      : FirstFunctionArgError<DB, Sources, SplitColumnList<Inner>>
+    : never
+  : never;
+
+type StrictFunctionType<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Expression extends string,
+> = FunctionCallError<DB, Sources, Expression> extends infer Error
+  ? [Error] extends [never]
+    ? FunctionReturnType<Expression>
+    : Error
+  : never;
+
 export type ResolveColumnType<
   DB extends SchemaLike,
   Sources extends Source[],
@@ -470,7 +541,9 @@ export type ResolveColumnType<
     : unknown
   : [ScalarSubqueryInner<Expression>] extends [never]
     ? IsFunctionCall<Expression> extends true
-      ? FunctionReturnType<Expression>
+      ? Strict extends true
+        ? StrictFunctionType<DB, Sources, Expression>
+        : FunctionReturnType<Expression>
       : [LiteralType<Expression>] extends [never]
         ? IsOperatorExpression<Expression> extends true
           ? unknown
@@ -558,7 +631,13 @@ type EntryContribution<
 > = Entry[1] extends '*'
   ? MergedStarColumns<DB, Sources>
   : StripQualifier<Entry[1]> extends '*'
-    ? StarColumnsForAlias<DB, Sources, Unquote<Qualifier<Entry[1]>>>
+    ? Strict extends true
+      ? [FindSourceByName<Sources, Unquote<Qualifier<Entry[1]>>>] extends [never]
+        ? {
+            [Key in Entry[1]]: QueryTypeError<`unknown alias: ${Unquote<Qualifier<Entry[1]>>}`>;
+          }
+        : StarColumnsForAlias<DB, Sources, Unquote<Qualifier<Entry[1]>>>
+      : StarColumnsForAlias<DB, Sources, Unquote<Qualifier<Entry[1]>>>
     : { [Key in Entry[0]]: ResolveColumnType<DB, Sources, Entry[1], Strict> };
 
 type BuildMixed<

--- a/tests/strict-blind-spots.test-d.ts
+++ b/tests/strict-blind-spots.test-d.ts
@@ -1,0 +1,92 @@
+import type { Query, StrictRow, StrictQuery, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  posts: { id: number; user_id: number; title: string };
+}
+
+type TypoInsideFunctionArgIsCaught = Expect<
+  Equal<
+    StrictQuery<DB, 'select max(naem) as m from users'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+type ValidFunctionArgResolves = Expect<
+  Equal<StrictRow<DB, 'select max(name) as m from users'>, { m: number }>
+>;
+
+type NestedFunctionArgIsCaught = Expect<
+  Equal<
+    StrictQuery<DB, 'select coalesce(lower(naem)) as m from users'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+type CountStarStillResolves = Expect<
+  Equal<StrictRow<DB, 'select count(*) as total from users'>, { total: number }>
+>;
+
+type CountDistinctColumnValidated = Expect<
+  Equal<
+    StrictQuery<DB, 'select count(distinct naem) as total from users'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+type LiteralFunctionArgSkipsValidation = Expect<
+  Equal<StrictRow<DB, "select coalesce(name, 'anon') as n from users">, { n: unknown }>
+>;
+
+type UnknownAliasStarIsCaught = Expect<
+  Equal<
+    StrictQuery<DB, 'select x.* from users u'>,
+    QueryTypeError<'unknown alias: x'>[]
+  >
+>;
+
+type KnownAliasStarStillResolves = Expect<
+  Equal<StrictRow<DB, 'select u.* from users u'>, { id: number; name: string }>
+>;
+
+type AmbiguousBareColumnIsCaught = Expect<
+  Equal<
+    StrictQuery<DB, 'select id from users u join posts p on u.id = p.user_id'>,
+    QueryTypeError<'ambiguous column: id'>[]
+  >
+>;
+
+type UnambiguousBareColumnAcrossJoinResolves = Expect<
+  Equal<
+    StrictRow<DB, 'select title from users u join posts p on u.id = p.user_id'>,
+    { title: string }
+  >
+>;
+
+type LooseAmbiguityKeepsFirstMatch = Expect<
+  Equal<
+    Query<DB, 'select id from users u join posts p on u.id = p.user_id'>,
+    { id: number }[]
+  >
+>;
+
+export type Assertions = [
+  TypoInsideFunctionArgIsCaught,
+  ValidFunctionArgResolves,
+  NestedFunctionArgIsCaught,
+  CountStarStillResolves,
+  CountDistinctColumnValidated,
+  LiteralFunctionArgSkipsValidation,
+  UnknownAliasStarIsCaught,
+  KnownAliasStarStillResolves,
+  AmbiguousBareColumnIsCaught,
+  UnambiguousBareColumnAcrossJoinResolves,
+  LooseAmbiguityKeepsFirstMatch,
+];


### PR DESCRIPTION
## Problem (#59)

Three verified cases where strict mode failed to flag what it promises to catch:

1. **Columns inside function args were never validated** — `StrictRow<DB, 'select max(naem) as m from users'>` → `{ m: number }`, the typo passed silently.
2. **Unknown alias on qualified star yielded `{}`** — `select x.* from users u` (strict) returned an empty row with no error, while `x.col` correctly errored.
3. **Ambiguous bare columns resolved to the first table** — `select id from users u join posts p ...` typed `id` from `users` even though a real engine rejects the ambiguous reference.

## Fix

1. In strict mode, function-call expressions extract their argument list (paren-aware, comma-split) and validate each **single-token column reference** strictly — including nested function calls and `count(distinct col)`. `*`, `u.*`, literals, placeholders, operator expressions and multi-word args (e.g. `cast(x as int)`) are skipped, so no false positives.
2. Qualified-star entries check `FindSourceByName` in strict mode and surface `QueryTypeError<'unknown alias: x'>`.
3. Bare-column resolution counts matching sources in strict mode; two or more → `QueryTypeError<'ambiguous column: id'>`. Loose mode keeps first-match.

## Tests

`tests/strict-blind-spots.test-d.ts`: typo in arg, valid arg, nested call, `count(*)`, `count(distinct ...)`, literal arg, unknown/known alias star, ambiguous/unambiguous join columns, loose-mode control. Full suite passes.

Closes #59