### PR TITLE
fix: raise the parser recursion ceiling past 100-column selects

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -673,9 +673,10 @@ type BuildMixed<
   Sources extends Source[],
   Entries extends [string, string][],
   Strict extends boolean,
+  Accumulated = unknown,
 > = Entries extends [infer Head extends [string, string], ...infer Tail extends [string, string][]]
-  ? EntryContribution<DB, Sources, Head, Strict> & BuildMixed<DB, Sources, Tail, Strict>
-  : unknown;
+  ? BuildMixed<DB, Sources, Tail, Strict, Accumulated & EntryContribution<DB, Sources, Head, Strict>>
+  : Accumulated;
 
 type BuildSelection<
   DB extends SchemaLike,

--- a/src/string.ts
+++ b/src/string.ts
@@ -103,41 +103,68 @@ export type DropFirstWord<S extends string> = S extends `${string} ${infer Rest}
 export type IsKeyword<Token extends string, Keyword extends string> =
   Lowercase<Token> extends Lowercase<Keyword> ? true : false;
 
+type SplitAtNextParen<S extends string> = S extends `${infer BeforeOpen}(${infer AfterOpen}`
+  ? BeforeOpen extends `${infer BeforeClose})${infer AfterClose}`
+    ? { before: BeforeClose; marker: ')'; after: `${AfterClose}(${AfterOpen}` }
+    : { before: BeforeOpen; marker: '('; after: AfterOpen }
+  : S extends `${infer BeforeClose})${infer AfterClose}`
+    ? { before: BeforeClose; marker: ')'; after: AfterClose }
+    : never;
+
 type ScanParenGroup<
   S extends string,
   Depth extends unknown[],
   Inner extends string,
-> = S extends `${infer Char}${infer Rest}`
-  ? Char extends '('
-    ? ScanParenGroup<Rest, [...Depth, unknown], `${Inner}${Char}`>
-    : Char extends ')'
-      ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
-        ? ScanParenGroup<Rest, DepthRest, `${Inner}${Char}`>
-        : { inner: Inner; rest: Rest }
-      : ScanParenGroup<Rest, Depth, `${Inner}${Char}`>
-  : { inner: Inner; rest: '' };
+> = [SplitAtNextParen<S>] extends [never]
+  ? { inner: `${Inner}${S}`; rest: '' }
+  : SplitAtNextParen<S> extends {
+        before: infer Before extends string;
+        marker: infer Marker extends string;
+        after: infer After extends string;
+      }
+    ? Marker extends '('
+      ? ScanParenGroup<After, [...Depth, unknown], `${Inner}${Before}(`>
+      : Depth extends [unknown, ...infer DepthRest extends unknown[]]
+        ? ScanParenGroup<After, DepthRest, `${Inner}${Before})`>
+        : { inner: `${Inner}${Before}`; rest: After }
+    : never;
 
 export type ExtractParenGroup<S extends string> = ScanParenGroup<S, [], ''>;
+
+type SplitAtNextListMarker<S extends string> = S extends `${infer BeforeComma},${infer AfterComma}`
+  ? BeforeComma extends `${infer BeforeOpen}(${infer AfterOpen}`
+    ? BeforeOpen extends `${infer BeforeClose})${infer AfterClose}`
+      ? { before: BeforeClose; marker: ')'; after: `${AfterClose}(${AfterOpen},${AfterComma}` }
+      : { before: BeforeOpen; marker: '('; after: `${AfterOpen},${AfterComma}` }
+    : BeforeComma extends `${infer BeforeClose})${infer AfterClose}`
+      ? { before: BeforeClose; marker: ')'; after: `${AfterClose},${AfterComma}` }
+      : { before: BeforeComma; marker: ','; after: AfterComma }
+  : SplitAtNextParen<S>;
 
 type ScanColumnList<
   S extends string,
   Depth extends unknown[],
   Current extends string,
-> = S extends `${infer Char}${infer Rest}`
-  ? Char extends '('
-    ? ScanColumnList<Rest, [...Depth, unknown], `${Current}${Char}`>
-    : Char extends ')'
-      ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
-        ? ScanColumnList<Rest, DepthRest, `${Current}${Char}`>
-        : ScanColumnList<Rest, Depth, `${Current}${Char}`>
-      : Char extends ','
-        ? Depth extends []
-          ? [Trim<Current>, ...ScanColumnList<Rest, Depth, ''>]
-          : ScanColumnList<Rest, Depth, `${Current}${Char}`>
-        : ScanColumnList<Rest, Depth, `${Current}${Char}`>
-  : [Trim<Current>];
+  Accumulated extends string[],
+> = [SplitAtNextListMarker<S>] extends [never]
+  ? [...Accumulated, Trim<`${Current}${S}`>]
+  : SplitAtNextListMarker<S> extends {
+        before: infer Before extends string;
+        marker: infer Marker extends string;
+        after: infer After extends string;
+      }
+    ? Marker extends '('
+      ? ScanColumnList<After, [...Depth, unknown], `${Current}${Before}(`, Accumulated>
+      : Marker extends ')'
+        ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
+          ? ScanColumnList<After, DepthRest, `${Current}${Before})`, Accumulated>
+          : ScanColumnList<After, Depth, `${Current}${Before})`, Accumulated>
+        : Depth extends []
+          ? ScanColumnList<After, Depth, '', [...Accumulated, Trim<`${Current}${Before}`>]>
+          : ScanColumnList<After, Depth, `${Current}${Before},`, Accumulated>
+    : never;
 
-export type SplitColumnList<S extends string> = ScanColumnList<S, [], ''>;
+export type SplitColumnList<S extends string> = ScanColumnList<S, [], '', []>;
 
 export type OpenCount<
   S extends string,

--- a/tests/depth.test-d.ts
+++ b/tests/depth.test-d.ts
@@ -32,6 +32,7 @@ interface Wide {
 
 interface DB {
   wide: Wide;
+  users: { id: number };
 }
 
 type WideRows = Query<
@@ -43,4 +44,14 @@ type WideQueryResolvesEveryColumn = Expect<Equal<WideRows, Wide[]>>;
 
 type DeepColumnTypeResolves = Expect<Equal<WideRows[number]['c20'], string>>;
 
-export type DepthLock = [WideQueryResolvesEveryColumn, DeepColumnTypeResolves];
+type HundredColumnRows = Query<DB, 'select id as c001, id as c002, id as c003, id as c004, id as c005, id as c006, id as c007, id as c008, id as c009, id as c010, id as c011, id as c012, id as c013, id as c014, id as c015, id as c016, id as c017, id as c018, id as c019, id as c020, id as c021, id as c022, id as c023, id as c024, id as c025, id as c026, id as c027, id as c028, id as c029, id as c030, id as c031, id as c032, id as c033, id as c034, id as c035, id as c036, id as c037, id as c038, id as c039, id as c040, id as c041, id as c042, id as c043, id as c044, id as c045, id as c046, id as c047, id as c048, id as c049, id as c050, id as c051, id as c052, id as c053, id as c054, id as c055, id as c056, id as c057, id as c058, id as c059, id as c060, id as c061, id as c062, id as c063, id as c064, id as c065, id as c066, id as c067, id as c068, id as c069, id as c070, id as c071, id as c072, id as c073, id as c074, id as c075, id as c076, id as c077, id as c078, id as c079, id as c080, id as c081, id as c082, id as c083, id as c084, id as c085, id as c086, id as c087, id as c088, id as c089, id as c090, id as c091, id as c092, id as c093, id as c094, id as c095, id as c096, id as c097, id as c098, id as c099, id as c100 from users'>;
+
+type HundredColumnQueryResolves = Expect<
+  Equal<HundredColumnRows, { c001: number; c002: number; c003: number; c004: number; c005: number; c006: number; c007: number; c008: number; c009: number; c010: number; c011: number; c012: number; c013: number; c014: number; c015: number; c016: number; c017: number; c018: number; c019: number; c020: number; c021: number; c022: number; c023: number; c024: number; c025: number; c026: number; c027: number; c028: number; c029: number; c030: number; c031: number; c032: number; c033: number; c034: number; c035: number; c036: number; c037: number; c038: number; c039: number; c040: number; c041: number; c042: number; c043: number; c044: number; c045: number; c046: number; c047: number; c048: number; c049: number; c050: number; c051: number; c052: number; c053: number; c054: number; c055: number; c056: number; c057: number; c058: number; c059: number; c060: number; c061: number; c062: number; c063: number; c064: number; c065: number; c066: number; c067: number; c068: number; c069: number; c070: number; c071: number; c072: number; c073: number; c074: number; c075: number; c076: number; c077: number; c078: number; c079: number; c080: number; c081: number; c082: number; c083: number; c084: number; c085: number; c086: number; c087: number; c088: number; c089: number; c090: number; c091: number; c092: number; c093: number; c094: number; c095: number; c096: number; c097: number; c098: number; c099: number; c100: number }[]>
+>;
+
+export type DepthLock = [
+  WideQueryResolvesEveryColumn,
+  DeepColumnTypeResolves,
+  HundredColumnQueryResolves,
+];


### PR DESCRIPTION
## Problem (#49)

Verified by probes: 45 columns / 825 chars compiled; **48 columns / 879 chars failed** with `TS2589: Type instantiation is excessively deep and possibly infinite`. Independently, a 2-column query whose column list was ~1,100 chars also failed — `ScanColumnList` recursed once per character. Real-world wide tables (50+ columns) could not be typed at all. `tests/depth.test-d.ts` only locked 20 columns, far below the ceiling.

## Fix

- `ScanColumnList` and `ScanParenGroup` now jump from marker to marker (`,` / `(` / `)`) using template-literal splitting with an earliest-marker cascade, instead of consuming one character per recursion — recursion depth is now proportional to the number of markers, not characters.
- The column list accumulates into a tail parameter (no spread-recursion), and `BuildMixed` carries an intersection accumulator, so TypeScript's tail-recursion elimination applies to both (limit ~1000 instead of ~50).
- Explicit `[never]` guards keep the scanners' termination branches reachable.

## Tests

`tests/depth.test-d.ts` now locks a **100-column, 1,216-character** select (plus the original 20-column shape/deep-access locks). Full suite passes.

Closes #49