### PR TITLE
fix: stop generating SQLite INTEGER PRIMARY KEY columns as nullable

### DIFF
--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -35,6 +35,13 @@ interface SqliteTableInfoRow {
   name: string;
   type: string;
   notnull: number;
+  pk: number;
+}
+
+function isRowidAlias(column: SqliteTableInfoRow, primaryKeyCount: number): boolean {
+  return (
+    column.pk > 0 && primaryKeyCount === 1 && column.type.toUpperCase().trim() === 'INTEGER'
+  );
 }
 
 export async function introspectSqlite(connection: ConnectionInfo): Promise<TableSchema[]> {
@@ -63,12 +70,14 @@ export async function introspectSqlite(connection: ConnectionInfo): Promise<Tabl
         .prepare(`PRAGMA table_info(${quoteIdentifier(tableRow.name)})`)
         .all() as unknown as SqliteTableInfoRow[];
 
+      const primaryKeyCount = columns.filter((column) => column.pk > 0).length;
+
       return {
         name: tableRow.name,
         columns: columns.map((column) => ({
           name: column.name,
           tsType: mapSqliteType(column.type),
-          nullable: column.notnull === 0,
+          nullable: column.notnull === 0 && !isRowidAlias(column, primaryKeyCount),
         })),
       };
     });

--- a/tests/cli-generate.test.ts
+++ b/tests/cli-generate.test.ts
@@ -44,7 +44,7 @@ describe('runGenerate (end to end against a real sqlite file)', () => {
       expect(written).toBe(
         'export interface DB {\n' +
           '  users: {\n' +
-          '    id: number | null;\n' +
+          '    id: number;\n' +
           '    name: string;\n' +
           '    bio: string | null;\n' +
           '  };\n' +

--- a/tests/cli-sqlite-introspect.test.ts
+++ b/tests/cli-sqlite-introspect.test.ts
@@ -33,11 +33,29 @@ describe('introspectSqlite', () => {
       expect(tables).toHaveLength(1);
       expect(tables[0]?.name).toBe('users');
       expect(tables[0]?.columns).toEqual([
-        { name: 'id', tsType: 'number', nullable: true },
+        { name: 'id', tsType: 'number', nullable: false },
         { name: 'name', tsType: 'string', nullable: false },
         { name: 'bio', tsType: 'string', nullable: true },
         { name: 'active', tsType: '0 | 1', nullable: false },
       ]);
+    } finally {
+      rmSync(join(file, '..'), { recursive: true, force: true });
+    }
+  });
+
+  it('keeps composite and non-INTEGER primary keys nullable-aware', async () => {
+    const file = withTempDatabase((db) => {
+      db.exec('create table pairs (a integer, b integer, primary key (a, b))');
+      db.exec('create table codes (code text primary key)');
+    });
+
+    try {
+      const tables = await introspectSqlite({ url: file });
+      const pairs = tables.find((table) => table.name === 'pairs');
+      const codes = tables.find((table) => table.name === 'codes');
+
+      expect(pairs?.columns.map((column) => column.nullable)).toEqual([true, true]);
+      expect(codes?.columns[0]?.nullable).toBe(true);
     } finally {
       rmSync(join(file, '..'), { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem (#70)

Nullability was derived only from `notnull === 0`, but `PRAGMA table_info` reports `notnull=0` for `id integer primary key` even though that column is a rowid alias and can never be NULL on read. Every sqlite INTEGER PK was generated `id: number | null`, forcing spurious null checks on all downstream queries. `tests/cli-generate.test.ts` asserted the buggy output as correct.

## Fix

The pragma's `pk` field is now consulted: a **single-column** primary key whose declared type is exactly `INTEGER` (the rowid-alias condition) forces `nullable: false`. Composite PKs and non-INTEGER PKs (`text primary key`) keep pragma-declared nullability — those genuinely admit NULL in legacy rowid tables.

## Tests

- e2e lock updated: generated schema now emits `id: number`.
- Introspector lock updated plus a new case: composite `(a, b)` INTEGER PK and `text primary key` stay nullable.

Full suite passes.

Closes #70