### PR TITLE
fix: CTE column-list renames, scalar subquery nullability and TOP column guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,7 +783,8 @@ This is a focused tool for the common read path, not a full SQL grammar:
   literal). Schema-qualified tables (`public.users`) resolve by their final
   segment (`users`).
 - **`TOP` supports a plain count, `TOP N PERCENT`, `TOP N WITH TIES`, and
-  `TOP N PERCENT WITH TIES`** (any order of `PERCENT`/`WITH TIES`) — none of
+  `TOP N PERCENT WITH TIES`** (`PERCENT` before `WITH TIES`, the only order
+  T-SQL accepts) — none of
   these affect the inferred row shape, same as `LIMIT`/`OFFSET`. `OUTPUT`
   only recognizes the `inserted`/`deleted` pseudo-table prefixes (they
   resolve against the statement's single table); `OUTPUT ... INTO @table` is

--- a/src/cte.ts
+++ b/src/cte.ts
@@ -1,25 +1,36 @@
-import type { Trim, FirstWord, DropFirstWord, IsKeyword, ExtractParenGroup } from './string.js';
-import type { SchemaLike, Flatten } from './parse.js';
+import type {
+  Trim,
+  FirstWord,
+  DropFirstWord,
+  IsKeyword,
+  ExtractParenGroup,
+  SplitColumnList,
+} from './string.js';
+import type { SchemaLike, Flatten, QueryTypeError, SelectColumnKeys } from './parse.js';
 import type { InferRowWith } from './parse.js';
 
-type CteEntry = [name: string, query: string];
+type CteEntry = [name: string, query: string, columns: string[] | null];
 
 type CteNameAndRest<S extends string> = S extends `${infer NamePart}(${infer AfterOpen}`
   ? NamePart extends `${string} ${string}`
-    ? { name: FirstWord<S>; rest: Trim<DropFirstWord<S>> }
-    : ExtractParenGroup<AfterOpen> extends { rest: infer Rest extends string }
-      ? { name: NamePart; rest: Trim<Rest> }
+    ? { name: FirstWord<S>; columns: null; rest: Trim<DropFirstWord<S>> }
+    : ExtractParenGroup<AfterOpen> extends {
+          inner: infer Cols extends string;
+          rest: infer Rest extends string;
+        }
+      ? { name: Trim<NamePart>; columns: SplitColumnList<Cols>; rest: Trim<Rest> }
       : never
-  : { name: FirstWord<S>; rest: Trim<DropFirstWord<S>> };
+  : { name: FirstWord<S>; columns: null; rest: Trim<DropFirstWord<S>> };
 
 type ParseCteEntry<S extends string> = CteNameAndRest<Trim<S>> extends {
   name: infer Name extends string;
+  columns: infer Columns extends string[] | null;
   rest: infer Rest extends string;
 }
   ? IsKeyword<FirstWord<Rest>, 'as'> extends true
     ? Trim<DropFirstWord<Rest>> extends `(${infer AfterOpen}`
       ? ExtractParenGroup<AfterOpen> extends { inner: infer SubQuery extends string; rest: infer AfterQuery extends string }
-        ? { name: Name; query: Trim<SubQuery>; rest: Trim<AfterQuery> }
+        ? { name: Name; columns: Columns; query: Trim<SubQuery>; rest: Trim<AfterQuery> }
         : never
       : never
     : never
@@ -28,12 +39,13 @@ type ParseCteEntry<S extends string> = CteNameAndRest<Trim<S>> extends {
 type ParseCteList<S extends string, Accumulated extends CteEntry[] = []> =
   ParseCteEntry<S> extends {
     name: infer Name extends string;
+    columns: infer Columns extends string[] | null;
     query: infer Query extends string;
     rest: infer Rest extends string;
   }
     ? Rest extends `,${infer After}`
-      ? ParseCteList<Trim<After>, [...Accumulated, [Name, Query]]>
-      : { ctes: [...Accumulated, [Name, Query]]; rest: Rest }
+      ? ParseCteList<Trim<After>, [...Accumulated, [Name, Query, Columns]]>
+      : { ctes: [...Accumulated, [Name, Query, Columns]]; rest: Rest }
     : never;
 
 type SkipRecursiveKeyword<S extends string> = IsKeyword<FirstWord<S>, 'recursive'> extends true
@@ -49,6 +61,36 @@ export type ParseWithClause<S extends string> = IsKeyword<FirstWord<S>, 'with'> 
     : never
   : never;
 
+type RenameKeys<Row, Keys extends string[], NewNames extends string[]> = NewNames extends [
+  infer NewName extends string,
+  ...infer NewTail extends string[],
+]
+  ? Keys extends [infer OldKey extends string, ...infer OldTail extends string[]]
+    ? { [Key in NewName]: OldKey extends keyof Row ? Row[OldKey] : unknown } & RenameKeys<
+        Row,
+        OldTail,
+        NewTail
+      >
+    : Record<never, never>
+  : Record<never, never>;
+
+type CteRow<
+  DB extends SchemaLike,
+  Query extends string,
+  Columns extends string[] | null,
+  Strict extends boolean,
+> = Flatten<InferRowWith<DB, Query, Strict>> extends infer Row
+  ? Columns extends string[]
+    ? Row extends QueryTypeError<string>
+      ? Row
+      : SelectColumnKeys<Query> extends infer Keys extends string[]
+        ? [Keys] extends [never]
+          ? Row
+          : Flatten<RenameKeys<Row, Keys, Columns>>
+        : Row
+    : Row
+  : never;
+
 export type BuildCteMap<
   DB extends SchemaLike,
   Ctes extends CteEntry[],
@@ -59,6 +101,6 @@ export type BuildCteMap<
       DB,
       Tail,
       Strict,
-      Accumulated & { [Key in Head[0]]: Flatten<InferRowWith<DB & Accumulated, Head[1], Strict>> }
+      Accumulated & { [Key in Head[0]]: CteRow<DB & Accumulated, Head[1], Head[2], Strict> }
     >
   : Accumulated;

--- a/src/params.ts
+++ b/src/params.ts
@@ -252,9 +252,11 @@ type ContainsPlaceholderLikeChar<S extends string> = S extends
   ? true
   : false;
 
-type AnyCteBodyHasPlaceholder<Ctes extends [string, string][]> = Ctes extends [
-  infer Head extends [string, string],
-  ...infer Tail extends [string, string][],
+type CteScanEntry = [name: string, query: string, columns: string[] | null];
+
+type AnyCteBodyHasPlaceholder<Ctes extends CteScanEntry[]> = Ctes extends [
+  infer Head extends CteScanEntry,
+  ...infer Tail extends CteScanEntry[],
 ]
   ? ContainsPlaceholderLikeChar<Head[1]> extends true
     ? true
@@ -263,7 +265,7 @@ type AnyCteBodyHasPlaceholder<Ctes extends [string, string][]> = Ctes extends [
 
 type CteBodiesHavePlaceholder<Q extends string> = [ParseWithClause<Normalize<Q>>] extends [never]
   ? false
-  : ParseWithClause<Normalize<Q>> extends { ctes: infer Ctes extends [string, string][] }
+  : ParseWithClause<Normalize<Q>> extends { ctes: infer Ctes extends CteScanEntry[] }
     ? AnyCteBodyHasPlaceholder<Ctes>
     : false;
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -60,11 +60,19 @@ type StripWithTies<S extends string> = IsKeyword<FirstWord<S>, 'with'> extends t
     : S
   : S;
 
+type HasTopCount<S extends string> = Trim<S> extends `(${string}`
+  ? true
+  : FirstWord<Trim<S>> extends `${number}`
+    ? true
+    : false;
+
 type StripTopClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'top'> extends true
-  ? StripTopCount<DropFirstWord<Trim<S>>> extends infer AfterCount extends string
-    ? IsKeyword<FirstWord<AfterCount>, 'percent'> extends true
-      ? StripWithTies<Trim<DropFirstWord<AfterCount>>>
-      : StripWithTies<AfterCount>
+  ? HasTopCount<DropFirstWord<Trim<S>>> extends true
+    ? StripTopCount<DropFirstWord<Trim<S>>> extends infer AfterCount extends string
+      ? IsKeyword<FirstWord<AfterCount>, 'percent'> extends true
+        ? StripWithTies<Trim<DropFirstWord<AfterCount>>>
+        : StripWithTies<AfterCount>
+      : S
     : S
   : S;
 
@@ -303,6 +311,18 @@ type ParseColumnEntries<Columns extends string[]> = {
   [Index in keyof Columns]: ParseColumnEntry<Columns[Index]>;
 };
 
+type EntryKeyList<Entries extends [string, string][]> = {
+  [Index in keyof Entries]: Entries[Index][0];
+};
+
+export type SelectColumnKeys<Q extends string> = ParseStatementNormalized<Normalize<Q>> extends {
+  columns: infer Columns extends string;
+}
+  ? EntryKeyList<ParseColumnEntries<SplitColumnList<Columns>>> extends infer Keys extends string[]
+    ? Keys
+    : never
+  : never;
+
 type ApplyNull<T, Nullable extends boolean> = Nullable extends true ? T | null : T;
 
 type SourceColumnType<
@@ -460,6 +480,12 @@ type ScalarSubqueryInner<Expression extends string> = Trim<Expression> extends `
 
 type IsUnion<T, U = T> = T extends U ? ([U] extends [T] ? false : true) : never;
 
+type IsCountSubquery<Q extends string> = Lowercase<
+  FirstWord<DropFirstWord<Q>>
+> extends `count(${string}`
+  ? true
+  : false;
+
 type ScalarSubqueryType<
   DB extends SchemaLike,
   Q extends string,
@@ -471,7 +497,9 @@ type ScalarSubqueryType<
       ? Row
       : IsUnion<keyof Row> extends true
         ? unknown
-        : Row[keyof Row]
+        : IsCountSubquery<Q> extends true
+          ? Row[keyof Row]
+          : Row[keyof Row] | null
   : unknown;
 
 type StripDistinctPrefix<Arg extends string> = IsKeyword<FirstWord<Arg>, 'distinct'> extends true
@@ -669,7 +697,7 @@ export type ResolveCteContext<
 > = [ParseWithClause<Normalize<Q>>] extends [never]
   ? { db: DB; query: Normalize<Q> }
   : ParseWithClause<Normalize<Q>> extends {
-        ctes: infer Ctes extends [string, string][];
+        ctes: infer Ctes extends [string, string, string[] | null][];
         rest: infer Rest extends string;
       }
     ? { db: DB & BuildCteMap<DB, Ctes, Strict>; query: Rest }

--- a/tests/cte.test-d.ts
+++ b/tests/cte.test-d.ts
@@ -60,17 +60,17 @@ type WithRecursiveResolvesInStrictModeToo = Expect<
   >
 >;
 
-type CteColumnListDoesNotBreakTheCteName = Expect<
+type CteColumnListRenamesTheColumn = Expect<
   Equal<
     Query<DB, 'with popular(x) as (select id from posts) select x from popular'>,
-    { x: unknown }[]
+    { x: number }[]
   >
 >;
 
-type CteMultiColumnListAlsoResolvesByName = Expect<
+type CteMultiColumnListRenamesPositionally = Expect<
   Equal<
     Query<DB, 'with popular(x, y) as (select id, title from posts) select x, y from popular'>,
-    { x: unknown; y: unknown }[]
+    { x: number; y: string }[]
   >
 >;
 
@@ -105,8 +105,8 @@ export type CteLock = [
   CteStrictUnknownColumnIsTypeError,
   WithRecursiveIsNotConfusedByTheKeyword,
   WithRecursiveResolvesInStrictModeToo,
-  CteColumnListDoesNotBreakTheCteName,
-  CteMultiColumnListAlsoResolvesByName,
+  CteColumnListRenamesTheColumn,
+  CteMultiColumnListRenamesPositionally,
   ParamAfterCteResolvesAgainstCteShape,
   ParamAfterMultipleCtesStillResolves,
   ParamInsideCteBodyFallsBackSafelyInsteadOfClaimingZeroParams,

--- a/tests/paren-boundary.test-d.ts
+++ b/tests/paren-boundary.test-d.ts
@@ -15,14 +15,14 @@ interface DB {
 type ScalarSubqueryKeepsSiblingColumns = Expect<
   Equal<
     Query<DB, 'select (select max(id) from orders) as m, name from users'>,
-    { m: number; name: string }[]
+    { m: number | null; name: string }[]
   >
 >;
 
 type ScalarSubqueryNoAliasFallsBackToRawTextKey = Expect<
   Equal<
     Query<DB, 'select (select max(id) from orders), name from users'>,
-    { '(select max(id) from orders)': number; name: string }[]
+    { '(select max(id) from orders)': number | null; name: string }[]
   >
 >;
 

--- a/tests/parser-edges.test-d.ts
+++ b/tests/parser-edges.test-d.ts
@@ -1,0 +1,71 @@
+import type { Query, StrictQuery, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; top: string };
+  orders: { id: number; total: number };
+}
+
+type CteColumnRenameSingle = Expect<
+  Equal<
+    Query<DB, 'with t(x) as (select id from users) select x from t'>,
+    { x: number }[]
+  >
+>;
+
+type CteColumnRenameStrict = Expect<
+  Equal<
+    StrictQuery<DB, 'with t(x) as (select id from users) select x from t'>,
+    { x: number }[]
+  >
+>;
+
+type CteBodyErrorSurvivesRename = Expect<
+  Equal<
+    StrictQuery<DB, 'with t(x) as (select nope from users) select x from t'>,
+    QueryTypeError<'unknown column: x'>[]
+  >
+>;
+
+type ScalarSubqueryIsNullable = Expect<
+  Equal<
+    Query<DB, 'select (select total from orders) as t from users'>,
+    { t: number | null }[]
+  >
+>;
+
+type ScalarCountSubqueryIsNotNullable = Expect<
+  Equal<
+    Query<DB, 'select (select count(*) from orders) as c from users'>,
+    { c: number }[]
+  >
+>;
+
+type ColumnNamedTopIsNotEaten = Expect<
+  Equal<Query<DB, 'select top from users'>, { top: string }[]>
+>;
+
+type TopWithCountIsStillStripped = Expect<
+  Equal<Query<DB, 'select top 10 id from users'>, { id: number }[]>
+>;
+
+type TopWithParenCountIsStillStripped = Expect<
+  Equal<Query<DB, 'select top (10) id from users'>, { id: number }[]>
+>;
+
+export type Assertions = [
+  CteColumnRenameSingle,
+  CteColumnRenameStrict,
+  CteBodyErrorSurvivesRename,
+  ScalarSubqueryIsNullable,
+  ScalarCountSubqueryIsNotNullable,
+  ColumnNamedTopIsNotEaten,
+  TopWithCountIsStillStripped,
+  TopWithParenCountIsStillStripped,
+];

--- a/tests/scalar-subquery.test-d.ts
+++ b/tests/scalar-subquery.test-d.ts
@@ -25,7 +25,7 @@ type ScalarSubqueryFromTheIssueExample = Expect<
 type ScalarSubqueryAliasedColumnFromInnerTable = Expect<
   Equal<
     Query<DB, 'select id, (select views from posts) as v from users'>,
-    { id: number; v: number }[]
+    { id: number; v: number | null }[]
   >
 >;
 


### PR DESCRIPTION
## Problems (#60)

- **CTE column-list rename parsed then discarded** — `with t(x) as (select id from users) select x from t` → `{ x: unknown }`.
- **Scalar subquery type omitted `| null`** — `(select max(id) from orders) as m` → `number`, but a scalar subquery yields NULL on zero rows.
- **A first select-item column actually named `top` was eaten by `StripTopClause`** — the T-SQL strip ran for every dialect with no count guard.
- **README overpromised TOP modifier order** — only `PERCENT`-first works (which is also the only order real T-SQL accepts).

## Fixes

- `CteNameAndRest` now captures the `(a, b)` column list; `BuildCteMap` renames the CTE row positionally by zipping the list with the body's select-entry keys. Strict-mode errors from the CTE body survive the rename; `select *` bodies fall back to the previous behavior.
- `ScalarSubqueryType` appends `| null`, except when the subquery head is `count(...)` (always returns a row). Existing locks updated accordingly (`max`-subquery probes now `number | null`).
- `TOP` only strips when followed by a numeric count or `(n)` group, so a column named `top` resolves again.
- README TOP claim corrected.

## Tests

`tests/parser-edges.test-d.ts`: single/strict CTE rename, CTE body error propagation, nullable scalar subquery, non-nullable count subquery, `top` column probe, `top 10`/`top (10)` controls. Full suite passes.

Closes #60