### PR TITLE
feat: write metadata, driver error messages and opt-in placeholder-style checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,24 +582,20 @@ Swap `createPgExecutor` for `createMysql2Executor`/`createPostgresJsExecutor`/
 `createNodeSqliteExecutor` depending on which Drizzle driver you're using —
 `$client` is always the native driver instance underneath.
 
-**mssql (SQL Server)** (no dedicated adapter — `mssql` binds parameters by
-name rather than by position, so the executor needs a couple of extra lines)
+**mssql (SQL Server)**
 
 ```ts
 import sql from 'mssql';
+import { createMssqlExecutor } from '@owlsql/core/mssql';
+
 const pool = await sql.connect({ /* ... */ });
-const db = createTypedDb<DB>(async (query, params) => {
-  const request = pool.request();
-  params.forEach((value, index) => request.input(`p${index + 1}`, value));
-  const result = await request.query(query);
-  return result.recordset;
-});
+const db = createTypedDb<DB>(createMssqlExecutor(pool));
 ```
 
-`mssql` binds named parameters (`request.input('name', value)`), so build the
-query with matching `@pN` placeholders — `Params<DB, Q>` still gives you a
-positional tuple typed against the query's `@` placeholders, in the order they
-appear.
+The adapter scans the query for `@name` placeholders (skipping string
+literals and `@@` system variables) and binds each one by name via
+`request.input(...)`, in order of first appearance — matching how
+`Params<DB, Q>` types the positional tuple. A repeated `@name` binds once.
 
 ## Database support
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,26 @@ For this to work, write the comparison **with spaces around the operator**
 (`id = $1`, not `id=$1`) — that is what lets the compiler see the column,
 operator, and placeholder as separate tokens.
 
+**Placeholder-style checking (opt-in).** The type layer accepts `$n`, `?` and
+`@name` interchangeably, but each driver only understands its own style — `?`
+with the pg adapter is a runtime syntax error. Declare the style your executor
+expects and mismatches become compile errors:
+
+```ts
+const db = createTypedDb<DB, { placeholders: 'dollar' }>(createPgExecutor(pool));
+
+// @ts-expect-error '?' is not a pg placeholder — use $1
+await db.query('select id from users where id = ?', 1);
+```
+
+Styles: `'dollar'` (pg, postgres.js), `'question'` (mysql2), `'at'` (mssql).
+`node:sqlite` accepts all three, so leave the option off there.
+
+**Write metadata.** Adapters report driver metadata alongside the rows: on a
+successful `Result`, `result.meta?.rowCount` carries the affected-row count
+and `result.meta?.lastInsertRowid` the generated id (where the driver
+provides one), so an INSERT without `RETURNING` is no longer a black box.
+
 ### 11. Transactions
 
 There is no built-in transaction API yet — and there is a footgun to know

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ No install, no database — see [`examples/playground`](examples/playground).
   - [8. Strict mode — turn typos into type errors](#8-strict-mode--turn-typos-into-type-errors)
   - [9. Joins](#9-joins)
   - [10. Typed parameters](#10-typed-parameters)
+  - [11. Transactions](#11-transactions)
 - [Driver recipes](#driver-recipes)
 - [Database support](#database-support)
 - [Editor autocomplete](#editor-autocomplete)
@@ -451,6 +452,48 @@ across joins (`where p.views > $1` resolves against the aliased table). Use the
 For this to work, write the comparison **with spaces around the operator**
 (`id = $1`, not `id=$1`) — that is what lets the compiler see the column,
 operator, and placeholder as separate tokens.
+
+### 11. Transactions
+
+There is no built-in transaction API yet — and there is a footgun to know
+about: **never run `BEGIN`/`COMMIT` through an executor bound to a pool.**
+Each `query()` may check out a *different* connection, so `BEGIN` runs on
+connection A and `COMMIT` on connection B, leaving an open transaction (and
+its locks) on a pooled connection that is later handed to another caller.
+
+The adapters accept anything with the right `query`/`execute` shape — a
+`pg.Pool`, `pg.Client` or `pg.PoolClient`; a mysql2 `Pool` or `Connection` —
+so pin one connection and scope a client to it:
+
+```ts
+import { Pool } from 'pg';
+import { createTypedDb } from '@owlsql/core';
+import { createPgExecutor } from '@owlsql/core/pg';
+
+const pool = new Pool();
+
+async function transferFunds(from: number, to: number, amount: number) {
+  const client = await pool.connect();
+  const tx = createTypedDb<DB>(createPgExecutor(client));
+
+  try {
+    await client.query('begin');
+    await tx.query('update accounts set balance = balance - $1 where id = $2', amount, from);
+    await tx.query('update accounts set balance = balance + $1 where id = $2', amount, to);
+    await client.query('commit');
+  } catch (error) {
+    await client.query('rollback');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+```
+
+postgres.js has its own `sql.begin(...)` — build the executor from the
+transaction-scoped `sql` it hands you. Kysely users should use Kysely's
+`db.transaction()`. `node:sqlite` is a single connection, so plain
+`begin`/`commit` statements are safe there.
 
 ## Driver recipes
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
       "types": "./dist/adapters/node-sqlite.d.ts",
       "import": "./dist/adapters/node-sqlite.js"
     },
+    "./mssql": {
+      "types": "./dist/adapters/mssql.d.ts",
+      "import": "./dist/adapters/mssql.js"
+    },
     "./kysely": {
       "types": "./dist/adapters/kysely.d.ts",
       "import": "./dist/adapters/kysely.js"

--- a/src/adapters/kysely.ts
+++ b/src/adapters/kysely.ts
@@ -1,9 +1,16 @@
 import { CompiledQuery, type Kysely } from 'kysely';
-import type { Executor } from '../index.js';
+import type { Executor, QueryMeta } from '../index.js';
 
 export function createKyselyExecutor<DB>(db: Kysely<DB>): Executor {
   return async (sql, params) => {
     const result = await db.executeQuery(CompiledQuery.raw(sql, params as unknown[]));
-    return result.rows;
+    const meta: QueryMeta = {};
+    if (typeof result.numAffectedRows === 'bigint') {
+      meta.rowCount = result.numAffectedRows;
+    }
+    if (typeof result.insertId === 'bigint') {
+      meta.lastInsertRowid = result.insertId;
+    }
+    return { rows: [...result.rows], meta };
   };
 }

--- a/src/adapters/mssql.ts
+++ b/src/adapters/mssql.ts
@@ -1,0 +1,18 @@
+import type { ConnectionPool } from 'mssql';
+import type { Executor } from '../index.js';
+import { collectNamedParameters } from './named-params.js';
+
+const MSSQL_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@']);
+
+export function createMssqlExecutor(pool: ConnectionPool): Executor {
+  return async (sql, params) => {
+    const request = pool.request();
+
+    collectNamedParameters(sql, MSSQL_PARAM_PREFIXES).forEach((name, index) => {
+      request.input(name.slice(1), params[index] ?? null);
+    });
+
+    const result = await request.query(sql);
+    return result.recordset ?? [];
+  };
+}

--- a/src/adapters/mssql.ts
+++ b/src/adapters/mssql.ts
@@ -1,10 +1,10 @@
 import type { ConnectionPool } from 'mssql';
-import type { Executor } from '../index.js';
+import type { DialectExecutor, QueryMeta } from '../index.js';
 import { collectNamedParameters } from './named-params.js';
 
 const MSSQL_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@']);
 
-export function createMssqlExecutor(pool: ConnectionPool): Executor {
+export function createMssqlExecutor(pool: ConnectionPool): DialectExecutor<'at'> {
   return async (sql, params) => {
     const request = pool.request();
 
@@ -13,6 +13,10 @@ export function createMssqlExecutor(pool: ConnectionPool): Executor {
     });
 
     const result = await request.query(sql);
-    return result.recordset ?? [];
+    const meta: QueryMeta = {};
+    if (typeof result.rowsAffected?.[0] === 'number') {
+      meta.rowCount = result.rowsAffected[0];
+    }
+    return { rows: result.recordset ?? [], meta };
   };
 }

--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -1,9 +1,10 @@
 import type { Pool } from 'mysql2/promise';
+import type { ExecuteValues } from 'mysql2';
 import type { Executor } from '../index.js';
 
 export function createMysql2Executor(pool: Pool): Executor {
   return async (sql, params) => {
-    const [rows] = await pool.query(sql, params as unknown[]);
-    return rows as unknown[];
+    const [rows] = await pool.execute(sql, params as ExecuteValues);
+    return Array.isArray(rows) ? rows : [];
   };
 }

--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -1,12 +1,26 @@
 import type { Pool, Connection } from 'mysql2/promise';
 import type { ExecuteValues } from 'mysql2';
-import type { Executor } from '../index.js';
+import type { DialectExecutor, QueryMeta } from '../index.js';
 
 export type Mysql2Queryable = Pool | Connection;
 
-export function createMysql2Executor(connection: Mysql2Queryable): Executor {
+function writeMeta(header: { affectedRows?: number; insertId?: number }): QueryMeta {
+  const meta: QueryMeta = {};
+  if (typeof header.affectedRows === 'number') {
+    meta.rowCount = header.affectedRows;
+  }
+  if (typeof header.insertId === 'number' && header.insertId !== 0) {
+    meta.lastInsertRowid = header.insertId;
+  }
+  return meta;
+}
+
+export function createMysql2Executor(connection: Mysql2Queryable): DialectExecutor<'question'> {
   return async (sql, params) => {
     const [rows] = await connection.execute(sql, params as ExecuteValues);
-    return Array.isArray(rows) ? rows : [];
+    if (Array.isArray(rows)) {
+      return rows;
+    }
+    return { rows: [], meta: writeMeta(rows as { affectedRows?: number; insertId?: number }) };
   };
 }

--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -1,10 +1,12 @@
-import type { Pool } from 'mysql2/promise';
+import type { Pool, Connection } from 'mysql2/promise';
 import type { ExecuteValues } from 'mysql2';
 import type { Executor } from '../index.js';
 
-export function createMysql2Executor(pool: Pool): Executor {
+export type Mysql2Queryable = Pool | Connection;
+
+export function createMysql2Executor(connection: Mysql2Queryable): Executor {
   return async (sql, params) => {
-    const [rows] = await pool.execute(sql, params as ExecuteValues);
+    const [rows] = await connection.execute(sql, params as ExecuteValues);
     return Array.isArray(rows) ? rows : [];
   };
 }

--- a/src/adapters/named-params.ts
+++ b/src/adapters/named-params.ts
@@ -1,0 +1,36 @@
+const NAMED_PARAM_BODY = /^[A-Za-z0-9_]+/;
+
+export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string>): string[] {
+  const names: string[] = [];
+  let insideLiteral = false;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index] as string;
+
+    if (char === "'") {
+      insideLiteral = !insideLiteral;
+      continue;
+    }
+    if (insideLiteral) {
+      continue;
+    }
+
+    if (prefixes.has(char)) {
+      if (sql[index + 1] === char) {
+        index += 1;
+        continue;
+      }
+
+      const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
+      if (body) {
+        const name = `${char}${body[0]}`;
+        if (!names.includes(name)) {
+          names.push(name);
+        }
+        index += body[0].length;
+      }
+    }
+  }
+
+  return names;
+}

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -1,11 +1,10 @@
 import type { DatabaseSync } from 'node:sqlite';
 import type { Executor } from '../index.js';
+import { collectNamedParameters } from './named-params.js';
 
 type SqliteParam = null | number | bigint | string | NodeJS.ArrayBufferView;
 
-const NAMED_PARAM_PREFIXES = new Set(['@', '$', ':']);
-
-const NAMED_PARAM_BODY = /^[A-Za-z0-9_]+/;
+const SQLITE_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@', '$', ':']);
 
 function toSqliteValue(value: unknown): SqliteParam {
   if (typeof value === 'boolean') {
@@ -20,41 +19,11 @@ function toSqliteValue(value: unknown): SqliteParam {
   return value as SqliteParam;
 }
 
-export function collectNamedParameters(sql: string): string[] {
-  const names: string[] = [];
-  let insideLiteral = false;
-
-  for (let index = 0; index < sql.length; index += 1) {
-    const char = sql[index] as string;
-
-    if (char === "'") {
-      insideLiteral = !insideLiteral;
-      continue;
-    }
-    if (insideLiteral) {
-      continue;
-    }
-
-    if (NAMED_PARAM_PREFIXES.has(char)) {
-      const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
-      if (body) {
-        const name = `${char}${body[0]}`;
-        if (!names.includes(name)) {
-          names.push(name);
-        }
-        index += body[0].length;
-      }
-    }
-  }
-
-  return names;
-}
-
 export function createNodeSqliteExecutor(db: DatabaseSync): Executor {
   return async (sql, params) => {
     const statement = db.prepare(sql);
     const values = params.map(toSqliteValue);
-    const namedParameters = collectNamedParameters(sql);
+    const namedParameters = collectNamedParameters(sql, SQLITE_PARAM_PREFIXES);
 
     if (namedParameters.length > 0) {
       const bag: Record<string, SqliteParam> = {};

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from 'node:sqlite';
-import type { Executor } from '../index.js';
+import type { DialectExecutor } from '../index.js';
 import { collectNamedParameters } from './named-params.js';
 
 type SqliteParam = null | number | bigint | string | NodeJS.ArrayBufferView;
@@ -19,7 +19,9 @@ function toSqliteValue(value: unknown): SqliteParam {
   return value as SqliteParam;
 }
 
-export function createNodeSqliteExecutor(db: DatabaseSync): Executor {
+export function createNodeSqliteExecutor(
+  db: DatabaseSync,
+): DialectExecutor<'question' | 'at' | 'dollar'> {
   return async (sql, params) => {
     const statement = db.prepare(sql);
     const values = params.map(toSqliteValue);

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -3,8 +3,67 @@ import type { Executor } from '../index.js';
 
 type SqliteParam = null | number | bigint | string | NodeJS.ArrayBufferView;
 
+const NAMED_PARAM_PREFIXES = new Set(['@', '$', ':']);
+
+const NAMED_PARAM_BODY = /^[A-Za-z0-9_]+/;
+
+function toSqliteValue(value: unknown): SqliteParam {
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (value === undefined) {
+    return null;
+  }
+  return value as SqliteParam;
+}
+
+export function collectNamedParameters(sql: string): string[] {
+  const names: string[] = [];
+  let insideLiteral = false;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index] as string;
+
+    if (char === "'") {
+      insideLiteral = !insideLiteral;
+      continue;
+    }
+    if (insideLiteral) {
+      continue;
+    }
+
+    if (NAMED_PARAM_PREFIXES.has(char)) {
+      const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
+      if (body) {
+        const name = `${char}${body[0]}`;
+        if (!names.includes(name)) {
+          names.push(name);
+        }
+        index += body[0].length;
+      }
+    }
+  }
+
+  return names;
+}
+
 export function createNodeSqliteExecutor(db: DatabaseSync): Executor {
   return async (sql, params) => {
-    return db.prepare(sql).all(...(params as unknown as SqliteParam[]));
+    const statement = db.prepare(sql);
+    const values = params.map(toSqliteValue);
+    const namedParameters = collectNamedParameters(sql);
+
+    if (namedParameters.length > 0) {
+      const bag: Record<string, SqliteParam> = {};
+      namedParameters.forEach((name, index) => {
+        bag[name] = values[index] ?? null;
+      });
+      return statement.all(bag);
+    }
+
+    return statement.all(...values);
   };
 }

--- a/src/adapters/pg.ts
+++ b/src/adapters/pg.ts
@@ -1,11 +1,16 @@
 import type { Pool, Client, PoolClient } from 'pg';
-import type { Executor } from '../index.js';
+import type { DialectExecutor } from '../index.js';
 
 export type PgQueryable = Pool | Client | PoolClient;
 
-export function createPgExecutor(client: PgQueryable): Executor {
+export function createPgExecutor(client: PgQueryable): DialectExecutor<'dollar'> {
   return async (sql, params) => {
-    const result = await client.query(sql, params as unknown[]);
-    return result.rows;
+    const result =
+      params.length === 0 ? await client.query(sql) : await client.query(sql, params as unknown[]);
+
+    return {
+      rows: result.rows,
+      meta: result.rowCount === null ? {} : { rowCount: result.rowCount },
+    };
   };
 }

--- a/src/adapters/pg.ts
+++ b/src/adapters/pg.ts
@@ -1,9 +1,11 @@
-import type { Pool } from 'pg';
+import type { Pool, Client, PoolClient } from 'pg';
 import type { Executor } from '../index.js';
 
-export function createPgExecutor(pool: Pool): Executor {
+export type PgQueryable = Pool | Client | PoolClient;
+
+export function createPgExecutor(client: PgQueryable): Executor {
   return async (sql, params) => {
-    const result = await pool.query(sql, params as unknown[]);
+    const result = await client.query(sql, params as unknown[]);
     return result.rows;
   };
 }

--- a/src/adapters/postgres.ts
+++ b/src/adapters/postgres.ts
@@ -1,10 +1,14 @@
 import type postgres from 'postgres';
-import type { Executor } from '../index.js';
+import type { DialectExecutor } from '../index.js';
 
 type PostgresUnsafeParam = NonNullable<Parameters<postgres.Sql['unsafe']>[1]>[number];
 
-export function createPostgresJsExecutor(client: postgres.Sql): Executor {
+export function createPostgresJsExecutor(client: postgres.Sql): DialectExecutor<'dollar'> {
   return async (sql, params) => {
-    return client.unsafe(sql, params as unknown as PostgresUnsafeParam[]);
+    const result = await client.unsafe(sql, params as unknown as PostgresUnsafeParam[]);
+    return {
+      rows: [...result],
+      meta: typeof result.count === 'number' ? { rowCount: result.count } : {},
+    };
   };
 }

--- a/src/cli/dialects/mssql.ts
+++ b/src/cli/dialects/mssql.ts
@@ -129,7 +129,7 @@ export async function introspectMssql(connection: ConnectionInfo): Promise<Table
       tablesResult.recordset.map((row) => row.table_name),
     );
   } finally {
-    await pool.close();
+    await pool.close().catch(() => undefined);
   }
 }
 

--- a/src/cli/dialects/mysql.ts
+++ b/src/cli/dialects/mysql.ts
@@ -96,7 +96,7 @@ export async function introspectMysql(connection: ConnectionInfo): Promise<Table
       (tableRows as unknown as MysqlColumnRow[]).map((row) => readField(row, 'table_name')),
     );
   } finally {
-    await connectionHandle.end();
+    await connectionHandle.end().catch(() => undefined);
   }
 }
 

--- a/src/cli/dialects/postgres.ts
+++ b/src/cli/dialects/postgres.ts
@@ -115,7 +115,7 @@ export async function introspectPostgres(connection: ConnectionInfo): Promise<Ta
       buildEnumMap(enumsResult.rows),
     );
   } finally {
-    await pool.end();
+    await pool.end().catch(() => undefined);
   }
 }
 

--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -44,6 +44,21 @@ function isRowidAlias(column: SqliteTableInfoRow, primaryKeyCount: number): bool
   );
 }
 
+const SQLITE_URL_PREFIXES = ['sqlite://', 'sqlite:', 'file://'];
+
+export function normalizeSqlitePath(url: string): string {
+  for (const prefix of SQLITE_URL_PREFIXES) {
+    if (url.startsWith(prefix)) {
+      return url.slice(prefix.length);
+    }
+  }
+  return url;
+}
+
+function isMemoryDatabase(path: string): boolean {
+  return path === ':memory:' || path.startsWith('file::memory:');
+}
+
 export async function introspectSqlite(connection: ConnectionInfo): Promise<TableSchema[]> {
   let DatabaseSyncCtor: typeof import('node:sqlite').DatabaseSync;
   try {
@@ -54,11 +69,15 @@ export async function introspectSqlite(connection: ConnectionInfo): Promise<Tabl
     );
   }
 
-  if (connection.url !== ':memory:' && !existsSync(connection.url)) {
-    throw new Error(`SQLite database file not found: "${connection.url}".`);
+  const path = connection.url.startsWith('file::memory:')
+    ? connection.url
+    : normalizeSqlitePath(connection.url);
+
+  if (!isMemoryDatabase(path) && !existsSync(path)) {
+    throw new Error(`SQLite database file not found: "${path}".`);
   }
 
-  const db = new DatabaseSyncCtor(connection.url);
+  const db = new DatabaseSyncCtor(path, { readOnly: !isMemoryDatabase(path) });
 
   try {
     const tableRows = db

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -11,6 +11,8 @@ export interface GenerateOptions {
   out: string;
   dialect?: Dialect | undefined;
   schema?: string | undefined;
+  tables?: string[] | undefined;
+  exclude?: string[] | undefined;
 }
 
 const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
@@ -30,6 +32,10 @@ export function detectDialect(url: string): Dialect {
 
   if (url.startsWith('mysql://')) {
     return 'mysql';
+  }
+
+  if (url.startsWith('sqlite://') || url.startsWith('sqlite:') || url.startsWith('file:')) {
+    return 'sqlite';
   }
 
   if (url.startsWith('mssql://') || url.startsWith('sqlserver://')) {
@@ -56,16 +62,50 @@ const INTROSPECTORS: Record<Dialect, (connection: ConnectionInfo) => Promise<Tab
   mssql: introspectMssql,
 };
 
+function filterTables(tables: TableSchema[], options: GenerateOptions): TableSchema[] {
+  const include = options.tables?.map((name) => name.toLowerCase());
+  const exclude = options.exclude?.map((name) => name.toLowerCase());
+
+  return tables.filter((table) => {
+    const name = table.name.toLowerCase();
+    if (include && !include.includes(name)) {
+      return false;
+    }
+    if (exclude?.includes(name)) {
+      return false;
+    }
+    return true;
+  });
+}
+
 export async function runGenerate(options: GenerateOptions): Promise<void> {
   const dialect = options.dialect ?? detectDialect(options.url);
   const connection: ConnectionInfo = { url: options.url, schema: options.schema };
 
-  const tables = await INTROSPECTORS[dialect](connection);
+  const introspected = await INTROSPECTORS[dialect](connection);
 
-  if (tables.length === 0) {
+  if (introspected.length === 0) {
     throw new Error('No tables found. Check the connection URL and --schema, if provided.');
   }
 
+  const tables = filterTables(introspected, options);
+
+  if (tables.length === 0) {
+    throw new Error(
+      `No tables left after filtering. Available tables: ${introspected
+        .map((table) => table.name)
+        .join(', ')}`,
+    );
+  }
+
   const source = renderSchema(tables);
-  await writeFile(options.out, source, 'utf8');
+
+  try {
+    await writeFile(options.out, source, 'utf8');
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(`Cannot write "${options.out}": the directory does not exist.`);
+    }
+    throw error;
+  }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,31 +1,68 @@
 #!/usr/bin/env node
+import { readFileSync } from 'node:fs';
 import type { Dialect } from './types.js';
 import { runGenerate } from './generate.js';
 
 const DIALECTS: Dialect[] = ['postgres', 'mysql', 'sqlite', 'mssql'];
+
+const USAGE = `Usage: owlsql generate --url <connection-string> [options]
+
+Options:
+  --url <string>       Connection string, or a path to a SQLite database file (required)
+  --out <file>         Output file (default: ./schema.ts)
+  --dialect <name>     ${DIALECTS.join(' | ')} (auto-detected from the URL)
+  --schema <name>      Schema/database to introspect
+  --table <a,b>        Only include the listed tables
+  --exclude <a,b>      Skip the listed tables
+  --help               Show this help
+  --version            Print the version
+`;
+
+const BOOLEAN_FLAGS = new Set(['help', 'version']);
+
+const VALUE_FLAGS = new Set(['url', 'out', 'dialect', 'schema', 'table', 'exclude']);
 
 export function parseFlags(args: string[]): Map<string, string> {
   const flags = new Map<string, string>();
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (!arg?.startsWith('--')) {
+    if (arg === undefined) {
       continue;
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument "${arg}". Flags start with --, e.g. --url.`);
     }
 
     const body = arg.slice(2);
     const equalsIndex = body.indexOf('=');
+    const name = equalsIndex === -1 ? body : body.slice(0, equalsIndex);
+
+    if (!BOOLEAN_FLAGS.has(name) && !VALUE_FLAGS.has(name)) {
+      throw new Error(`Unknown flag --${name}. Run owlsql --help for the list of flags.`);
+    }
+
+    if (flags.has(name)) {
+      throw new Error(`Duplicate flag --${name}.`);
+    }
+
+    if (BOOLEAN_FLAGS.has(name)) {
+      flags.set(name, '');
+      continue;
+    }
+
     if (equalsIndex !== -1) {
-      flags.set(body.slice(0, equalsIndex), body.slice(equalsIndex + 1));
+      flags.set(name, body.slice(equalsIndex + 1));
       continue;
     }
 
     const value = args[index + 1];
     if (value === undefined || value.startsWith('--')) {
-      throw new Error(`Missing value for --${body}`);
+      throw new Error(`Missing value for --${name}`);
     }
 
-    flags.set(body, value);
+    flags.set(name, value);
     index += 1;
   }
 
@@ -44,35 +81,93 @@ function parseDialect(raw: string | undefined): Dialect | undefined {
   return raw as Dialect;
 }
 
+function parseTableList(raw: string | undefined): string[] | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const names = raw
+    .split(',')
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+  return names.length > 0 ? names : undefined;
+}
+
+function readVersion(): string {
+  const packageJsonUrl = new URL('../../package.json', import.meta.url);
+  const parsed: unknown = JSON.parse(readFileSync(packageJsonUrl, 'utf8'));
+  if (parsed && typeof parsed === 'object' && 'version' in parsed) {
+    return String((parsed as { version: unknown }).version);
+  }
+  return 'unknown';
+}
+
+export function formatCliError(error: unknown): string {
+  if (error instanceof AggregateError) {
+    const first = error.errors.find(
+      (inner): inner is Error => inner instanceof Error && inner.message.length > 0,
+    );
+    if (first) {
+      return first.message;
+    }
+    return error.message.length > 0 ? error.message : 'Connection failed.';
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}
+
 async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);
 
+  if (command === undefined || command === '--help' || command === '-h') {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  if (command === '--version' || command === '-v') {
+    process.stdout.write(`${readVersion()}\n`);
+    return;
+  }
+
   if (command !== 'generate') {
-    process.stderr.write(
-      'Usage: owlsql generate --url <connection-string> [--out ./schema.ts] [--dialect postgres|mysql|sqlite|mssql] [--schema <name>]\n',
-    );
-    process.exitCode = command === undefined ? 0 : 1;
+    process.stderr.write(USAGE);
+    process.exitCode = 1;
     return;
   }
 
   const flags = parseFlags(rest);
+
+  if (flags.has('help')) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  if (flags.has('version')) {
+    process.stdout.write(`${readVersion()}\n`);
+    return;
+  }
+
   const url = flags.get('url');
   if (!url) {
     throw new Error('--url is required, e.g. --url postgres://user:pass@host/db');
   }
 
+  const out = flags.get('out') ?? './schema.ts';
+
   await runGenerate({
     url,
-    out: flags.get('out') ?? './schema.ts',
+    out,
     dialect: parseDialect(flags.get('dialect')),
     schema: flags.get('schema'),
+    tables: parseTableList(flags.get('table')),
+    exclude: parseTableList(flags.get('exclude')),
   });
 
-  process.stdout.write(`Wrote ${flags.get('out') ?? './schema.ts'}\n`);
+  process.stdout.write(`Wrote ${out}\n`);
 }
 
 main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`Error: ${message}\n`);
+  process.stderr.write(`Error: ${formatCliError(error)}\n`);
   process.exitCode = 1;
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,10 @@ import type {
   InferRow,
   InferResultStrict,
   InferRowStrict,
+  QueryTypeError,
 } from './parse.js';
-import type { InferParams } from './params.js';
-import { type Result, ok, err } from './result.js';
+import type { InferParams, UsedPlaceholderStyles } from './params.js';
+import { type Result, type QueryMeta, ok, err } from './result.js';
 
 export type {
   Schema,
@@ -21,7 +22,7 @@ export type {
 export type { ParseSelect, ParseStatement, ParsedStatement, Source } from './parse.js';
 export type { FunctionReturnTypes } from './functions.js';
 export type { InferParams } from './params.js';
-export type { Result, Ok, Err } from './result.js';
+export type { Result, Ok, Err, QueryMeta } from './result.js';
 export { ResultStatus, ok, err, isOk, isErr } from './result.js';
 
 export type Query<DB extends SchemaLike, Q extends string> = InferResult<DB, Q>;
@@ -45,20 +46,55 @@ export interface QueryError {
   cause?: unknown;
 }
 
-export type Executor = (sql: string, params: readonly unknown[]) => Promise<unknown[]>;
+export type ExecutorResult = unknown[] | { rows: unknown[]; meta?: QueryMeta };
+
+export type Executor = (sql: string, params: readonly unknown[]) => Promise<ExecutorResult>;
+
+export type PlaceholderStyle = 'dollar' | 'question' | 'at';
+
+export type DialectExecutor<Style extends PlaceholderStyle = PlaceholderStyle> = Executor & {
+  readonly __placeholderStyle?: Style;
+};
+
+type ValidatePlaceholderStyle<
+  Q extends string,
+  Style extends PlaceholderStyle,
+> = PlaceholderStyle extends Style
+  ? unknown
+  : [UsedPlaceholderStyles<Q>] extends [never]
+    ? unknown
+    : [UsedPlaceholderStyles<Q>] extends [Style]
+      ? unknown
+      : QueryTypeError<'the query placeholder style does not match the executor dialect'>;
 
 export interface TypedDbOptions {
   strict?: boolean;
+  placeholders?: PlaceholderStyle;
 }
 
-export interface TypedDb<DB extends SchemaLike, Strict extends boolean = false> {
+type OptionsStyle<Options> = Options extends { placeholders: infer Style extends PlaceholderStyle }
+  ? Style
+  : PlaceholderStyle;
+
+export interface TypedDb<
+  DB extends SchemaLike,
+  Strict extends boolean = false,
+  Style extends PlaceholderStyle = PlaceholderStyle,
+> {
   readonly __owlsqlTypedDb?: true;
   query<Q extends string>(
-    sql: Q,
+    sql: Q & ValidatePlaceholderStyle<Q, Style>,
     ...params: InferParams<DB, Q>
   ): Promise<
     Result<Strict extends true ? InferResultStrict<DB, Q> : InferResult<DB, Q>, QueryError>
   >;
+}
+
+function describeCause(cause: unknown): string {
+  if (cause instanceof Error && cause.message.length > 0) {
+    return cause.message;
+  }
+  return String(cause);
 }
 
 export function createTypedDb<
@@ -67,7 +103,7 @@ export function createTypedDb<
 >(
   executor: Executor,
   options?: Options,
-): TypedDb<DB, Options extends { strict: true } ? true : false> {
+): TypedDb<DB, Options extends { strict: true } ? true : false, OptionsStyle<Options>> {
   void options;
   return {
     async query(sql, ...params) {
@@ -79,12 +115,14 @@ export function createTypedDb<
       }
 
       try {
-        const rows = await executor(sql, params);
-        return ok(rows as never);
+        const executed = await executor(sql, params);
+        const rows = Array.isArray(executed) ? executed : executed.rows;
+        const meta = Array.isArray(executed) ? undefined : executed.meta;
+        return ok(rows as never, meta);
       } catch (cause) {
         return err({
           kind: QueryErrorKind.ExecutorFailed,
-          message: 'The executor threw while running the query.',
+          message: `The executor threw while running the query: ${describeCause(cause)}`,
           cause,
         });
       }

--- a/src/params.ts
+++ b/src/params.ts
@@ -269,6 +269,17 @@ type CteBodiesHavePlaceholder<Q extends string> = [ParseWithClause<Normalize<Q>>
     ? AnyCteBodyHasPlaceholder<Ctes>
     : false;
 
+type StripDoubledAt<S extends string> = S extends `${infer Before}@@${infer After}`
+  ? StripDoubledAt<`${Before}${After}`>
+  : S;
+
+export type UsedPlaceholderStyles<Q extends string> = Normalize<Q> extends infer Text extends string
+  ?
+      | (Text extends `${string}?${string}` ? 'question' : never)
+      | (Text extends `${string}$${string}` ? 'dollar' : never)
+      | (StripDoubledAt<Text> extends `${string}@${string}` ? 'at' : never)
+  : never;
+
 export type InferParams<DB extends SchemaLike, Q extends string> =
   IsKeyword<FirstWord<Normalize<Q>>, 'insert'> extends true
     ? InsertParamTypes<DB, Normalize<Q>>

--- a/src/result.ts
+++ b/src/result.ts
@@ -3,9 +3,15 @@ export enum ResultStatus {
   Error = 'ERROR',
 }
 
+export interface QueryMeta {
+  rowCount?: number | bigint;
+  lastInsertRowid?: number | bigint;
+}
+
 export interface Ok<T> {
   status: ResultStatus.Ok;
   value: T;
+  meta?: QueryMeta;
 }
 
 export interface Err<E> {
@@ -15,8 +21,10 @@ export interface Err<E> {
 
 export type Result<T, E> = Ok<T> | Err<E>;
 
-export function ok<T>(value: T): Ok<T> {
-  return { status: ResultStatus.Ok, value };
+export function ok<T>(value: T, meta?: QueryMeta): Ok<T> {
+  return meta === undefined
+    ? { status: ResultStatus.Ok, value }
+    : { status: ResultStatus.Ok, value, meta };
 }
 
 export function err<E>(error: E): Err<E> {

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ConnectionPool } from 'mssql';
+import { createMssqlExecutor } from '../src/adapters/mssql.js';
+
+interface FakeRequest {
+  input: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
+}
+
+function fakePool(result: unknown): { pool: ConnectionPool; request: FakeRequest } {
+  const request: FakeRequest = {
+    input: vi.fn(),
+    query: vi.fn().mockResolvedValue(result),
+  };
+  const pool = { request: () => request } as unknown as ConnectionPool;
+  return { pool, request };
+}
+
+describe('createMssqlExecutor', () => {
+  it('binds @name placeholders by name in order of first appearance', async () => {
+    const { pool, request } = fakePool({ recordset: [{ id: 1 }] });
+    const executor = createMssqlExecutor(pool);
+
+    const rows = await executor('select id from users where name = @name and id = @id', [
+      'ada',
+      7,
+    ]);
+
+    expect(request.input.mock.calls).toEqual([
+      ['name', 'ada'],
+      ['id', 7],
+    ]);
+    expect(rows).toEqual([{ id: 1 }]);
+  });
+
+  it('binds a repeated @name once', async () => {
+    const { pool, request } = fakePool({ recordset: [] });
+    const executor = createMssqlExecutor(pool);
+
+    await executor('select id from users where id = @id or parent_id = @id', [7]);
+
+    expect(request.input.mock.calls).toEqual([['id', 7]]);
+  });
+
+  it('ignores @@system variables and literals containing @', async () => {
+    const { pool, request } = fakePool({ recordset: [] });
+    const executor = createMssqlExecutor(pool);
+
+    await executor("select id from users where email like '%@%' and id = @@rowcount", []);
+
+    expect(request.input).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array when a write produces no recordset', async () => {
+    const { pool } = fakePool({ recordset: undefined });
+    const executor = createMssqlExecutor(pool);
+
+    const rows = await executor('update users set name = @name where id = @id', ['ada', 1]);
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -21,7 +21,7 @@ describe('createMssqlExecutor', () => {
     const { pool, request } = fakePool({ recordset: [{ id: 1 }] });
     const executor = createMssqlExecutor(pool);
 
-    const rows = await executor('select id from users where name = @name and id = @id', [
+    const result = await executor('select id from users where name = @name and id = @id', [
       'ada',
       7,
     ]);
@@ -30,7 +30,7 @@ describe('createMssqlExecutor', () => {
       ['name', 'ada'],
       ['id', 7],
     ]);
-    expect(rows).toEqual([{ id: 1 }]);
+    expect(result).toEqual({ rows: [{ id: 1 }], meta: {} });
   });
 
   it('binds a repeated @name once', async () => {
@@ -51,12 +51,12 @@ describe('createMssqlExecutor', () => {
     expect(request.input).not.toHaveBeenCalled();
   });
 
-  it('returns an empty array when a write produces no recordset', async () => {
-    const { pool } = fakePool({ recordset: undefined });
+  it('returns empty rows and rowCount metadata when a write produces no recordset', async () => {
+    const { pool } = fakePool({ recordset: undefined, rowsAffected: [3] });
     const executor = createMssqlExecutor(pool);
 
-    const rows = await executor('update users set name = @name where id = @id', ['ada', 1]);
+    const result = await executor('update users set name = @name where id = @id', ['ada', 1]);
 
-    expect(rows).toEqual([]);
+    expect(result).toEqual({ rows: [], meta: { rowCount: 3 } });
   });
 });

--- a/tests/adapter-mysql2.test.ts
+++ b/tests/adapter-mysql2.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Pool } from 'mysql2/promise';
+import { createMysql2Executor } from '../src/adapters/mysql2.js';
+
+function fakePool(result: unknown): { pool: Pool; execute: ReturnType<typeof vi.fn> } {
+  const execute = vi.fn().mockResolvedValue([result, undefined]);
+  return { pool: { execute } as unknown as Pool, execute };
+}
+
+describe('createMysql2Executor', () => {
+  it('returns row arrays from SELECT results', async () => {
+    const rows = [{ id: 1 }, { id: 2 }];
+    const { pool, execute } = fakePool(rows);
+
+    const executor = createMysql2Executor(pool);
+    const result = await executor('select id from users', []);
+
+    expect(result).toEqual(rows);
+    expect(execute).toHaveBeenCalledWith('select id from users', []);
+  });
+
+  it('returns an empty array instead of a ResultSetHeader for writes', async () => {
+    const header = { affectedRows: 1, insertId: 7, fieldCount: 0 };
+    const { pool } = fakePool(header);
+
+    const executor = createMysql2Executor(pool);
+    const result = await executor('insert into users (name) values (?)', ['ada']);
+
+    expect(result).toEqual([]);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('uses execute for server-side parameter binding', async () => {
+    const { pool, execute } = fakePool([]);
+
+    const executor = createMysql2Executor(pool);
+    await executor('select id from users where id = ?', [7]);
+
+    expect(execute).toHaveBeenCalledWith('select id from users where id = ?', [7]);
+  });
+});

--- a/tests/adapter-mysql2.test.ts
+++ b/tests/adapter-mysql2.test.ts
@@ -19,15 +19,14 @@ describe('createMysql2Executor', () => {
     expect(execute).toHaveBeenCalledWith('select id from users', []);
   });
 
-  it('returns an empty array instead of a ResultSetHeader for writes', async () => {
+  it('returns empty rows plus write metadata instead of a ResultSetHeader', async () => {
     const header = { affectedRows: 1, insertId: 7, fieldCount: 0 };
     const { pool } = fakePool(header);
 
     const executor = createMysql2Executor(pool);
     const result = await executor('insert into users (name) values (?)', ['ada']);
 
-    expect(result).toEqual([]);
-    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual({ rows: [], meta: { rowCount: 1, lastInsertRowid: 7 } });
   });
 
   it('uses execute for server-side parameter binding', async () => {

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -42,4 +42,59 @@ describe('createNodeSqliteExecutor', () => {
       expect(result.value).toEqual([{ id: 2, name: 'grace' }]);
     }
   });
+
+  it('routes @name and $name placeholders through the named-parameters object', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const atResult = await db.query('select id, name from users where id = @id', 1);
+    expect(isOk(atResult)).toBe(true);
+    if (isOk(atResult)) {
+      expect(atResult.value).toEqual([{ id: 1, name: 'ada' }]);
+    }
+
+    const dollarResult = await db.query('select id, name from users where name = $name', 'grace');
+    expect(isOk(dollarResult)).toBe(true);
+    if (isOk(dollarResult)) {
+      expect(dollarResult.value).toEqual([{ id: 2, name: 'grace' }]);
+    }
+  });
+
+  it('ignores named-parameter lookalikes inside string literals', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const result = await db.query("select id from users where name = 'no @param here' or id = ?", 1);
+
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value).toEqual([{ id: 1 }]);
+    }
+  });
+
+  it('coerces boolean and Date params to driver-supported values', async () => {
+    const sqlite = new DatabaseSync(':memory:');
+    sqlite.exec('create table flags (id integer primary key, active integer, seen_at text)');
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    const stamp = new Date('2026-01-02T03:04:05.000Z');
+    await executor('insert into flags (id, active, seen_at) values (?, ?, ?)', [1, true, stamp]);
+
+    const rows = await executor('select active, seen_at from flags where id = ?', [1]);
+    expect(rows).toEqual([{ active: 1, seen_at: '2026-01-02T03:04:05.000Z' }]);
+  });
+
+  it('supports an INSERT round-trip through the typed client', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const insert = await db.query('insert into users (id, name) values ($1, $2)', 3, 'lin');
+    expect(isOk(insert)).toBe(true);
+
+    const rows = await db.query('select name from users where id = ?', 3);
+    expect(isOk(rows)).toBe(true);
+    if (isOk(rows)) {
+      expect(rows.value).toEqual([{ name: 'lin' }]);
+    }
+  });
 });

--- a/tests/adapters.test-d.ts
+++ b/tests/adapters.test-d.ts
@@ -1,4 +1,4 @@
-import type { Executor } from '../src/index.js';
+import type { Executor, DialectExecutor } from '../src/index.js';
 import type { Pool as PgPool, Client as PgClient, PoolClient as PgPoolClient } from 'pg';
 import type { Pool as Mysql2Pool, Connection as Mysql2Connection } from 'mysql2/promise';
 import type postgres from 'postgres';
@@ -18,19 +18,22 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type PgExecutorMatchesShape = Expect<
-  Equal<ReturnType<typeof createPgExecutor>, Executor>
+  Equal<ReturnType<typeof createPgExecutor>, DialectExecutor<'dollar'>>
 >;
 
 type Mysql2ExecutorMatchesShape = Expect<
-  Equal<ReturnType<typeof createMysql2Executor>, Executor>
+  Equal<ReturnType<typeof createMysql2Executor>, DialectExecutor<'question'>>
 >;
 
 type PostgresJsExecutorMatchesShape = Expect<
-  Equal<ReturnType<typeof createPostgresJsExecutor>, Executor>
+  Equal<ReturnType<typeof createPostgresJsExecutor>, DialectExecutor<'dollar'>>
 >;
 
 type NodeSqliteExecutorMatchesShape = Expect<
-  Equal<ReturnType<typeof createNodeSqliteExecutor>, Executor>
+  Equal<
+    ReturnType<typeof createNodeSqliteExecutor>,
+    DialectExecutor<'question' | 'at' | 'dollar'>
+  >
 >;
 
 type KyselyExecutorMatchesShape = Expect<

--- a/tests/adapters.test-d.ts
+++ b/tests/adapters.test-d.ts
@@ -1,6 +1,6 @@
 import type { Executor } from '../src/index.js';
-import type { Pool as PgPool } from 'pg';
-import type { Pool as Mysql2Pool } from 'mysql2/promise';
+import type { Pool as PgPool, Client as PgClient, PoolClient as PgPoolClient } from 'pg';
+import type { Pool as Mysql2Pool, Connection as Mysql2Connection } from 'mysql2/promise';
 import type postgres from 'postgres';
 import type { DatabaseSync } from 'node:sqlite';
 import type { Kysely } from 'kysely';
@@ -39,7 +39,10 @@ type KyselyExecutorMatchesShape = Expect<
 
 export function adapterCallSites() {
   createPgExecutor({} as PgPool);
+  createPgExecutor({} as PgClient);
+  createPgExecutor({} as PgPoolClient);
   createMysql2Executor({} as Mysql2Pool);
+  createMysql2Executor({} as Mysql2Connection);
   createPostgresJsExecutor({} as postgres.Sql);
   createNodeSqliteExecutor({} as DatabaseSync);
   createKyselyExecutor({} as Kysely<{ users: { id: number } }>);

--- a/tests/cli-flags.test.ts
+++ b/tests/cli-flags.test.ts
@@ -29,4 +29,30 @@ describe('parseFlags', () => {
     expect(() => parseFlags(['--url'])).toThrow('Missing value for --url');
     expect(() => parseFlags(['--url', '--out', './schema.ts'])).toThrow('Missing value for --url');
   });
+
+  it('rejects unknown flags instead of ignoring them', () => {
+    expect(() => parseFlags(['--output', './x.ts'])).toThrow('Unknown flag --output');
+    expect(() => parseFlags(['--shema', 'app'])).toThrow('Unknown flag --shema');
+  });
+
+  it('rejects positional arguments', () => {
+    expect(() => parseFlags(['generate.ts'])).toThrow('Unexpected argument "generate.ts"');
+  });
+
+  it('rejects duplicate flags instead of last-win', () => {
+    expect(() => parseFlags(['--out', 'a.ts', '--out', 'b.ts'])).toThrow('Duplicate flag --out');
+  });
+
+  it('treats --help and --version as boolean flags', () => {
+    expect(parseFlags(['--help']).has('help')).toBe(true);
+    expect(parseFlags(['--version']).has('version')).toBe(true);
+    const flags = parseFlags(['--help', '--url', 'x']);
+    expect(flags.get('url')).toBe('x');
+  });
+
+  it('accepts --table and --exclude lists', () => {
+    const flags = parseFlags(['--table', 'users,posts', '--exclude', 'migrations']);
+    expect(flags.get('table')).toBe('users,posts');
+    expect(flags.get('exclude')).toBe('migrations');
+  });
 });

--- a/tests/cli-ux.test.ts
+++ b/tests/cli-ux.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+import { detectDialect, runGenerate } from '../src/cli/generate.js';
+import { normalizeSqlitePath } from '../src/cli/dialects/sqlite.js';
+import { formatCliError } from '../src/cli/index.js';
+
+function createDatabase(): { dir: string; file: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
+  const file = join(dir, 'app.db');
+  const db = new DatabaseSync(file);
+  db.exec('create table users (id integer primary key, name text not null)');
+  db.exec('create table posts (id integer primary key, title text not null)');
+  db.close();
+  return { dir, file };
+}
+
+describe('sqlite URL forms', () => {
+  it('routes sqlite:// and file: URLs to the sqlite dialect', () => {
+    expect(detectDialect('sqlite://./app.db')).toBe('sqlite');
+    expect(detectDialect('sqlite:./app.db')).toBe('sqlite');
+    expect(detectDialect('file:./app.db')).toBe('sqlite');
+  });
+
+  it('normalizes sqlite prefixes to plain paths', () => {
+    expect(normalizeSqlitePath('sqlite://./app.db')).toBe('./app.db');
+    expect(normalizeSqlitePath('sqlite:./app.db')).toBe('./app.db');
+    expect(normalizeSqlitePath('file://./app.db')).toBe('./app.db');
+    expect(normalizeSqlitePath('./app.db')).toBe('./app.db');
+  });
+
+  it('introspects through a sqlite:// URL', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await runGenerate({ url: `sqlite://${file}`, out });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('table filtering', () => {
+  it('honors --table include lists', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await runGenerate({ url: file, out, tables: ['users'] });
+      const { readFileSync } = await import('node:fs');
+      const written = readFileSync(out, 'utf8');
+      expect(written).toContain('users');
+      expect(written).not.toContain('posts');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors --exclude lists', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await runGenerate({ url: file, out, exclude: ['posts'] });
+      const { readFileSync } = await import('node:fs');
+      const written = readFileSync(out, 'utf8');
+      expect(written).toContain('users');
+      expect(written).not.toContain('posts');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('lists available tables when the filter matches nothing', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await expect(runGenerate({ url: file, out, tables: ['nope'] })).rejects.toThrow(
+        'Available tables: users, posts',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('write errors', () => {
+  it('reports a missing output directory clearly', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'missing-dir', 'schema.ts');
+      await expect(runGenerate({ url: file, out })).rejects.toThrow('directory does not exist');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('formatCliError', () => {
+  it('unwraps AggregateError to the first inner message', () => {
+    const aggregate = new AggregateError([new Error('connect ECONNREFUSED ::1:5432')], '');
+    expect(formatCliError(aggregate)).toBe('connect ECONNREFUSED ::1:5432');
+  });
+
+  it('falls back to a generic message for empty AggregateErrors', () => {
+    expect(formatCliError(new AggregateError([], ''))).toBe('Connection failed.');
+  });
+
+  it('passes ordinary errors through', () => {
+    expect(formatCliError(new Error('boom'))).toBe('boom');
+  });
+});

--- a/tests/dialect-brand.test-d.ts
+++ b/tests/dialect-brand.test-d.ts
@@ -1,0 +1,33 @@
+import { createTypedDb, type Executor } from '../src/index.js';
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+declare const executor: Executor;
+
+export async function placeholderStyleCallSites() {
+  const pgDb = createTypedDb<DB, { placeholders: 'dollar' }>(executor);
+  const mysqlDb = createTypedDb<DB, { placeholders: 'question' }>(executor);
+  const uncheckedDb = createTypedDb<DB>(executor);
+
+  await pgDb.query('select id from users where id = $1', 1);
+
+  // @ts-expect-error a dollar-style client rejects ? placeholders
+  await pgDb.query('select id from users where id = ?', 1);
+
+  await mysqlDb.query('select id from users where id = ?', 1);
+
+  // @ts-expect-error a question-style client rejects $n placeholders
+  await mysqlDb.query('select id from users where id = $1', 1);
+
+  // @ts-expect-error a question-style client rejects @name placeholders
+  await mysqlDb.query('select id from users where id = @id', 1);
+
+  await uncheckedDb.query('select id from users where id = $1', 1);
+  await uncheckedDb.query('select id from users where id = ?', 1);
+
+  await pgDb.query('select id, name from users');
+
+  await pgDb.query("select id from users where name = 'why?'");
+}

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -38,6 +38,32 @@ function executorThrowing(cause: unknown): RecordingExecutor {
 }
 
 describe('createTypedDb.query', () => {
+  it('surfaces executor metadata on the Ok result', async () => {
+    const executor: Executor = async () => ({ rows: [], meta: { rowCount: 3, lastInsertRowid: 9 } });
+    const db = createTypedDb<DB>(executor);
+
+    const result = await db.query('insert into users (name) values ($1)', 'ada');
+
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value).toEqual([]);
+      expect(result.meta).toEqual({ rowCount: 3, lastInsertRowid: 9 });
+    }
+  });
+
+  it('includes the driver message in EXECUTOR_FAILED errors', async () => {
+    const { executor } = executorThrowing(new Error('connection refused'));
+    const db = createTypedDb<DB>(executor);
+
+    const result = await db.query('select id from users');
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.kind).toBe(QueryErrorKind.ExecutorFailed);
+      expect(result.error.message).toContain('connection refused');
+    }
+  });
+
   it('returns Ok with the rows from the executor on success', async () => {
     const sampleRows = [{ id: 1, name: 'ada' }];
     const { executor, calls } = executorReturning(sampleRows);


### PR DESCRIPTION
## Problems (#65)

1. **Write metadata was unreachable** — `Executor` returned `Promise<unknown[]>`, so pg discarded `rowCount`, kysely discarded `numAffectedRows`; an INSERT without RETURNING gave the caller nothing actionable.
2. **Static error message** — `EXECUTOR_FAILED` always carried the same text; the driver error lived only in `cause`.
3. **Placeholder dialect not coupled to the adapter** — `?` with `createPgExecutor` compiled and failed at runtime; README documents a per-dialect table but nothing enforced it.
4. The pg adapter always forwarded a (possibly empty) values array, forcing the extended query protocol, which rejects multi-statement SQL.

## Fixes

1. `Executor` may now resolve `unknown[]` **or** `{ rows, meta }` (`QueryMeta` = `rowCount`, `lastInsertRowid`). `createTypedDb` normalizes and surfaces `meta` on the Ok result. Adapters wired: pg (`rowCount`), mysql2 (`affectedRows`/`insertId` — a write now yields `[]` + meta instead of a fake array), postgres.js (`count`), kysely (`numAffectedRows`/`insertId`), mssql (`rowsAffected`). Existing array-returning custom executors keep working unchanged.
2. `EXECUTOR_FAILED` message now embeds the driver message (`...: connect ECONNREFUSED`).
3. Opt-in compile-time placeholder checking: `createTypedDb<DB, { placeholders: 'dollar' }>(...)` rejects `?`/`@name` queries at the call site (literals are masked first, so `'why?'` doesn't trip it). Styles: `dollar`/`question`/`at`; omit the option for mixed-style drivers like node:sqlite. Adapters annotate their dialect via the exported `DialectExecutor<Style>`.
4. pg adapter sends `pool.query(sql)` alone when there are no params.

## Tests

Runtime: meta pass-through, driver-message embedding. `tests/dialect-brand.test-d.ts`: dollar/question/at rejection matrix, unchecked default, literal `?` immunity. Adapter tests updated for `{ rows, meta }`. Full suite passes (128).

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compile-time validation for SQL placeholder styles.
  * Query results can now include affected-row counts and last-insert IDs.
  * Added MSSQL adapter support and expanded PostgreSQL/MySQL2 connection options.
  * SQLite now supports named parameters, value conversion, and memory database URLs.
  * Added table inclusion/exclusion filters to schema generation.

* **Bug Fixes**
  * Improved CLI validation, error messages, and cleanup handling.
  * Added transaction guidance and updated adapter documentation.

* **Documentation**
  * Expanded tutorials with placeholder checking, query metadata, transactions, and MSSQL usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->