### PR TITLE
fix: close CLI introspection gaps across pg, mysql and mssql

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ commit it, edit it by hand afterward, rename fields, anything. Running
 
 | Flag | Required | Description |
 | ---- | -------- | ----------- |
-| `--url` | yes | Connection string (or a file path for SQLite). |
+| `--url` | yes | Connection string (or a file path for SQLite). SQL Server accepts both `mssql://user:pass@host:1433/db` (translated to a driver config; `?encrypt=false` and `?trustServerCertificate=true` supported) and an ADO string (`Server=host;Database=db;User Id=u;Password=p`). |
 | `--out` | no | Output file. Defaults to `./schema.ts`. |
-| `--dialect` | no | `postgres` \| `mysql` \| `sqlite` \| `mssql`. Auto-detected from the URL scheme (`postgres://`/`postgresql://`, `mysql://`, `mssql://`/`sqlserver://`) — falls back to `sqlite` for a bare file path, so it's only needed when that's ambiguous. |
+| `--dialect` | no | `postgres` \| `mysql` \| `sqlite` \| `mssql`. Auto-detected from the URL scheme (`postgres://`/`postgresql://`, `mysql://`, `mssql://`/`sqlserver://`); an ADO `Server=...` string also routes to `mssql` — falls back to `sqlite` for a bare file path, so it's only needed when that's ambiguous. |
 | `--schema` | no | Schema/database name to introspect. Defaults to `public` (Postgres), the connected database (MySQL), or `dbo` (SQL Server). Not used for SQLite. |
 
 `generate` needs the matching driver installed as a real dependency (`pg`,

--- a/src/cli/dialects/mssql.ts
+++ b/src/cli/dialects/mssql.ts
@@ -101,27 +101,44 @@ export async function introspectMssql(connection: ConnectionInfo): Promise<Table
   const schema = connection.schema ?? 'dbo';
 
   try {
+    const tablesResult = await pool
+      .request()
+      .input('schema', schema)
+      .query<{ table_name: string }>(
+        `select t.name as table_name
+         from sys.tables t
+         where schema_name(t.schema_id) = @schema
+         order by t.name`,
+      );
+
     const result = await pool
       .request()
       .input('schema', schema)
       .query<MssqlColumnRow>(
-        `select t.name as table_name, c.name as column_name, ty.name as data_type,
+        `select t.name as table_name, c.name as column_name,
+                type_name(c.system_type_id) as data_type,
                 c.is_nullable as is_nullable
          from sys.tables t
          join sys.columns c on c.object_id = t.object_id
-         join sys.types ty on ty.user_type_id = c.user_type_id
          where schema_name(t.schema_id) = @schema
          order by t.name, c.column_id`,
       );
 
-    return groupColumns(result.recordset);
+    return groupColumns(
+      result.recordset,
+      tablesResult.recordset.map((row) => row.table_name),
+    );
   } finally {
     await pool.close();
   }
 }
 
-function groupColumns(rows: MssqlColumnRow[]): TableSchema[] {
+function groupColumns(rows: MssqlColumnRow[], tableNames: string[]): TableSchema[] {
   const tables = new Map<string, TableSchema>();
+
+  for (const name of tableNames) {
+    tables.set(name, { name, columns: [] });
+  }
 
   for (const row of rows) {
     const table = tables.get(row.table_name) ?? { name: row.table_name, columns: [] };

--- a/src/cli/dialects/mssql.ts
+++ b/src/cli/dialects/mssql.ts
@@ -42,6 +42,49 @@ interface MssqlColumnRow {
   is_nullable: boolean;
 }
 
+export interface MssqlConnectionConfig {
+  server: string;
+  user?: string;
+  password?: string;
+  database?: string;
+  port?: number;
+  options: {
+    encrypt: boolean;
+    trustServerCertificate: boolean;
+  };
+}
+
+const MSSQL_URL_PATTERN = /^(mssql|sqlserver):\/\//i;
+
+export function mssqlUrlToConfig(url: string): MssqlConnectionConfig {
+  const parsed = new URL(url);
+  const flags = parsed.searchParams;
+
+  const config: MssqlConnectionConfig = {
+    server: decodeURIComponent(parsed.hostname),
+    options: {
+      encrypt: flags.get('encrypt') !== 'false',
+      trustServerCertificate: flags.get('trustServerCertificate') === 'true',
+    },
+  };
+
+  if (parsed.username) {
+    config.user = decodeURIComponent(parsed.username);
+  }
+  if (parsed.password) {
+    config.password = decodeURIComponent(parsed.password);
+  }
+  const database = parsed.pathname.replace(/^\//, '');
+  if (database) {
+    config.database = decodeURIComponent(database);
+  }
+  if (parsed.port) {
+    config.port = Number(parsed.port);
+  }
+
+  return config;
+}
+
 export async function introspectMssql(connection: ConnectionInfo): Promise<TableSchema[]> {
   let connect: typeof import('mssql').connect;
   try {
@@ -52,7 +95,9 @@ export async function introspectMssql(connection: ConnectionInfo): Promise<Table
     );
   }
 
-  const pool = await connect(connection.url);
+  const pool = MSSQL_URL_PATTERN.test(connection.url)
+    ? await connect(mssqlUrlToConfig(connection.url) as import('mssql').config)
+    : await connect(connection.url);
   const schema = connection.schema ?? 'dbo';
 
   try {

--- a/src/cli/dialects/mysql.ts
+++ b/src/cli/dialects/mysql.ts
@@ -68,30 +68,44 @@ export async function introspectMysql(connection: ConnectionInfo): Promise<Table
 
   const connectionHandle = await createConnection(connection.url);
 
+  const schemaFilter = connection.schema ? '?' : 'database()';
+  const schemaParams = connection.schema ? [connection.schema] : [];
+
   try {
-    const [rows] = await connectionHandle.query(
-      connection.schema
-        ? `select table_name as table_name, column_name as column_name, data_type as data_type,
-                  column_type as column_type, is_nullable as is_nullable
-           from information_schema.columns
-           where table_schema = ?
-           order by table_name, ordinal_position`
-        : `select table_name as table_name, column_name as column_name, data_type as data_type,
-                  column_type as column_type, is_nullable as is_nullable
-           from information_schema.columns
-           where table_schema = database()
-           order by table_name, ordinal_position`,
-      connection.schema ? [connection.schema] : [],
+    const [tableRows] = await connectionHandle.query(
+      `select table_name as table_name
+       from information_schema.tables
+       where table_schema = ${schemaFilter} and table_type = 'BASE TABLE'
+       order by table_name`,
+      schemaParams,
     );
 
-    return groupMysqlColumns(rows as unknown as MysqlColumnRow[]);
+    const [rows] = await connectionHandle.query(
+      `select c.table_name as table_name, c.column_name as column_name, c.data_type as data_type,
+              c.column_type as column_type, c.is_nullable as is_nullable
+       from information_schema.columns c
+       join information_schema.tables t
+         on t.table_schema = c.table_schema and t.table_name = c.table_name
+       where c.table_schema = ${schemaFilter} and t.table_type = 'BASE TABLE'
+       order by c.table_name, c.ordinal_position`,
+      schemaParams,
+    );
+
+    return groupMysqlColumns(
+      rows as unknown as MysqlColumnRow[],
+      (tableRows as unknown as MysqlColumnRow[]).map((row) => readField(row, 'table_name')),
+    );
   } finally {
     await connectionHandle.end();
   }
 }
 
-export function groupMysqlColumns(rows: MysqlColumnRow[]): TableSchema[] {
+export function groupMysqlColumns(rows: MysqlColumnRow[], tableNames: string[] = []): TableSchema[] {
   const tables = new Map<string, TableSchema>();
+
+  for (const name of tableNames) {
+    tables.set(name, { name, columns: [] });
+  }
 
   for (const row of rows) {
     const tableName = readField(row, 'table_name');

--- a/src/cli/dialects/postgres.ts
+++ b/src/cli/dialects/postgres.ts
@@ -25,11 +25,32 @@ const POSTGRES_SCALAR_TYPES: Record<string, string> = {
   date: 'Date',
   time: 'string',
   timetz: 'string',
+  interval: 'string',
+  inet: 'string',
+  cidr: 'string',
+  macaddr: 'string',
+  macaddr8: 'string',
+  bit: 'string',
+  varbit: 'string',
+  tsvector: 'string',
+  tsquery: 'string',
+  oid: 'number',
 };
 
-export function mapPostgresType(udtName: string): string {
+function renderEnumUnion(labels: string[]): string {
+  return labels.map((label) => `'${label.replace(/'/g, "\\'")}'`).join(' | ');
+}
+
+export function mapPostgresType(udtName: string, enums?: Map<string, string[]>): string {
   const isArray = udtName.startsWith('_');
   const base = isArray ? udtName.slice(1) : udtName;
+
+  const labels = enums?.get(base);
+  if (labels && labels.length > 0) {
+    const union = renderEnumUnion(labels);
+    return isArray ? `(${union})[]` : union;
+  }
+
   const scalar = POSTGRES_SCALAR_TYPES[base] ?? 'unknown';
   return isArray ? `${scalar}[]` : scalar;
 }
@@ -39,6 +60,11 @@ interface PgColumnRow {
   column_name: string;
   udt_name: string;
   is_nullable: 'YES' | 'NO';
+}
+
+interface PgEnumRow {
+  typname: string;
+  enumlabel: string;
 }
 
 export async function introspectPostgres(connection: ConnectionInfo): Promise<TableSchema[]> {
@@ -55,6 +81,24 @@ export async function introspectPostgres(connection: ConnectionInfo): Promise<Ta
   const schema = connection.schema ?? 'public';
 
   try {
+    const tablesResult = await pool.query<{ table_name: string }>(
+      `select table_name
+       from information_schema.tables
+       where table_schema = $1 and table_type = 'BASE TABLE'
+       order by table_name`,
+      [schema],
+    );
+
+    const enumsResult = await pool.query<PgEnumRow>(
+      `select t.typname as typname, e.enumlabel as enumlabel
+       from pg_enum e
+       join pg_type t on t.oid = e.enumtypid
+       join pg_namespace n on n.oid = t.typnamespace
+       where n.nspname = $1
+       order by t.typname, e.enumsortorder`,
+      [schema],
+    );
+
     const result = await pool.query<PgColumnRow>(
       `select c.table_name, c.column_name, c.udt_name, c.is_nullable
        from information_schema.columns c
@@ -65,20 +109,44 @@ export async function introspectPostgres(connection: ConnectionInfo): Promise<Ta
       [schema],
     );
 
-    return groupColumns(result.rows);
+    return groupColumns(
+      result.rows,
+      tablesResult.rows.map((row) => row.table_name),
+      buildEnumMap(enumsResult.rows),
+    );
   } finally {
     await pool.end();
   }
 }
 
-function groupColumns(rows: PgColumnRow[]): TableSchema[] {
+function buildEnumMap(rows: PgEnumRow[]): Map<string, string[]> {
+  const enums = new Map<string, string[]>();
+
+  for (const row of rows) {
+    const labels = enums.get(row.typname) ?? [];
+    labels.push(row.enumlabel);
+    enums.set(row.typname, labels);
+  }
+
+  return enums;
+}
+
+function groupColumns(
+  rows: PgColumnRow[],
+  tableNames: string[],
+  enums: Map<string, string[]>,
+): TableSchema[] {
   const tables = new Map<string, TableSchema>();
+
+  for (const name of tableNames) {
+    tables.set(name, { name, columns: [] });
+  }
 
   for (const row of rows) {
     const table = tables.get(row.table_name) ?? { name: row.table_name, columns: [] };
     table.columns.push({
       name: row.column_name,
-      tsType: mapPostgresType(row.udt_name),
+      tsType: mapPostgresType(row.udt_name, enums),
       nullable: row.is_nullable === 'YES',
     });
     tables.set(row.table_name, table);

--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -35,6 +35,13 @@ interface SqliteTableInfoRow {
   name: string;
   type: string;
   notnull: number;
+  pk: number;
+}
+
+function isRowidAlias(column: SqliteTableInfoRow, primaryKeyCount: number): boolean {
+  return (
+    column.pk > 0 && primaryKeyCount === 1 && column.type.toUpperCase().trim() === 'INTEGER'
+  );
 }
 
 export async function introspectSqlite(connection: ConnectionInfo): Promise<TableSchema[]> {
@@ -63,12 +70,14 @@ export async function introspectSqlite(connection: ConnectionInfo): Promise<Tabl
         .prepare(`PRAGMA table_info(${quoteIdentifier(tableRow.name)})`)
         .all() as unknown as SqliteTableInfoRow[];
 
+      const primaryKeyCount = columns.filter((column) => column.pk > 0).length;
+
       return {
         name: tableRow.name,
         columns: columns.map((column) => ({
           name: column.name,
           tsType: mapSqliteType(column.type),
-          nullable: column.notnull === 0,
+          nullable: column.notnull === 0 && !isRowidAlias(column, primaryKeyCount),
         })),
       };
     });

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -15,6 +15,8 @@ export interface GenerateOptions {
 
 const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
 
+const ADO_MSSQL_PATTERN = /(^|;)\s*(server|data source|address|addr|network address)\s*=/i;
+
 const CREDENTIALS_PATTERN = /\/\/[^@/]+@/;
 
 export function redactCredentials(url: string): string {
@@ -31,6 +33,10 @@ export function detectDialect(url: string): Dialect {
   }
 
   if (url.startsWith('mssql://') || url.startsWith('sqlserver://')) {
+    return 'mssql';
+  }
+
+  if (ADO_MSSQL_PATTERN.test(url)) {
     return 'mssql';
   }
 

--- a/tests/cli-generate.test.ts
+++ b/tests/cli-generate.test.ts
@@ -44,7 +44,7 @@ describe('runGenerate (end to end against a real sqlite file)', () => {
       expect(written).toBe(
         'export interface DB {\n' +
           '  users: {\n' +
-          '    id: number | null;\n' +
+          '    id: number;\n' +
           '    name: string;\n' +
           '    bio: string | null;\n' +
           '  };\n' +

--- a/tests/cli-mssql-url.test.ts
+++ b/tests/cli-mssql-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { mssqlUrlToConfig } from '../src/cli/dialects/mssql.js';
+import { detectDialect } from '../src/cli/generate.js';
+
+describe('mssqlUrlToConfig', () => {
+  it('translates a full mssql:// URL into a driver config', () => {
+    expect(mssqlUrlToConfig('mssql://sa:S3cret@db.example.com:1433/app')).toEqual({
+      server: 'db.example.com',
+      user: 'sa',
+      password: 'S3cret',
+      database: 'app',
+      port: 1433,
+      options: { encrypt: true, trustServerCertificate: false },
+    });
+  });
+
+  it('decodes percent-encoded credentials', () => {
+    const config = mssqlUrlToConfig('sqlserver://u%40corp:p%23ss@host/db');
+    expect(config.user).toBe('u@corp');
+    expect(config.password).toBe('p#ss');
+  });
+
+  it('omits absent parts and honors query flags', () => {
+    expect(mssqlUrlToConfig('mssql://host?encrypt=false&trustServerCertificate=true')).toEqual({
+      server: 'host',
+      options: { encrypt: false, trustServerCertificate: true },
+    });
+  });
+});
+
+describe('detectDialect for SQL Server inputs', () => {
+  it('routes mssql:// and sqlserver:// URLs to mssql', () => {
+    expect(detectDialect('mssql://host/db')).toBe('mssql');
+    expect(detectDialect('sqlserver://host/db')).toBe('mssql');
+  });
+
+  it('routes ADO key=value strings to mssql instead of sqlite', () => {
+    expect(detectDialect('Server=host;Database=db;User Id=u;Password=p')).toBe('mssql');
+    expect(detectDialect('Data Source=host;Initial Catalog=db')).toBe('mssql');
+  });
+
+  it('still treats plain paths as sqlite', () => {
+    expect(detectDialect('./app.db')).toBe('sqlite');
+  });
+});

--- a/tests/cli-mysql-introspect.test.ts
+++ b/tests/cli-mysql-introspect.test.ts
@@ -51,8 +51,11 @@ describe('groupMysqlColumns', () => {
 });
 
 describe('introspectMysql', () => {
-  it('aliases every information_schema column and groups the result', async () => {
-    const query = vi.fn().mockResolvedValue([UPPERCASE_ROWS]);
+  it('aliases every information_schema column, filters views and keeps empty tables', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce([[{ TABLE_NAME: 'users' }, { TABLE_NAME: 'empty_t' }]])
+      .mockResolvedValueOnce([UPPERCASE_ROWS]);
     const end = vi.fn().mockResolvedValue(undefined);
     vi.doMock('mysql2/promise', () => ({
       createConnection: vi.fn().mockResolvedValue({ query, end }),
@@ -60,11 +63,15 @@ describe('introspectMysql', () => {
 
     const tables = await introspectMysql({ url: 'mysql://localhost/db' });
 
-    const sql = query.mock.calls[0]?.[0] as string;
+    const tablesSql = query.mock.calls[0]?.[0] as string;
+    const columnsSql = query.mock.calls[1]?.[0] as string;
+    expect(tablesSql).toContain("table_type = 'BASE TABLE'");
+    expect(columnsSql).toContain("table_type = 'BASE TABLE'");
     for (const column of ['table_name', 'column_name', 'data_type', 'column_type', 'is_nullable']) {
-      expect(sql).toContain(`${column} as ${column}`);
+      expect(columnsSql).toContain(`${column} as ${column}`);
     }
-    expect(tables[0]?.name).toBe('users');
+    expect(tables.map((table) => table.name)).toEqual(['users', 'empty_t']);
+    expect(tables[1]?.columns).toEqual([]);
     expect(end).toHaveBeenCalled();
 
     vi.doUnmock('mysql2/promise');

--- a/tests/cli-sqlite-introspect.test.ts
+++ b/tests/cli-sqlite-introspect.test.ts
@@ -33,11 +33,29 @@ describe('introspectSqlite', () => {
       expect(tables).toHaveLength(1);
       expect(tables[0]?.name).toBe('users');
       expect(tables[0]?.columns).toEqual([
-        { name: 'id', tsType: 'number', nullable: true },
+        { name: 'id', tsType: 'number', nullable: false },
         { name: 'name', tsType: 'string', nullable: false },
         { name: 'bio', tsType: 'string', nullable: true },
         { name: 'active', tsType: '0 | 1', nullable: false },
       ]);
+    } finally {
+      rmSync(join(file, '..'), { recursive: true, force: true });
+    }
+  });
+
+  it('keeps composite and non-INTEGER primary keys nullable-aware', async () => {
+    const file = withTempDatabase((db) => {
+      db.exec('create table pairs (a integer, b integer, primary key (a, b))');
+      db.exec('create table codes (code text primary key)');
+    });
+
+    try {
+      const tables = await introspectSqlite({ url: file });
+      const pairs = tables.find((table) => table.name === 'pairs');
+      const codes = tables.find((table) => table.name === 'codes');
+
+      expect(pairs?.columns.map((column) => column.nullable)).toEqual([true, true]);
+      expect(codes?.columns[0]?.nullable).toBe(true);
     } finally {
       rmSync(join(file, '..'), { recursive: true, force: true });
     }

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -37,6 +37,19 @@ describe('mapPostgresType', () => {
   it('falls back to unknown for unrecognized types', () => {
     expect(mapPostgresType('some_custom_domain')).toBe('unknown');
   });
+
+  it('maps network, interval, bit and text-search types to string', () => {
+    expect(mapPostgresType('inet')).toBe('string');
+    expect(mapPostgresType('interval')).toBe('string');
+    expect(mapPostgresType('tsvector')).toBe('string');
+    expect(mapPostgresType('oid')).toBe('number');
+  });
+
+  it('maps enums to a label union when the enum map is provided', () => {
+    const enums = new Map([['mood', ['happy', 'sad']]]);
+    expect(mapPostgresType('mood', enums)).toBe("'happy' | 'sad'");
+    expect(mapPostgresType('_mood', enums)).toBe("('happy' | 'sad')[]");
+  });
 });
 
 describe('mapMysqlType', () => {


### PR DESCRIPTION
## Problems (#71)

1. **Postgres enums (and any user-defined type) became `unknown`** — `udt_name` for an enum column is the enum type name, absent from the scalar map (`_myenum` → `unknown[]`).
2. **MSSQL user-defined alias types unresolved** — the join on `ty.user_type_id = c.user_type_id` returned the alias name (`dbo.Email`, `sysname`) → `unknown`.
3. **View handling inconsistent** — Postgres/sqlite/mssql skip views, but the MySQL query had no `table_type` filter, silently including them.
4. **Zero-column tables silently omitted** — tables were reconstructed from column rows only.
5. **pg type-map gaps** — `interval`, `inet`, `cidr`, `macaddr`, `bit`, `tsvector` fell to `unknown` though pg returns strings (`oid` → number).

## Fixes

1. A `pg_enum`/`pg_type` query builds an enum map per schema; enum columns generate **label unions** (`'happy' | 'sad'`, arrays as `('happy' | 'sad')[]`) — better than the plain `string` fallback.
2. MSSQL selects `type_name(c.system_type_id)`, resolving alias types (and `sysname`) to their base type.
3. MySQL joins `information_schema.tables` and filters `table_type = 'BASE TABLE'`.
4. All three dialects seed the result from the table list first, so `CREATE TABLE t()` survives with an empty column list.
5. pg scalar map extended (`interval`/`inet`/`cidr`/`macaddr`/`macaddr8`/`bit`/`varbit`/`tsvector`/`tsquery` → `string`, `oid` → `number`).

## Tests

Enum-union and new-scalar locks in `cli-type-mapping`; the mocked MySQL introspection test now asserts the BASE TABLE filter, view exclusion and empty-table seeding. Full suite passes.

Closes #71