### PR TITLE
ci: add Node 20/22/24 runtime matrix, workflow permissions and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   types:
     name: Types (TypeScript ${{ matrix.typescript }})
@@ -24,13 +27,17 @@ jobs:
       - run: npm run test:types
 
   runtime:
-    name: Runtime tests
+    name: Runtime tests (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
       - run: npm run test:runtime

--- a/README.md
+++ b/README.md
@@ -582,24 +582,20 @@ Swap `createPgExecutor` for `createMysql2Executor`/`createPostgresJsExecutor`/
 `createNodeSqliteExecutor` depending on which Drizzle driver you're using —
 `$client` is always the native driver instance underneath.
 
-**mssql (SQL Server)** (no dedicated adapter — `mssql` binds parameters by
-name rather than by position, so the executor needs a couple of extra lines)
+**mssql (SQL Server)**
 
 ```ts
 import sql from 'mssql';
+import { createMssqlExecutor } from '@owlsql/core/mssql';
+
 const pool = await sql.connect({ /* ... */ });
-const db = createTypedDb<DB>(async (query, params) => {
-  const request = pool.request();
-  params.forEach((value, index) => request.input(`p${index + 1}`, value));
-  const result = await request.query(query);
-  return result.recordset;
-});
+const db = createTypedDb<DB>(createMssqlExecutor(pool));
 ```
 
-`mssql` binds named parameters (`request.input('name', value)`), so build the
-query with matching `@pN` placeholders — `Params<DB, Q>` still gives you a
-positional tuple typed against the query's `@` placeholders, in the order they
-appear.
+The adapter scans the query for `@name` placeholders (skipping string
+literals and `@@` system variables) and binds each one by name via
+`request.input(...)`, in order of first appearance — matching how
+`Params<DB, Q>` types the positional tuple. A repeated `@name` binds once.
 
 ## Database support
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,26 @@ For this to work, write the comparison **with spaces around the operator**
 (`id = $1`, not `id=$1`) — that is what lets the compiler see the column,
 operator, and placeholder as separate tokens.
 
+**Placeholder-style checking (opt-in).** The type layer accepts `$n`, `?` and
+`@name` interchangeably, but each driver only understands its own style — `?`
+with the pg adapter is a runtime syntax error. Declare the style your executor
+expects and mismatches become compile errors:
+
+```ts
+const db = createTypedDb<DB, { placeholders: 'dollar' }>(createPgExecutor(pool));
+
+// @ts-expect-error '?' is not a pg placeholder — use $1
+await db.query('select id from users where id = ?', 1);
+```
+
+Styles: `'dollar'` (pg, postgres.js), `'question'` (mysql2), `'at'` (mssql).
+`node:sqlite` accepts all three, so leave the option off there.
+
+**Write metadata.** Adapters report driver metadata alongside the rows: on a
+successful `Result`, `result.meta?.rowCount` carries the affected-row count
+and `result.meta?.lastInsertRowid` the generated id (where the driver
+provides one), so an INSERT without `RETURNING` is no longer a black box.
+
 ### 11. Transactions
 
 There is no built-in transaction API yet — and there is a footgun to know

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ No install, no database — see [`examples/playground`](examples/playground).
   - [8. Strict mode — turn typos into type errors](#8-strict-mode--turn-typos-into-type-errors)
   - [9. Joins](#9-joins)
   - [10. Typed parameters](#10-typed-parameters)
+  - [11. Transactions](#11-transactions)
 - [Driver recipes](#driver-recipes)
 - [Database support](#database-support)
 - [Editor autocomplete](#editor-autocomplete)
@@ -451,6 +452,48 @@ across joins (`where p.views > $1` resolves against the aliased table). Use the
 For this to work, write the comparison **with spaces around the operator**
 (`id = $1`, not `id=$1`) — that is what lets the compiler see the column,
 operator, and placeholder as separate tokens.
+
+### 11. Transactions
+
+There is no built-in transaction API yet — and there is a footgun to know
+about: **never run `BEGIN`/`COMMIT` through an executor bound to a pool.**
+Each `query()` may check out a *different* connection, so `BEGIN` runs on
+connection A and `COMMIT` on connection B, leaving an open transaction (and
+its locks) on a pooled connection that is later handed to another caller.
+
+The adapters accept anything with the right `query`/`execute` shape — a
+`pg.Pool`, `pg.Client` or `pg.PoolClient`; a mysql2 `Pool` or `Connection` —
+so pin one connection and scope a client to it:
+
+```ts
+import { Pool } from 'pg';
+import { createTypedDb } from '@owlsql/core';
+import { createPgExecutor } from '@owlsql/core/pg';
+
+const pool = new Pool();
+
+async function transferFunds(from: number, to: number, amount: number) {
+  const client = await pool.connect();
+  const tx = createTypedDb<DB>(createPgExecutor(client));
+
+  try {
+    await client.query('begin');
+    await tx.query('update accounts set balance = balance - $1 where id = $2', amount, from);
+    await tx.query('update accounts set balance = balance + $1 where id = $2', amount, to);
+    await client.query('commit');
+  } catch (error) {
+    await client.query('rollback');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+```
+
+postgres.js has its own `sql.begin(...)` — build the executor from the
+transaction-scoped `sql` it hands you. Kysely users should use Kysely's
+`db.transaction()`. `node:sqlite` is a single connection, so plain
+`begin`/`commit` statements are safe there.
 
 ## Driver recipes
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
       "types": "./dist/adapters/node-sqlite.d.ts",
       "import": "./dist/adapters/node-sqlite.js"
     },
+    "./mssql": {
+      "types": "./dist/adapters/mssql.d.ts",
+      "import": "./dist/adapters/mssql.js"
+    },
     "./kysely": {
       "types": "./dist/adapters/kysely.d.ts",
       "import": "./dist/adapters/kysely.js"

--- a/src/adapters/kysely.ts
+++ b/src/adapters/kysely.ts
@@ -1,9 +1,16 @@
 import { CompiledQuery, type Kysely } from 'kysely';
-import type { Executor } from '../index.js';
+import type { Executor, QueryMeta } from '../index.js';
 
 export function createKyselyExecutor<DB>(db: Kysely<DB>): Executor {
   return async (sql, params) => {
     const result = await db.executeQuery(CompiledQuery.raw(sql, params as unknown[]));
-    return result.rows;
+    const meta: QueryMeta = {};
+    if (typeof result.numAffectedRows === 'bigint') {
+      meta.rowCount = result.numAffectedRows;
+    }
+    if (typeof result.insertId === 'bigint') {
+      meta.lastInsertRowid = result.insertId;
+    }
+    return { rows: [...result.rows], meta };
   };
 }

--- a/src/adapters/mssql.ts
+++ b/src/adapters/mssql.ts
@@ -1,0 +1,18 @@
+import type { ConnectionPool } from 'mssql';
+import type { Executor } from '../index.js';
+import { collectNamedParameters } from './named-params.js';
+
+const MSSQL_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@']);
+
+export function createMssqlExecutor(pool: ConnectionPool): Executor {
+  return async (sql, params) => {
+    const request = pool.request();
+
+    collectNamedParameters(sql, MSSQL_PARAM_PREFIXES).forEach((name, index) => {
+      request.input(name.slice(1), params[index] ?? null);
+    });
+
+    const result = await request.query(sql);
+    return result.recordset ?? [];
+  };
+}

--- a/src/adapters/mssql.ts
+++ b/src/adapters/mssql.ts
@@ -1,10 +1,10 @@
 import type { ConnectionPool } from 'mssql';
-import type { Executor } from '../index.js';
+import type { DialectExecutor, QueryMeta } from '../index.js';
 import { collectNamedParameters } from './named-params.js';
 
 const MSSQL_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@']);
 
-export function createMssqlExecutor(pool: ConnectionPool): Executor {
+export function createMssqlExecutor(pool: ConnectionPool): DialectExecutor<'at'> {
   return async (sql, params) => {
     const request = pool.request();
 
@@ -13,6 +13,10 @@ export function createMssqlExecutor(pool: ConnectionPool): Executor {
     });
 
     const result = await request.query(sql);
-    return result.recordset ?? [];
+    const meta: QueryMeta = {};
+    if (typeof result.rowsAffected?.[0] === 'number') {
+      meta.rowCount = result.rowsAffected[0];
+    }
+    return { rows: result.recordset ?? [], meta };
   };
 }

--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -1,9 +1,10 @@
 import type { Pool } from 'mysql2/promise';
+import type { ExecuteValues } from 'mysql2';
 import type { Executor } from '../index.js';
 
 export function createMysql2Executor(pool: Pool): Executor {
   return async (sql, params) => {
-    const [rows] = await pool.query(sql, params as unknown[]);
-    return rows as unknown[];
+    const [rows] = await pool.execute(sql, params as ExecuteValues);
+    return Array.isArray(rows) ? rows : [];
   };
 }

--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -1,12 +1,26 @@
 import type { Pool, Connection } from 'mysql2/promise';
 import type { ExecuteValues } from 'mysql2';
-import type { Executor } from '../index.js';
+import type { DialectExecutor, QueryMeta } from '../index.js';
 
 export type Mysql2Queryable = Pool | Connection;
 
-export function createMysql2Executor(connection: Mysql2Queryable): Executor {
+function writeMeta(header: { affectedRows?: number; insertId?: number }): QueryMeta {
+  const meta: QueryMeta = {};
+  if (typeof header.affectedRows === 'number') {
+    meta.rowCount = header.affectedRows;
+  }
+  if (typeof header.insertId === 'number' && header.insertId !== 0) {
+    meta.lastInsertRowid = header.insertId;
+  }
+  return meta;
+}
+
+export function createMysql2Executor(connection: Mysql2Queryable): DialectExecutor<'question'> {
   return async (sql, params) => {
     const [rows] = await connection.execute(sql, params as ExecuteValues);
-    return Array.isArray(rows) ? rows : [];
+    if (Array.isArray(rows)) {
+      return rows;
+    }
+    return { rows: [], meta: writeMeta(rows as { affectedRows?: number; insertId?: number }) };
   };
 }

--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -1,10 +1,12 @@
-import type { Pool } from 'mysql2/promise';
+import type { Pool, Connection } from 'mysql2/promise';
 import type { ExecuteValues } from 'mysql2';
 import type { Executor } from '../index.js';
 
-export function createMysql2Executor(pool: Pool): Executor {
+export type Mysql2Queryable = Pool | Connection;
+
+export function createMysql2Executor(connection: Mysql2Queryable): Executor {
   return async (sql, params) => {
-    const [rows] = await pool.execute(sql, params as ExecuteValues);
+    const [rows] = await connection.execute(sql, params as ExecuteValues);
     return Array.isArray(rows) ? rows : [];
   };
 }

--- a/src/adapters/named-params.ts
+++ b/src/adapters/named-params.ts
@@ -1,0 +1,36 @@
+const NAMED_PARAM_BODY = /^[A-Za-z0-9_]+/;
+
+export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string>): string[] {
+  const names: string[] = [];
+  let insideLiteral = false;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index] as string;
+
+    if (char === "'") {
+      insideLiteral = !insideLiteral;
+      continue;
+    }
+    if (insideLiteral) {
+      continue;
+    }
+
+    if (prefixes.has(char)) {
+      if (sql[index + 1] === char) {
+        index += 1;
+        continue;
+      }
+
+      const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
+      if (body) {
+        const name = `${char}${body[0]}`;
+        if (!names.includes(name)) {
+          names.push(name);
+        }
+        index += body[0].length;
+      }
+    }
+  }
+
+  return names;
+}

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -1,11 +1,10 @@
 import type { DatabaseSync } from 'node:sqlite';
 import type { Executor } from '../index.js';
+import { collectNamedParameters } from './named-params.js';
 
 type SqliteParam = null | number | bigint | string | NodeJS.ArrayBufferView;
 
-const NAMED_PARAM_PREFIXES = new Set(['@', '$', ':']);
-
-const NAMED_PARAM_BODY = /^[A-Za-z0-9_]+/;
+const SQLITE_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@', '$', ':']);
 
 function toSqliteValue(value: unknown): SqliteParam {
   if (typeof value === 'boolean') {
@@ -20,41 +19,11 @@ function toSqliteValue(value: unknown): SqliteParam {
   return value as SqliteParam;
 }
 
-export function collectNamedParameters(sql: string): string[] {
-  const names: string[] = [];
-  let insideLiteral = false;
-
-  for (let index = 0; index < sql.length; index += 1) {
-    const char = sql[index] as string;
-
-    if (char === "'") {
-      insideLiteral = !insideLiteral;
-      continue;
-    }
-    if (insideLiteral) {
-      continue;
-    }
-
-    if (NAMED_PARAM_PREFIXES.has(char)) {
-      const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
-      if (body) {
-        const name = `${char}${body[0]}`;
-        if (!names.includes(name)) {
-          names.push(name);
-        }
-        index += body[0].length;
-      }
-    }
-  }
-
-  return names;
-}
-
 export function createNodeSqliteExecutor(db: DatabaseSync): Executor {
   return async (sql, params) => {
     const statement = db.prepare(sql);
     const values = params.map(toSqliteValue);
-    const namedParameters = collectNamedParameters(sql);
+    const namedParameters = collectNamedParameters(sql, SQLITE_PARAM_PREFIXES);
 
     if (namedParameters.length > 0) {
       const bag: Record<string, SqliteParam> = {};

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from 'node:sqlite';
-import type { Executor } from '../index.js';
+import type { DialectExecutor } from '../index.js';
 import { collectNamedParameters } from './named-params.js';
 
 type SqliteParam = null | number | bigint | string | NodeJS.ArrayBufferView;
@@ -19,7 +19,9 @@ function toSqliteValue(value: unknown): SqliteParam {
   return value as SqliteParam;
 }
 
-export function createNodeSqliteExecutor(db: DatabaseSync): Executor {
+export function createNodeSqliteExecutor(
+  db: DatabaseSync,
+): DialectExecutor<'question' | 'at' | 'dollar'> {
   return async (sql, params) => {
     const statement = db.prepare(sql);
     const values = params.map(toSqliteValue);

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -3,8 +3,67 @@ import type { Executor } from '../index.js';
 
 type SqliteParam = null | number | bigint | string | NodeJS.ArrayBufferView;
 
+const NAMED_PARAM_PREFIXES = new Set(['@', '$', ':']);
+
+const NAMED_PARAM_BODY = /^[A-Za-z0-9_]+/;
+
+function toSqliteValue(value: unknown): SqliteParam {
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (value === undefined) {
+    return null;
+  }
+  return value as SqliteParam;
+}
+
+export function collectNamedParameters(sql: string): string[] {
+  const names: string[] = [];
+  let insideLiteral = false;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index] as string;
+
+    if (char === "'") {
+      insideLiteral = !insideLiteral;
+      continue;
+    }
+    if (insideLiteral) {
+      continue;
+    }
+
+    if (NAMED_PARAM_PREFIXES.has(char)) {
+      const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
+      if (body) {
+        const name = `${char}${body[0]}`;
+        if (!names.includes(name)) {
+          names.push(name);
+        }
+        index += body[0].length;
+      }
+    }
+  }
+
+  return names;
+}
+
 export function createNodeSqliteExecutor(db: DatabaseSync): Executor {
   return async (sql, params) => {
-    return db.prepare(sql).all(...(params as unknown as SqliteParam[]));
+    const statement = db.prepare(sql);
+    const values = params.map(toSqliteValue);
+    const namedParameters = collectNamedParameters(sql);
+
+    if (namedParameters.length > 0) {
+      const bag: Record<string, SqliteParam> = {};
+      namedParameters.forEach((name, index) => {
+        bag[name] = values[index] ?? null;
+      });
+      return statement.all(bag);
+    }
+
+    return statement.all(...values);
   };
 }

--- a/src/adapters/pg.ts
+++ b/src/adapters/pg.ts
@@ -1,11 +1,16 @@
 import type { Pool, Client, PoolClient } from 'pg';
-import type { Executor } from '../index.js';
+import type { DialectExecutor } from '../index.js';
 
 export type PgQueryable = Pool | Client | PoolClient;
 
-export function createPgExecutor(client: PgQueryable): Executor {
+export function createPgExecutor(client: PgQueryable): DialectExecutor<'dollar'> {
   return async (sql, params) => {
-    const result = await client.query(sql, params as unknown[]);
-    return result.rows;
+    const result =
+      params.length === 0 ? await client.query(sql) : await client.query(sql, params as unknown[]);
+
+    return {
+      rows: result.rows,
+      meta: result.rowCount === null ? {} : { rowCount: result.rowCount },
+    };
   };
 }

--- a/src/adapters/pg.ts
+++ b/src/adapters/pg.ts
@@ -1,9 +1,11 @@
-import type { Pool } from 'pg';
+import type { Pool, Client, PoolClient } from 'pg';
 import type { Executor } from '../index.js';
 
-export function createPgExecutor(pool: Pool): Executor {
+export type PgQueryable = Pool | Client | PoolClient;
+
+export function createPgExecutor(client: PgQueryable): Executor {
   return async (sql, params) => {
-    const result = await pool.query(sql, params as unknown[]);
+    const result = await client.query(sql, params as unknown[]);
     return result.rows;
   };
 }

--- a/src/adapters/postgres.ts
+++ b/src/adapters/postgres.ts
@@ -1,10 +1,14 @@
 import type postgres from 'postgres';
-import type { Executor } from '../index.js';
+import type { DialectExecutor } from '../index.js';
 
 type PostgresUnsafeParam = NonNullable<Parameters<postgres.Sql['unsafe']>[1]>[number];
 
-export function createPostgresJsExecutor(client: postgres.Sql): Executor {
+export function createPostgresJsExecutor(client: postgres.Sql): DialectExecutor<'dollar'> {
   return async (sql, params) => {
-    return client.unsafe(sql, params as unknown as PostgresUnsafeParam[]);
+    const result = await client.unsafe(sql, params as unknown as PostgresUnsafeParam[]);
+    return {
+      rows: [...result],
+      meta: typeof result.count === 'number' ? { rowCount: result.count } : {},
+    };
   };
 }

--- a/src/cli/dialects/mssql.ts
+++ b/src/cli/dialects/mssql.ts
@@ -129,7 +129,7 @@ export async function introspectMssql(connection: ConnectionInfo): Promise<Table
       tablesResult.recordset.map((row) => row.table_name),
     );
   } finally {
-    await pool.close();
+    await pool.close().catch(() => undefined);
   }
 }
 

--- a/src/cli/dialects/mysql.ts
+++ b/src/cli/dialects/mysql.ts
@@ -96,7 +96,7 @@ export async function introspectMysql(connection: ConnectionInfo): Promise<Table
       (tableRows as unknown as MysqlColumnRow[]).map((row) => readField(row, 'table_name')),
     );
   } finally {
-    await connectionHandle.end();
+    await connectionHandle.end().catch(() => undefined);
   }
 }
 

--- a/src/cli/dialects/postgres.ts
+++ b/src/cli/dialects/postgres.ts
@@ -115,7 +115,7 @@ export async function introspectPostgres(connection: ConnectionInfo): Promise<Ta
       buildEnumMap(enumsResult.rows),
     );
   } finally {
-    await pool.end();
+    await pool.end().catch(() => undefined);
   }
 }
 

--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -44,6 +44,21 @@ function isRowidAlias(column: SqliteTableInfoRow, primaryKeyCount: number): bool
   );
 }
 
+const SQLITE_URL_PREFIXES = ['sqlite://', 'sqlite:', 'file://'];
+
+export function normalizeSqlitePath(url: string): string {
+  for (const prefix of SQLITE_URL_PREFIXES) {
+    if (url.startsWith(prefix)) {
+      return url.slice(prefix.length);
+    }
+  }
+  return url;
+}
+
+function isMemoryDatabase(path: string): boolean {
+  return path === ':memory:' || path.startsWith('file::memory:');
+}
+
 export async function introspectSqlite(connection: ConnectionInfo): Promise<TableSchema[]> {
   let DatabaseSyncCtor: typeof import('node:sqlite').DatabaseSync;
   try {
@@ -54,11 +69,15 @@ export async function introspectSqlite(connection: ConnectionInfo): Promise<Tabl
     );
   }
 
-  if (connection.url !== ':memory:' && !existsSync(connection.url)) {
-    throw new Error(`SQLite database file not found: "${connection.url}".`);
+  const path = connection.url.startsWith('file::memory:')
+    ? connection.url
+    : normalizeSqlitePath(connection.url);
+
+  if (!isMemoryDatabase(path) && !existsSync(path)) {
+    throw new Error(`SQLite database file not found: "${path}".`);
   }
 
-  const db = new DatabaseSyncCtor(connection.url);
+  const db = new DatabaseSyncCtor(path, { readOnly: !isMemoryDatabase(path) });
 
   try {
     const tableRows = db

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -11,6 +11,8 @@ export interface GenerateOptions {
   out: string;
   dialect?: Dialect | undefined;
   schema?: string | undefined;
+  tables?: string[] | undefined;
+  exclude?: string[] | undefined;
 }
 
 const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
@@ -30,6 +32,10 @@ export function detectDialect(url: string): Dialect {
 
   if (url.startsWith('mysql://')) {
     return 'mysql';
+  }
+
+  if (url.startsWith('sqlite://') || url.startsWith('sqlite:') || url.startsWith('file:')) {
+    return 'sqlite';
   }
 
   if (url.startsWith('mssql://') || url.startsWith('sqlserver://')) {
@@ -56,16 +62,50 @@ const INTROSPECTORS: Record<Dialect, (connection: ConnectionInfo) => Promise<Tab
   mssql: introspectMssql,
 };
 
+function filterTables(tables: TableSchema[], options: GenerateOptions): TableSchema[] {
+  const include = options.tables?.map((name) => name.toLowerCase());
+  const exclude = options.exclude?.map((name) => name.toLowerCase());
+
+  return tables.filter((table) => {
+    const name = table.name.toLowerCase();
+    if (include && !include.includes(name)) {
+      return false;
+    }
+    if (exclude?.includes(name)) {
+      return false;
+    }
+    return true;
+  });
+}
+
 export async function runGenerate(options: GenerateOptions): Promise<void> {
   const dialect = options.dialect ?? detectDialect(options.url);
   const connection: ConnectionInfo = { url: options.url, schema: options.schema };
 
-  const tables = await INTROSPECTORS[dialect](connection);
+  const introspected = await INTROSPECTORS[dialect](connection);
 
-  if (tables.length === 0) {
+  if (introspected.length === 0) {
     throw new Error('No tables found. Check the connection URL and --schema, if provided.');
   }
 
+  const tables = filterTables(introspected, options);
+
+  if (tables.length === 0) {
+    throw new Error(
+      `No tables left after filtering. Available tables: ${introspected
+        .map((table) => table.name)
+        .join(', ')}`,
+    );
+  }
+
   const source = renderSchema(tables);
-  await writeFile(options.out, source, 'utf8');
+
+  try {
+    await writeFile(options.out, source, 'utf8');
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      throw new Error(`Cannot write "${options.out}": the directory does not exist.`);
+    }
+    throw error;
+  }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,31 +1,68 @@
 #!/usr/bin/env node
+import { readFileSync } from 'node:fs';
 import type { Dialect } from './types.js';
 import { runGenerate } from './generate.js';
 
 const DIALECTS: Dialect[] = ['postgres', 'mysql', 'sqlite', 'mssql'];
+
+const USAGE = `Usage: owlsql generate --url <connection-string> [options]
+
+Options:
+  --url <string>       Connection string, or a path to a SQLite database file (required)
+  --out <file>         Output file (default: ./schema.ts)
+  --dialect <name>     ${DIALECTS.join(' | ')} (auto-detected from the URL)
+  --schema <name>      Schema/database to introspect
+  --table <a,b>        Only include the listed tables
+  --exclude <a,b>      Skip the listed tables
+  --help               Show this help
+  --version            Print the version
+`;
+
+const BOOLEAN_FLAGS = new Set(['help', 'version']);
+
+const VALUE_FLAGS = new Set(['url', 'out', 'dialect', 'schema', 'table', 'exclude']);
 
 export function parseFlags(args: string[]): Map<string, string> {
   const flags = new Map<string, string>();
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (!arg?.startsWith('--')) {
+    if (arg === undefined) {
       continue;
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument "${arg}". Flags start with --, e.g. --url.`);
     }
 
     const body = arg.slice(2);
     const equalsIndex = body.indexOf('=');
+    const name = equalsIndex === -1 ? body : body.slice(0, equalsIndex);
+
+    if (!BOOLEAN_FLAGS.has(name) && !VALUE_FLAGS.has(name)) {
+      throw new Error(`Unknown flag --${name}. Run owlsql --help for the list of flags.`);
+    }
+
+    if (flags.has(name)) {
+      throw new Error(`Duplicate flag --${name}.`);
+    }
+
+    if (BOOLEAN_FLAGS.has(name)) {
+      flags.set(name, '');
+      continue;
+    }
+
     if (equalsIndex !== -1) {
-      flags.set(body.slice(0, equalsIndex), body.slice(equalsIndex + 1));
+      flags.set(name, body.slice(equalsIndex + 1));
       continue;
     }
 
     const value = args[index + 1];
     if (value === undefined || value.startsWith('--')) {
-      throw new Error(`Missing value for --${body}`);
+      throw new Error(`Missing value for --${name}`);
     }
 
-    flags.set(body, value);
+    flags.set(name, value);
     index += 1;
   }
 
@@ -44,35 +81,93 @@ function parseDialect(raw: string | undefined): Dialect | undefined {
   return raw as Dialect;
 }
 
+function parseTableList(raw: string | undefined): string[] | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const names = raw
+    .split(',')
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+  return names.length > 0 ? names : undefined;
+}
+
+function readVersion(): string {
+  const packageJsonUrl = new URL('../../package.json', import.meta.url);
+  const parsed: unknown = JSON.parse(readFileSync(packageJsonUrl, 'utf8'));
+  if (parsed && typeof parsed === 'object' && 'version' in parsed) {
+    return String((parsed as { version: unknown }).version);
+  }
+  return 'unknown';
+}
+
+export function formatCliError(error: unknown): string {
+  if (error instanceof AggregateError) {
+    const first = error.errors.find(
+      (inner): inner is Error => inner instanceof Error && inner.message.length > 0,
+    );
+    if (first) {
+      return first.message;
+    }
+    return error.message.length > 0 ? error.message : 'Connection failed.';
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}
+
 async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);
 
+  if (command === undefined || command === '--help' || command === '-h') {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  if (command === '--version' || command === '-v') {
+    process.stdout.write(`${readVersion()}\n`);
+    return;
+  }
+
   if (command !== 'generate') {
-    process.stderr.write(
-      'Usage: owlsql generate --url <connection-string> [--out ./schema.ts] [--dialect postgres|mysql|sqlite|mssql] [--schema <name>]\n',
-    );
-    process.exitCode = command === undefined ? 0 : 1;
+    process.stderr.write(USAGE);
+    process.exitCode = 1;
     return;
   }
 
   const flags = parseFlags(rest);
+
+  if (flags.has('help')) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  if (flags.has('version')) {
+    process.stdout.write(`${readVersion()}\n`);
+    return;
+  }
+
   const url = flags.get('url');
   if (!url) {
     throw new Error('--url is required, e.g. --url postgres://user:pass@host/db');
   }
 
+  const out = flags.get('out') ?? './schema.ts';
+
   await runGenerate({
     url,
-    out: flags.get('out') ?? './schema.ts',
+    out,
     dialect: parseDialect(flags.get('dialect')),
     schema: flags.get('schema'),
+    tables: parseTableList(flags.get('table')),
+    exclude: parseTableList(flags.get('exclude')),
   });
 
-  process.stdout.write(`Wrote ${flags.get('out') ?? './schema.ts'}\n`);
+  process.stdout.write(`Wrote ${out}\n`);
 }
 
 main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`Error: ${message}\n`);
+  process.stderr.write(`Error: ${formatCliError(error)}\n`);
   process.exitCode = 1;
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,10 @@ import type {
   InferRow,
   InferResultStrict,
   InferRowStrict,
+  QueryTypeError,
 } from './parse.js';
-import type { InferParams } from './params.js';
-import { type Result, ok, err } from './result.js';
+import type { InferParams, UsedPlaceholderStyles } from './params.js';
+import { type Result, type QueryMeta, ok, err } from './result.js';
 
 export type {
   Schema,
@@ -21,7 +22,7 @@ export type {
 export type { ParseSelect, ParseStatement, ParsedStatement, Source } from './parse.js';
 export type { FunctionReturnTypes } from './functions.js';
 export type { InferParams } from './params.js';
-export type { Result, Ok, Err } from './result.js';
+export type { Result, Ok, Err, QueryMeta } from './result.js';
 export { ResultStatus, ok, err, isOk, isErr } from './result.js';
 
 export type Query<DB extends SchemaLike, Q extends string> = InferResult<DB, Q>;
@@ -45,20 +46,55 @@ export interface QueryError {
   cause?: unknown;
 }
 
-export type Executor = (sql: string, params: readonly unknown[]) => Promise<unknown[]>;
+export type ExecutorResult = unknown[] | { rows: unknown[]; meta?: QueryMeta };
+
+export type Executor = (sql: string, params: readonly unknown[]) => Promise<ExecutorResult>;
+
+export type PlaceholderStyle = 'dollar' | 'question' | 'at';
+
+export type DialectExecutor<Style extends PlaceholderStyle = PlaceholderStyle> = Executor & {
+  readonly __placeholderStyle?: Style;
+};
+
+type ValidatePlaceholderStyle<
+  Q extends string,
+  Style extends PlaceholderStyle,
+> = PlaceholderStyle extends Style
+  ? unknown
+  : [UsedPlaceholderStyles<Q>] extends [never]
+    ? unknown
+    : [UsedPlaceholderStyles<Q>] extends [Style]
+      ? unknown
+      : QueryTypeError<'the query placeholder style does not match the executor dialect'>;
 
 export interface TypedDbOptions {
   strict?: boolean;
+  placeholders?: PlaceholderStyle;
 }
 
-export interface TypedDb<DB extends SchemaLike, Strict extends boolean = false> {
+type OptionsStyle<Options> = Options extends { placeholders: infer Style extends PlaceholderStyle }
+  ? Style
+  : PlaceholderStyle;
+
+export interface TypedDb<
+  DB extends SchemaLike,
+  Strict extends boolean = false,
+  Style extends PlaceholderStyle = PlaceholderStyle,
+> {
   readonly __owlsqlTypedDb?: true;
   query<Q extends string>(
-    sql: Q,
+    sql: Q & ValidatePlaceholderStyle<Q, Style>,
     ...params: InferParams<DB, Q>
   ): Promise<
     Result<Strict extends true ? InferResultStrict<DB, Q> : InferResult<DB, Q>, QueryError>
   >;
+}
+
+function describeCause(cause: unknown): string {
+  if (cause instanceof Error && cause.message.length > 0) {
+    return cause.message;
+  }
+  return String(cause);
 }
 
 export function createTypedDb<
@@ -67,7 +103,7 @@ export function createTypedDb<
 >(
   executor: Executor,
   options?: Options,
-): TypedDb<DB, Options extends { strict: true } ? true : false> {
+): TypedDb<DB, Options extends { strict: true } ? true : false, OptionsStyle<Options>> {
   void options;
   return {
     async query(sql, ...params) {
@@ -79,12 +115,14 @@ export function createTypedDb<
       }
 
       try {
-        const rows = await executor(sql, params);
-        return ok(rows as never);
+        const executed = await executor(sql, params);
+        const rows = Array.isArray(executed) ? executed : executed.rows;
+        const meta = Array.isArray(executed) ? undefined : executed.meta;
+        return ok(rows as never, meta);
       } catch (cause) {
         return err({
           kind: QueryErrorKind.ExecutorFailed,
-          message: 'The executor threw while running the query.',
+          message: `The executor threw while running the query: ${describeCause(cause)}`,
           cause,
         });
       }

--- a/src/params.ts
+++ b/src/params.ts
@@ -269,6 +269,17 @@ type CteBodiesHavePlaceholder<Q extends string> = [ParseWithClause<Normalize<Q>>
     ? AnyCteBodyHasPlaceholder<Ctes>
     : false;
 
+type StripDoubledAt<S extends string> = S extends `${infer Before}@@${infer After}`
+  ? StripDoubledAt<`${Before}${After}`>
+  : S;
+
+export type UsedPlaceholderStyles<Q extends string> = Normalize<Q> extends infer Text extends string
+  ?
+      | (Text extends `${string}?${string}` ? 'question' : never)
+      | (Text extends `${string}$${string}` ? 'dollar' : never)
+      | (StripDoubledAt<Text> extends `${string}@${string}` ? 'at' : never)
+  : never;
+
 export type InferParams<DB extends SchemaLike, Q extends string> =
   IsKeyword<FirstWord<Normalize<Q>>, 'insert'> extends true
     ? InsertParamTypes<DB, Normalize<Q>>

--- a/src/result.ts
+++ b/src/result.ts
@@ -3,9 +3,15 @@ export enum ResultStatus {
   Error = 'ERROR',
 }
 
+export interface QueryMeta {
+  rowCount?: number | bigint;
+  lastInsertRowid?: number | bigint;
+}
+
 export interface Ok<T> {
   status: ResultStatus.Ok;
   value: T;
+  meta?: QueryMeta;
 }
 
 export interface Err<E> {
@@ -15,8 +21,10 @@ export interface Err<E> {
 
 export type Result<T, E> = Ok<T> | Err<E>;
 
-export function ok<T>(value: T): Ok<T> {
-  return { status: ResultStatus.Ok, value };
+export function ok<T>(value: T, meta?: QueryMeta): Ok<T> {
+  return meta === undefined
+    ? { status: ResultStatus.Ok, value }
+    : { status: ResultStatus.Ok, value, meta };
 }
 
 export function err<E>(error: E): Err<E> {

--- a/src/ts-plugin/detect.cts
+++ b/src/ts-plugin/detect.cts
@@ -13,7 +13,7 @@ function findNodeAtPosition(typescript: TypeScript, sourceFile: ts.SourceFile, p
   let best: ts.Node = sourceFile;
 
   const visit = (node: ts.Node): void => {
-    if (position < node.getFullStart() || position > node.getEnd()) {
+    if (position < node.getFullStart() || position >= node.getEnd()) {
       return;
     }
 

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -25,81 +25,90 @@ function init(modules: { typescript: typeof ts }) {
       position,
       options,
     ) => {
-      const prior = info.languageService.getCompletionsAtPosition(fileName, position, options);
+      const native = () =>
+        info.languageService.getCompletionsAtPosition(fileName, position, options);
 
-      const program = info.languageService.getProgram();
-      const sourceFile = program?.getSourceFile(fileName);
-      if (!program || !sourceFile) {
-        return prior;
+      try {
+        const program = info.languageService.getProgram();
+        const sourceFile = program?.getSourceFile(fileName);
+        if (!program || !sourceFile) {
+          return native();
+        }
+
+        const checker = program.getTypeChecker();
+        const match = matchQueryLiteral(typescript, checker, sourceFile, position);
+        if (!match) {
+          return native();
+        }
+
+        const literalStart = match.literal.getStart(sourceFile) + 1;
+        const textBeforeCursor = sourceFile.text.slice(literalStart, position);
+        const context = getSelectListContext(textBeforeCursor) ?? getWhereClauseContext(textBeforeCursor);
+        if (!context) {
+          return native();
+        }
+
+        const fullLiteralText = match.literal.text;
+        const table = findFromTable(fullLiteralText);
+        const columns = getColumnNames(checker, match.dbType, match.literal, table);
+        const filtered = columns.filter((name) => name.startsWith(context.prefix));
+
+        return {
+          isGlobalCompletion: false,
+          isMemberCompletion: false,
+          isNewIdentifierLocation: false,
+          entries: filtered.map((name) => ({
+            name,
+            kind: typescript.ScriptElementKind.memberVariableElement,
+            sortText: '0',
+          })),
+        };
+      } catch {
+        return native();
       }
-
-      const checker = program.getTypeChecker();
-      const match = matchQueryLiteral(typescript, checker, sourceFile, position);
-      if (!match) {
-        return prior;
-      }
-
-      const literalStart = match.literal.getStart(sourceFile) + 1;
-      const textBeforeCursor = sourceFile.text.slice(literalStart, position);
-      const context = getSelectListContext(textBeforeCursor) ?? getWhereClauseContext(textBeforeCursor);
-      if (!context) {
-        return prior;
-      }
-
-      const fullLiteralText = match.literal.text;
-      const table = findFromTable(fullLiteralText);
-      const columns = getColumnNames(checker, match.dbType, match.literal, table);
-      const filtered = columns.filter((name) => name.startsWith(context.prefix));
-
-      return {
-        isGlobalCompletion: false,
-        isMemberCompletion: false,
-        isNewIdentifierLocation: false,
-        entries: filtered.map((name) => ({
-          name,
-          kind: typescript.ScriptElementKind.memberVariableElement,
-          sortText: '0',
-        })),
-      };
     };
 
     proxy.getCompletionsAtPosition = getCompletionsAtPosition;
 
     const getQuickInfoAtPosition: ts.LanguageService['getQuickInfoAtPosition'] = (fileName, position) => {
-      const prior = info.languageService.getQuickInfoAtPosition(fileName, position);
+      const native = () => info.languageService.getQuickInfoAtPosition(fileName, position);
 
-      const program = info.languageService.getProgram();
-      const sourceFile = program?.getSourceFile(fileName);
-      if (!program || !sourceFile) {
-        return prior;
+      try {
+        const program = info.languageService.getProgram();
+        const sourceFile = program?.getSourceFile(fileName);
+        if (!program || !sourceFile) {
+          return native();
+        }
+
+        const checker = program.getTypeChecker();
+        const match = matchQueryLiteral(typescript, checker, sourceFile, position);
+        if (!match) {
+          return native();
+        }
+
+        const literalStart = match.literal.getStart(sourceFile) + 1;
+        const word = getWordAtOffset(match.literal.text, position - literalStart);
+        if (!word) {
+          return native();
+        }
+
+        const table = findFromTable(match.literal.text);
+        const columnType = getColumnType(checker, match.dbType, match.literal, table, word.word);
+        if (!columnType) {
+          return native();
+        }
+
+        const typeText = checker.typeToString(columnType);
+
+        return {
+          kind: typescript.ScriptElementKind.memberVariableElement,
+          kindModifiers: '',
+          textSpan: { start: literalStart + word.start, length: word.end - word.start },
+          displayParts: [{ text: `(column) ${word.word}: ${typeText}`, kind: 'text' }],
+        };
+      } catch {
+        return native();
       }
-
-      const checker = program.getTypeChecker();
-      const match = matchQueryLiteral(typescript, checker, sourceFile, position);
-      if (!match) {
-        return prior;
-      }
-
-      const literalStart = match.literal.getStart(sourceFile) + 1;
-      const word = getWordAtOffset(match.literal.text, position - literalStart);
-      if (!word) {
-        return prior;
-      }
-
-      const table = findFromTable(match.literal.text);
-      const columnType = getColumnType(checker, match.dbType, match.literal, table, word.word);
-      if (!columnType) {
-        return prior;
-      }
-
-      const typeText = checker.typeToString(columnType);
-
-      return {
-        kind: typescript.ScriptElementKind.memberVariableElement,
-        kindModifiers: '',
-        textSpan: { start: literalStart + word.start, length: word.end - word.start },
-        displayParts: [{ text: `(column) ${word.word}: ${typeText}`, kind: 'text' }],
-      };
     };
 
     proxy.getQuickInfoAtPosition = getQuickInfoAtPosition;

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -51,7 +51,17 @@ function init(modules: { typescript: typeof ts }) {
         const fullLiteralText = match.literal.text;
         const table = findFromTable(fullLiteralText);
         const columns = getColumnNames(checker, match.dbType, match.literal, table);
-        const filtered = columns.filter((name) => name.startsWith(context.prefix));
+        const prefix = context.prefix.toLowerCase();
+        const filtered = columns.filter((name) => name.toLowerCase().startsWith(prefix));
+
+        if (filtered.length === 0) {
+          return native();
+        }
+
+        const replacementSpan = {
+          start: position - context.prefix.length,
+          length: context.prefix.length,
+        };
 
         return {
           isGlobalCompletion: false,
@@ -61,6 +71,7 @@ function init(modules: { typescript: typeof ts }) {
             name,
             kind: typescript.ScriptElementKind.memberVariableElement,
             sortText: '0',
+            replacementSpan,
           })),
         };
       } catch {
@@ -69,6 +80,60 @@ function init(modules: { typescript: typeof ts }) {
     };
 
     proxy.getCompletionsAtPosition = getCompletionsAtPosition;
+
+    const getCompletionEntryDetails: ts.LanguageService['getCompletionEntryDetails'] = (
+      fileName,
+      position,
+      entryName,
+      formatOptions,
+      source,
+      preferences,
+      data,
+    ) => {
+      const native = () =>
+        info.languageService.getCompletionEntryDetails(
+          fileName,
+          position,
+          entryName,
+          formatOptions,
+          source,
+          preferences,
+          data,
+        );
+
+      try {
+        const program = info.languageService.getProgram();
+        const sourceFile = program?.getSourceFile(fileName);
+        if (!program || !sourceFile) {
+          return native();
+        }
+
+        const checker = program.getTypeChecker();
+        const match = matchQueryLiteral(typescript, checker, sourceFile, position);
+        if (!match) {
+          return native();
+        }
+
+        const table = findFromTable(match.literal.text);
+        const columnType = getColumnType(checker, match.dbType, match.literal, table, entryName);
+        if (!columnType) {
+          return native();
+        }
+
+        return {
+          name: entryName,
+          kind: typescript.ScriptElementKind.memberVariableElement,
+          kindModifiers: '',
+          displayParts: [
+            { text: `(column) ${entryName}: ${checker.typeToString(columnType)}`, kind: 'text' },
+          ],
+        };
+      } catch {
+        return native();
+      }
+    };
+
+    proxy.getCompletionEntryDetails = getCompletionEntryDetails;
 
     const getQuickInfoAtPosition: ts.LanguageService['getQuickInfoAtPosition'] = (fileName, position) => {
       const native = () => info.languageService.getQuickInfoAtPosition(fileName, position);

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -152,12 +152,13 @@ function init(modules: { typescript: typeof ts }) {
         }
 
         const literalStart = match.literal.getStart(sourceFile) + 1;
-        const word = getWordAtOffset(match.literal.text, position - literalStart);
+        const rawLiteralText = sourceFile.text.slice(literalStart, match.literal.getEnd() - 1);
+        const word = getWordAtOffset(rawLiteralText, position - literalStart);
         if (!word) {
           return native();
         }
 
-        const table = findFromTable(match.literal.text);
+        const table = findFromTable(rawLiteralText);
         const columnType = getColumnType(checker, match.dbType, match.literal, table, word.word);
         if (!columnType) {
           return native();

--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -1,7 +1,7 @@
 const SELECT_START = /^select\b/i;
 const HAS_FROM = /\bfrom\b/i;
-const HAS_WHERE = /\bwhere\b/i;
-const TRAILING_WORD = /([A-Za-z_][A-Za-z0-9_]*)$/;
+const HAS_COLUMN_CLAUSE = /\b(where|having|on|order\s+by|group\s+by)\b/i;
+const TRAILING_TOKEN = /([A-Za-z0-9_]+)$/;
 const FROM_TABLE = /\bfrom\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)/i;
 const WORD_CHAR = /[A-Za-z0-9_]/;
 const WORD_START_CHAR = /[A-Za-z_]/;
@@ -16,36 +16,77 @@ interface WordAtOffset {
   end: number;
 }
 
+interface StrippedText {
+  stripped: string;
+  insideLiteral: boolean;
+}
+
+function stripStringLiterals(text: string): StrippedText {
+  let stripped = '';
+  let insideLiteral = false;
+
+  for (const char of text) {
+    if (char === "'") {
+      insideLiteral = !insideLiteral;
+      stripped += char;
+      continue;
+    }
+    if (!insideLiteral) {
+      stripped += char;
+    }
+  }
+
+  return { stripped, insideLiteral };
+}
+
+function prefixFrom(textBeforeCursor: string): SelectListContext | null {
+  const token = TRAILING_TOKEN.exec(textBeforeCursor)?.[1];
+  if (token === undefined) {
+    return { prefix: '' };
+  }
+  if (!WORD_START_CHAR.test(token[0] ?? '')) {
+    return null;
+  }
+  return { prefix: token };
+}
+
 function getSelectListContext(textBeforeCursor: string): SelectListContext | null {
-  const trimmed = textBeforeCursor.trimStart();
-
-  if (!SELECT_START.test(trimmed)) {
+  const { stripped, insideLiteral } = stripStringLiterals(textBeforeCursor);
+  if (insideLiteral) {
     return null;
   }
 
-  if (HAS_FROM.test(textBeforeCursor)) {
+  if (!SELECT_START.test(stripped.trimStart())) {
     return null;
   }
 
-  const match = TRAILING_WORD.exec(textBeforeCursor);
-  return { prefix: match?.[1] ?? '' };
+  if (HAS_FROM.test(stripped)) {
+    return null;
+  }
+
+  return prefixFrom(textBeforeCursor);
 }
 
 function getWhereClauseContext(textBeforeCursor: string): SelectListContext | null {
-  if (!HAS_FROM.test(textBeforeCursor)) {
+  const { stripped, insideLiteral } = stripStringLiterals(textBeforeCursor);
+  if (insideLiteral) {
     return null;
   }
 
-  if (!HAS_WHERE.test(textBeforeCursor)) {
+  if (!HAS_FROM.test(stripped)) {
     return null;
   }
 
-  const match = TRAILING_WORD.exec(textBeforeCursor);
-  return { prefix: match?.[1] ?? '' };
+  if (!HAS_COLUMN_CLAUSE.test(stripped)) {
+    return null;
+  }
+
+  return prefixFrom(textBeforeCursor);
 }
 
 function findFromTable(fullLiteralText: string): string | null {
-  const match = FROM_TABLE.exec(fullLiteralText);
+  const { stripped } = stripStringLiterals(fullLiteralText);
+  const match = FROM_TABLE.exec(stripped);
   return match?.[1] ?? null;
 }
 

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ConnectionPool } from 'mssql';
+import { createMssqlExecutor } from '../src/adapters/mssql.js';
+
+interface FakeRequest {
+  input: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
+}
+
+function fakePool(result: unknown): { pool: ConnectionPool; request: FakeRequest } {
+  const request: FakeRequest = {
+    input: vi.fn(),
+    query: vi.fn().mockResolvedValue(result),
+  };
+  const pool = { request: () => request } as unknown as ConnectionPool;
+  return { pool, request };
+}
+
+describe('createMssqlExecutor', () => {
+  it('binds @name placeholders by name in order of first appearance', async () => {
+    const { pool, request } = fakePool({ recordset: [{ id: 1 }] });
+    const executor = createMssqlExecutor(pool);
+
+    const rows = await executor('select id from users where name = @name and id = @id', [
+      'ada',
+      7,
+    ]);
+
+    expect(request.input.mock.calls).toEqual([
+      ['name', 'ada'],
+      ['id', 7],
+    ]);
+    expect(rows).toEqual([{ id: 1 }]);
+  });
+
+  it('binds a repeated @name once', async () => {
+    const { pool, request } = fakePool({ recordset: [] });
+    const executor = createMssqlExecutor(pool);
+
+    await executor('select id from users where id = @id or parent_id = @id', [7]);
+
+    expect(request.input.mock.calls).toEqual([['id', 7]]);
+  });
+
+  it('ignores @@system variables and literals containing @', async () => {
+    const { pool, request } = fakePool({ recordset: [] });
+    const executor = createMssqlExecutor(pool);
+
+    await executor("select id from users where email like '%@%' and id = @@rowcount", []);
+
+    expect(request.input).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array when a write produces no recordset', async () => {
+    const { pool } = fakePool({ recordset: undefined });
+    const executor = createMssqlExecutor(pool);
+
+    const rows = await executor('update users set name = @name where id = @id', ['ada', 1]);
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -21,7 +21,7 @@ describe('createMssqlExecutor', () => {
     const { pool, request } = fakePool({ recordset: [{ id: 1 }] });
     const executor = createMssqlExecutor(pool);
 
-    const rows = await executor('select id from users where name = @name and id = @id', [
+    const result = await executor('select id from users where name = @name and id = @id', [
       'ada',
       7,
     ]);
@@ -30,7 +30,7 @@ describe('createMssqlExecutor', () => {
       ['name', 'ada'],
       ['id', 7],
     ]);
-    expect(rows).toEqual([{ id: 1 }]);
+    expect(result).toEqual({ rows: [{ id: 1 }], meta: {} });
   });
 
   it('binds a repeated @name once', async () => {
@@ -51,12 +51,12 @@ describe('createMssqlExecutor', () => {
     expect(request.input).not.toHaveBeenCalled();
   });
 
-  it('returns an empty array when a write produces no recordset', async () => {
-    const { pool } = fakePool({ recordset: undefined });
+  it('returns empty rows and rowCount metadata when a write produces no recordset', async () => {
+    const { pool } = fakePool({ recordset: undefined, rowsAffected: [3] });
     const executor = createMssqlExecutor(pool);
 
-    const rows = await executor('update users set name = @name where id = @id', ['ada', 1]);
+    const result = await executor('update users set name = @name where id = @id', ['ada', 1]);
 
-    expect(rows).toEqual([]);
+    expect(result).toEqual({ rows: [], meta: { rowCount: 3 } });
   });
 });

--- a/tests/adapter-mysql2.test.ts
+++ b/tests/adapter-mysql2.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Pool } from 'mysql2/promise';
+import { createMysql2Executor } from '../src/adapters/mysql2.js';
+
+function fakePool(result: unknown): { pool: Pool; execute: ReturnType<typeof vi.fn> } {
+  const execute = vi.fn().mockResolvedValue([result, undefined]);
+  return { pool: { execute } as unknown as Pool, execute };
+}
+
+describe('createMysql2Executor', () => {
+  it('returns row arrays from SELECT results', async () => {
+    const rows = [{ id: 1 }, { id: 2 }];
+    const { pool, execute } = fakePool(rows);
+
+    const executor = createMysql2Executor(pool);
+    const result = await executor('select id from users', []);
+
+    expect(result).toEqual(rows);
+    expect(execute).toHaveBeenCalledWith('select id from users', []);
+  });
+
+  it('returns an empty array instead of a ResultSetHeader for writes', async () => {
+    const header = { affectedRows: 1, insertId: 7, fieldCount: 0 };
+    const { pool } = fakePool(header);
+
+    const executor = createMysql2Executor(pool);
+    const result = await executor('insert into users (name) values (?)', ['ada']);
+
+    expect(result).toEqual([]);
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('uses execute for server-side parameter binding', async () => {
+    const { pool, execute } = fakePool([]);
+
+    const executor = createMysql2Executor(pool);
+    await executor('select id from users where id = ?', [7]);
+
+    expect(execute).toHaveBeenCalledWith('select id from users where id = ?', [7]);
+  });
+});

--- a/tests/adapter-mysql2.test.ts
+++ b/tests/adapter-mysql2.test.ts
@@ -19,15 +19,14 @@ describe('createMysql2Executor', () => {
     expect(execute).toHaveBeenCalledWith('select id from users', []);
   });
 
-  it('returns an empty array instead of a ResultSetHeader for writes', async () => {
+  it('returns empty rows plus write metadata instead of a ResultSetHeader', async () => {
     const header = { affectedRows: 1, insertId: 7, fieldCount: 0 };
     const { pool } = fakePool(header);
 
     const executor = createMysql2Executor(pool);
     const result = await executor('insert into users (name) values (?)', ['ada']);
 
-    expect(result).toEqual([]);
-    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual({ rows: [], meta: { rowCount: 1, lastInsertRowid: 7 } });
   });
 
   it('uses execute for server-side parameter binding', async () => {

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { DatabaseSync } from 'node:sqlite';
 import { createTypedDb, isOk } from '../src/index';
 import { createNodeSqliteExecutor } from '../src/adapters/node-sqlite';
+import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
 
 interface DB {
   users: { id: number; name: string };
 }
 
-function seededDatabase(): DatabaseSync {
+function seededDatabase(): import('node:sqlite').DatabaseSync {
+  const DatabaseSync = loadSqlite();
   const db = new DatabaseSync(':memory:');
   db.exec('create table users (id integer primary key, name text not null)');
   db.prepare('insert into users (id, name) values (?, ?)').run(1, 'ada');
@@ -15,7 +16,7 @@ function seededDatabase(): DatabaseSync {
   return db;
 }
 
-describe('createNodeSqliteExecutor', () => {
+describe.skipIf(!sqliteAvailable)('createNodeSqliteExecutor', () => {
   it('runs a real query against an in-memory node:sqlite database', async () => {
     const sqlite = seededDatabase();
     const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
@@ -73,6 +74,7 @@ describe('createNodeSqliteExecutor', () => {
   });
 
   it('coerces boolean and Date params to driver-supported values', async () => {
+    const DatabaseSync = loadSqlite();
     const sqlite = new DatabaseSync(':memory:');
     sqlite.exec('create table flags (id integer primary key, active integer, seen_at text)');
     const executor = createNodeSqliteExecutor(sqlite);

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -42,4 +42,59 @@ describe('createNodeSqliteExecutor', () => {
       expect(result.value).toEqual([{ id: 2, name: 'grace' }]);
     }
   });
+
+  it('routes @name and $name placeholders through the named-parameters object', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const atResult = await db.query('select id, name from users where id = @id', 1);
+    expect(isOk(atResult)).toBe(true);
+    if (isOk(atResult)) {
+      expect(atResult.value).toEqual([{ id: 1, name: 'ada' }]);
+    }
+
+    const dollarResult = await db.query('select id, name from users where name = $name', 'grace');
+    expect(isOk(dollarResult)).toBe(true);
+    if (isOk(dollarResult)) {
+      expect(dollarResult.value).toEqual([{ id: 2, name: 'grace' }]);
+    }
+  });
+
+  it('ignores named-parameter lookalikes inside string literals', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const result = await db.query("select id from users where name = 'no @param here' or id = ?", 1);
+
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value).toEqual([{ id: 1 }]);
+    }
+  });
+
+  it('coerces boolean and Date params to driver-supported values', async () => {
+    const sqlite = new DatabaseSync(':memory:');
+    sqlite.exec('create table flags (id integer primary key, active integer, seen_at text)');
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    const stamp = new Date('2026-01-02T03:04:05.000Z');
+    await executor('insert into flags (id, active, seen_at) values (?, ?, ?)', [1, true, stamp]);
+
+    const rows = await executor('select active, seen_at from flags where id = ?', [1]);
+    expect(rows).toEqual([{ active: 1, seen_at: '2026-01-02T03:04:05.000Z' }]);
+  });
+
+  it('supports an INSERT round-trip through the typed client', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const insert = await db.query('insert into users (id, name) values ($1, $2)', 3, 'lin');
+    expect(isOk(insert)).toBe(true);
+
+    const rows = await db.query('select name from users where id = ?', 3);
+    expect(isOk(rows)).toBe(true);
+    if (isOk(rows)) {
+      expect(rows.value).toEqual([{ name: 'lin' }]);
+    }
+  });
 });

--- a/tests/adapters.test-d.ts
+++ b/tests/adapters.test-d.ts
@@ -1,4 +1,4 @@
-import type { Executor } from '../src/index.js';
+import type { Executor, DialectExecutor } from '../src/index.js';
 import type { Pool as PgPool, Client as PgClient, PoolClient as PgPoolClient } from 'pg';
 import type { Pool as Mysql2Pool, Connection as Mysql2Connection } from 'mysql2/promise';
 import type postgres from 'postgres';
@@ -18,19 +18,22 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type PgExecutorMatchesShape = Expect<
-  Equal<ReturnType<typeof createPgExecutor>, Executor>
+  Equal<ReturnType<typeof createPgExecutor>, DialectExecutor<'dollar'>>
 >;
 
 type Mysql2ExecutorMatchesShape = Expect<
-  Equal<ReturnType<typeof createMysql2Executor>, Executor>
+  Equal<ReturnType<typeof createMysql2Executor>, DialectExecutor<'question'>>
 >;
 
 type PostgresJsExecutorMatchesShape = Expect<
-  Equal<ReturnType<typeof createPostgresJsExecutor>, Executor>
+  Equal<ReturnType<typeof createPostgresJsExecutor>, DialectExecutor<'dollar'>>
 >;
 
 type NodeSqliteExecutorMatchesShape = Expect<
-  Equal<ReturnType<typeof createNodeSqliteExecutor>, Executor>
+  Equal<
+    ReturnType<typeof createNodeSqliteExecutor>,
+    DialectExecutor<'question' | 'at' | 'dollar'>
+  >
 >;
 
 type KyselyExecutorMatchesShape = Expect<

--- a/tests/adapters.test-d.ts
+++ b/tests/adapters.test-d.ts
@@ -1,6 +1,6 @@
 import type { Executor } from '../src/index.js';
-import type { Pool as PgPool } from 'pg';
-import type { Pool as Mysql2Pool } from 'mysql2/promise';
+import type { Pool as PgPool, Client as PgClient, PoolClient as PgPoolClient } from 'pg';
+import type { Pool as Mysql2Pool, Connection as Mysql2Connection } from 'mysql2/promise';
 import type postgres from 'postgres';
 import type { DatabaseSync } from 'node:sqlite';
 import type { Kysely } from 'kysely';
@@ -39,7 +39,10 @@ type KyselyExecutorMatchesShape = Expect<
 
 export function adapterCallSites() {
   createPgExecutor({} as PgPool);
+  createPgExecutor({} as PgClient);
+  createPgExecutor({} as PgPoolClient);
   createMysql2Executor({} as Mysql2Pool);
+  createMysql2Executor({} as Mysql2Connection);
   createPostgresJsExecutor({} as postgres.Sql);
   createNodeSqliteExecutor({} as DatabaseSync);
   createKyselyExecutor({} as Kysely<{ users: { id: number } }>);

--- a/tests/cli-flags.test.ts
+++ b/tests/cli-flags.test.ts
@@ -29,4 +29,30 @@ describe('parseFlags', () => {
     expect(() => parseFlags(['--url'])).toThrow('Missing value for --url');
     expect(() => parseFlags(['--url', '--out', './schema.ts'])).toThrow('Missing value for --url');
   });
+
+  it('rejects unknown flags instead of ignoring them', () => {
+    expect(() => parseFlags(['--output', './x.ts'])).toThrow('Unknown flag --output');
+    expect(() => parseFlags(['--shema', 'app'])).toThrow('Unknown flag --shema');
+  });
+
+  it('rejects positional arguments', () => {
+    expect(() => parseFlags(['generate.ts'])).toThrow('Unexpected argument "generate.ts"');
+  });
+
+  it('rejects duplicate flags instead of last-win', () => {
+    expect(() => parseFlags(['--out', 'a.ts', '--out', 'b.ts'])).toThrow('Duplicate flag --out');
+  });
+
+  it('treats --help and --version as boolean flags', () => {
+    expect(parseFlags(['--help']).has('help')).toBe(true);
+    expect(parseFlags(['--version']).has('version')).toBe(true);
+    const flags = parseFlags(['--help', '--url', 'x']);
+    expect(flags.get('url')).toBe('x');
+  });
+
+  it('accepts --table and --exclude lists', () => {
+    const flags = parseFlags(['--table', 'users,posts', '--exclude', 'migrations']);
+    expect(flags.get('table')).toBe('users,posts');
+    expect(flags.get('exclude')).toBe('migrations');
+  });
 });

--- a/tests/cli-generate.test.ts
+++ b/tests/cli-generate.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { DatabaseSync } from 'node:sqlite';
 import { runGenerate, detectDialect } from '../src/cli/generate';
+import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
 
 describe('detectDialect', () => {
   it('detects postgres, mysql, and mssql from the URL scheme', () => {
@@ -27,14 +27,14 @@ describe('detectDialect', () => {
   });
 });
 
-describe('runGenerate (end to end against a real sqlite file)', () => {
+describe.skipIf(!sqliteAvailable)('runGenerate (end to end against a real sqlite file)', () => {
   it('introspects the database and writes the rendered schema to --out', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
     const dbFile = join(dir, 'app.db');
     const outFile = join(dir, 'schema.ts');
 
     try {
-      const db = new DatabaseSync(dbFile);
+      const db = new (loadSqlite())(dbFile);
       db.exec('create table users (id integer primary key, name text not null, bio text)');
       db.close();
 
@@ -60,7 +60,7 @@ describe('runGenerate (end to end against a real sqlite file)', () => {
     const dbFile = join(dir, 'empty.db');
 
     try {
-      const db = new DatabaseSync(dbFile);
+      const db = new (loadSqlite())(dbFile);
       db.close();
 
       await expect(

--- a/tests/cli-sqlite-introspect.test.ts
+++ b/tests/cli-sqlite-introspect.test.ts
@@ -2,19 +2,20 @@ import { describe, it, expect } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { DatabaseSync } from 'node:sqlite';
+import type { DatabaseSync } from 'node:sqlite';
 import { introspectSqlite } from '../src/cli/dialects/sqlite';
+import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
 
 function withTempDatabase(setup: (db: DatabaseSync) => void): string {
   const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
   const file = join(dir, 'test.db');
-  const db = new DatabaseSync(file);
+  const db = new (loadSqlite())(file);
   setup(db);
   db.close();
   return file;
 }
 
-describe('introspectSqlite', () => {
+describe.skipIf(!sqliteAvailable)('introspectSqlite', () => {
   it('introspects columns, types, and nullability from a real database file', async () => {
     const file = withTempDatabase((db) => {
       db.exec(`

--- a/tests/cli-ux.test.ts
+++ b/tests/cli-ux.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { DatabaseSync } from 'node:sqlite';
 import { detectDialect, runGenerate } from '../src/cli/generate.js';
+import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
 import { normalizeSqlitePath } from '../src/cli/dialects/sqlite.js';
 import { formatCliError } from '../src/cli/index.js';
 
 function createDatabase(): { dir: string; file: string } {
   const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
   const file = join(dir, 'app.db');
-  const db = new DatabaseSync(file);
+  const db = new (loadSqlite())(file);
   db.exec('create table users (id integer primary key, name text not null)');
   db.exec('create table posts (id integer primary key, title text not null)');
   db.close();
@@ -31,7 +31,7 @@ describe('sqlite URL forms', () => {
     expect(normalizeSqlitePath('./app.db')).toBe('./app.db');
   });
 
-  it('introspects through a sqlite:// URL', async () => {
+  it.skipIf(!sqliteAvailable)('introspects through a sqlite:// URL', async () => {
     const { dir, file } = createDatabase();
     try {
       const out = join(dir, 'schema.ts');
@@ -42,7 +42,7 @@ describe('sqlite URL forms', () => {
   });
 });
 
-describe('table filtering', () => {
+describe.skipIf(!sqliteAvailable)('table filtering', () => {
   it('honors --table include lists', async () => {
     const { dir, file } = createDatabase();
     try {
@@ -84,7 +84,7 @@ describe('table filtering', () => {
   });
 });
 
-describe('write errors', () => {
+describe.skipIf(!sqliteAvailable)('write errors', () => {
   it('reports a missing output directory clearly', async () => {
     const { dir, file } = createDatabase();
     try {

--- a/tests/cli-ux.test.ts
+++ b/tests/cli-ux.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+import { detectDialect, runGenerate } from '../src/cli/generate.js';
+import { normalizeSqlitePath } from '../src/cli/dialects/sqlite.js';
+import { formatCliError } from '../src/cli/index.js';
+
+function createDatabase(): { dir: string; file: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
+  const file = join(dir, 'app.db');
+  const db = new DatabaseSync(file);
+  db.exec('create table users (id integer primary key, name text not null)');
+  db.exec('create table posts (id integer primary key, title text not null)');
+  db.close();
+  return { dir, file };
+}
+
+describe('sqlite URL forms', () => {
+  it('routes sqlite:// and file: URLs to the sqlite dialect', () => {
+    expect(detectDialect('sqlite://./app.db')).toBe('sqlite');
+    expect(detectDialect('sqlite:./app.db')).toBe('sqlite');
+    expect(detectDialect('file:./app.db')).toBe('sqlite');
+  });
+
+  it('normalizes sqlite prefixes to plain paths', () => {
+    expect(normalizeSqlitePath('sqlite://./app.db')).toBe('./app.db');
+    expect(normalizeSqlitePath('sqlite:./app.db')).toBe('./app.db');
+    expect(normalizeSqlitePath('file://./app.db')).toBe('./app.db');
+    expect(normalizeSqlitePath('./app.db')).toBe('./app.db');
+  });
+
+  it('introspects through a sqlite:// URL', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await runGenerate({ url: `sqlite://${file}`, out });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('table filtering', () => {
+  it('honors --table include lists', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await runGenerate({ url: file, out, tables: ['users'] });
+      const { readFileSync } = await import('node:fs');
+      const written = readFileSync(out, 'utf8');
+      expect(written).toContain('users');
+      expect(written).not.toContain('posts');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors --exclude lists', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await runGenerate({ url: file, out, exclude: ['posts'] });
+      const { readFileSync } = await import('node:fs');
+      const written = readFileSync(out, 'utf8');
+      expect(written).toContain('users');
+      expect(written).not.toContain('posts');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('lists available tables when the filter matches nothing', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await expect(runGenerate({ url: file, out, tables: ['nope'] })).rejects.toThrow(
+        'Available tables: users, posts',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('write errors', () => {
+  it('reports a missing output directory clearly', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'missing-dir', 'schema.ts');
+      await expect(runGenerate({ url: file, out })).rejects.toThrow('directory does not exist');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('formatCliError', () => {
+  it('unwraps AggregateError to the first inner message', () => {
+    const aggregate = new AggregateError([new Error('connect ECONNREFUSED ::1:5432')], '');
+    expect(formatCliError(aggregate)).toBe('connect ECONNREFUSED ::1:5432');
+  });
+
+  it('falls back to a generic message for empty AggregateErrors', () => {
+    expect(formatCliError(new AggregateError([], ''))).toBe('Connection failed.');
+  });
+
+  it('passes ordinary errors through', () => {
+    expect(formatCliError(new Error('boom'))).toBe('boom');
+  });
+});

--- a/tests/dialect-brand.test-d.ts
+++ b/tests/dialect-brand.test-d.ts
@@ -1,0 +1,33 @@
+import { createTypedDb, type Executor } from '../src/index.js';
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+declare const executor: Executor;
+
+export async function placeholderStyleCallSites() {
+  const pgDb = createTypedDb<DB, { placeholders: 'dollar' }>(executor);
+  const mysqlDb = createTypedDb<DB, { placeholders: 'question' }>(executor);
+  const uncheckedDb = createTypedDb<DB>(executor);
+
+  await pgDb.query('select id from users where id = $1', 1);
+
+  // @ts-expect-error a dollar-style client rejects ? placeholders
+  await pgDb.query('select id from users where id = ?', 1);
+
+  await mysqlDb.query('select id from users where id = ?', 1);
+
+  // @ts-expect-error a question-style client rejects $n placeholders
+  await mysqlDb.query('select id from users where id = $1', 1);
+
+  // @ts-expect-error a question-style client rejects @name placeholders
+  await mysqlDb.query('select id from users where id = @id', 1);
+
+  await uncheckedDb.query('select id from users where id = $1', 1);
+  await uncheckedDb.query('select id from users where id = ?', 1);
+
+  await pgDb.query('select id, name from users');
+
+  await pgDb.query("select id from users where name = 'why?'");
+}

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -38,6 +38,32 @@ function executorThrowing(cause: unknown): RecordingExecutor {
 }
 
 describe('createTypedDb.query', () => {
+  it('surfaces executor metadata on the Ok result', async () => {
+    const executor: Executor = async () => ({ rows: [], meta: { rowCount: 3, lastInsertRowid: 9 } });
+    const db = createTypedDb<DB>(executor);
+
+    const result = await db.query('insert into users (name) values ($1)', 'ada');
+
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value).toEqual([]);
+      expect(result.meta).toEqual({ rowCount: 3, lastInsertRowid: 9 });
+    }
+  });
+
+  it('includes the driver message in EXECUTOR_FAILED errors', async () => {
+    const { executor } = executorThrowing(new Error('connection refused'));
+    const db = createTypedDb<DB>(executor);
+
+    const result = await db.query('select id from users');
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.kind).toBe(QueryErrorKind.ExecutorFailed);
+      expect(result.error.message).toContain('connection refused');
+    }
+  });
+
   it('returns Ok with the rows from the executor on success', async () => {
     const sampleRows = [{ id: 1, name: 'ada' }];
     const { executor, calls } = executorReturning(sampleRows);

--- a/tests/sqlite-availability.ts
+++ b/tests/sqlite-availability.ts
@@ -1,0 +1,18 @@
+type DatabaseSyncCtor = typeof import('node:sqlite').DatabaseSync;
+
+let databaseSync: DatabaseSyncCtor | undefined;
+
+try {
+  ({ DatabaseSync: databaseSync } = await import('node:sqlite'));
+} catch {
+  databaseSync = undefined;
+}
+
+export const sqliteAvailable = databaseSync !== undefined;
+
+export function loadSqlite(): DatabaseSyncCtor {
+  if (!databaseSync) {
+    throw new Error('node:sqlite is not available in this Node.js version');
+  }
+  return databaseSync;
+}

--- a/tests/ts-plugin-detect.test.ts
+++ b/tests/ts-plugin-detect.test.ts
@@ -35,6 +35,20 @@ describe('matchQueryLiteral', () => {
     expect(match).not.toBeNull();
   });
 
+  it('does not match when the cursor sits after the closing backtick', () => {
+    const match = run(
+      `
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      declare const db: TypedDb<DB>;
+      db.query(\`select 1\`);
+    `,
+      'select 1`',
+    );
+
+    expect(match).toBeNull();
+  });
+
   it('does not activate on an unrelated interface that happens to be named TypedDb', () => {
     const match = run(`
       interface TypedDb<DB> {

--- a/tests/ts-plugin-hover-crlf.test.ts
+++ b/tests/ts-plugin-hover-crlf.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { rmSync } from 'node:fs';
+import ts from 'typescript';
+import { buildLanguageService, loadPlugin } from './ts-plugin-test-helpers.js';
+
+const { plugin, dir: transpileDir } = loadPlugin();
+
+const CRLF_FIXTURE = [
+  "import type { TypedDb } from '@owlsql/core';",
+  '',
+  'interface DB {',
+  '  users: { id: number; name: string };',
+  '}',
+  '',
+  'declare const db: TypedDb<DB>;',
+  '',
+  'db.query(`select id,',
+  '  name from users`);',
+  '',
+].join('\r\n');
+
+const cleanupDirs: string[] = [transpileDir];
+
+afterAll(() => {
+  for (const dir of cleanupDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function hoverAt(markerOffsetInto: string, offset: number): ts.QuickInfo | undefined {
+  const { languageService, filePath, dir } = buildLanguageService(
+    CRLF_FIXTURE,
+    'owlsql-ts-plugin-crlf-',
+  );
+  cleanupDirs.push(dir);
+
+  const proxied = plugin({ typescript: ts }).create({ languageService });
+  const position = CRLF_FIXTURE.indexOf(markerOffsetInto) + offset;
+  return proxied.getQuickInfoAtPosition(filePath, position);
+}
+
+describe('ts-plugin hover on CRLF multiline templates', () => {
+  it('resolves the hovered column on a line after a CRLF break', () => {
+    const hover = hoverAt('name from users', 2);
+
+    expect(hover).toBeDefined();
+    expect(hover?.displayParts?.[0]?.text).toBe('(column) name: string');
+  });
+
+  it('anchors the text span at the raw source position of the word', () => {
+    const hover = hoverAt('name from users', 2);
+
+    expect(hover?.textSpan).toEqual({
+      start: CRLF_FIXTURE.indexOf('name from users'),
+      length: 'name'.length,
+    });
+  });
+
+  it('still resolves columns on the first template line', () => {
+    const hover = hoverAt('select id,', 'select '.length + 1);
+
+    expect(hover?.displayParts?.[0]?.text).toBe('(column) id: number');
+  });
+});

--- a/tests/ts-plugin-proxy.test.ts
+++ b/tests/ts-plugin-proxy.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const PLUGIN_DIR = join(fileURLToPath(new URL('.', import.meta.url)), '..', 'src', 'ts-plugin');
+
+const PLUGIN_MODULES = ['index.cts', 'sql-context.cts', 'schema.cts', 'detect.cts'];
+
+type PluginFactory = (modules: { typescript: typeof ts }) => {
+  create(info: unknown): ts.LanguageService;
+};
+
+const transpileDir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-proxy-'));
+
+function loadPlugin(): PluginFactory {
+  for (const moduleName of PLUGIN_MODULES) {
+    const source = readFileSync(join(PLUGIN_DIR, moduleName), 'utf8');
+    const output = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+      },
+      fileName: moduleName,
+    }).outputText;
+    writeFileSync(join(transpileDir, moduleName.replace('.cts', '.cjs')), output);
+  }
+
+  const requireCompiled = createRequire(import.meta.url);
+  return requireCompiled(join(transpileDir, 'index.cjs')) as PluginFactory;
+}
+
+const plugin = loadPlugin();
+
+afterAll(() => {
+  rmSync(transpileDir, { recursive: true, force: true });
+});
+
+const NATIVE_COMPLETIONS = {
+  isGlobalCompletion: true,
+  isMemberCompletion: false,
+  isNewIdentifierLocation: false,
+  entries: [{ name: 'nativeEntry', kind: ts.ScriptElementKind.unknown, sortText: '1' }],
+};
+
+const NATIVE_QUICK_INFO = {
+  kind: ts.ScriptElementKind.unknown,
+  kindModifiers: '',
+  textSpan: { start: 0, length: 0 },
+};
+
+function createProxy(languageServiceOverrides: Record<string, unknown>): ts.LanguageService {
+  const languageService = {
+    getCompletionsAtPosition: vi.fn().mockReturnValue(NATIVE_COMPLETIONS),
+    getQuickInfoAtPosition: vi.fn().mockReturnValue(NATIVE_QUICK_INFO),
+    getProgram: vi.fn().mockReturnValue(undefined),
+    ...languageServiceOverrides,
+  };
+
+  return plugin({ typescript: ts }).create({ languageService });
+}
+
+describe('ts-plugin proxy error handling', () => {
+  it('falls back to native completions when the plugin path throws', () => {
+    const getProgram = vi.fn(() => {
+      throw new Error('checker exploded');
+    });
+    const proxy = createProxy({ getProgram });
+
+    const result = proxy.getCompletionsAtPosition('file.ts', 10, undefined);
+
+    expect(result).toBe(NATIVE_COMPLETIONS);
+    expect(getProgram).toHaveBeenCalled();
+  });
+
+  it('falls back to native hover when the plugin path throws', () => {
+    const getProgram = vi.fn(() => {
+      throw new Error('checker exploded');
+    });
+    const proxy = createProxy({ getProgram });
+
+    const result = proxy.getQuickInfoAtPosition('file.ts', 10);
+
+    expect(result).toBe(NATIVE_QUICK_INFO);
+  });
+
+  it('computes native completions only once per request', () => {
+    const getCompletionsAtPosition = vi.fn().mockReturnValue(NATIVE_COMPLETIONS);
+    const proxy = createProxy({ getCompletionsAtPosition });
+
+    proxy.getCompletionsAtPosition('file.ts', 10, undefined);
+
+    expect(getCompletionsAtPosition).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns native results when there is no program', () => {
+    const proxy = createProxy({});
+
+    expect(proxy.getCompletionsAtPosition('file.ts', 10, undefined)).toBe(NATIVE_COMPLETIONS);
+    expect(proxy.getQuickInfoAtPosition('file.ts', 10)).toBe(NATIVE_QUICK_INFO);
+  });
+});

--- a/tests/ts-plugin-proxy.test.ts
+++ b/tests/ts-plugin-proxy.test.ts
@@ -1,39 +1,9 @@
 import { afterAll, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { fileURLToPath } from 'node:url';
+import { rmSync } from 'node:fs';
 import ts from 'typescript';
+import { loadPlugin } from './ts-plugin-test-helpers.js';
 
-const PLUGIN_DIR = join(fileURLToPath(new URL('.', import.meta.url)), '..', 'src', 'ts-plugin');
-
-const PLUGIN_MODULES = ['index.cts', 'sql-context.cts', 'schema.cts', 'detect.cts'];
-
-type PluginFactory = (modules: { typescript: typeof ts }) => {
-  create(info: unknown): ts.LanguageService;
-};
-
-const transpileDir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-proxy-'));
-
-function loadPlugin(): PluginFactory {
-  for (const moduleName of PLUGIN_MODULES) {
-    const source = readFileSync(join(PLUGIN_DIR, moduleName), 'utf8');
-    const output = ts.transpileModule(source, {
-      compilerOptions: {
-        module: ts.ModuleKind.CommonJS,
-        target: ts.ScriptTarget.ES2022,
-      },
-      fileName: moduleName,
-    }).outputText;
-    writeFileSync(join(transpileDir, moduleName.replace('.cts', '.cjs')), output);
-  }
-
-  const requireCompiled = createRequire(import.meta.url);
-  return requireCompiled(join(transpileDir, 'index.cjs')) as PluginFactory;
-}
-
-const plugin = loadPlugin();
+const { plugin, dir: transpileDir } = loadPlugin();
 
 afterAll(() => {
   rmSync(transpileDir, { recursive: true, force: true });

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -55,7 +55,37 @@ describe('getWhereClauseContext', () => {
   });
 });
 
+describe('context misfire guards', () => {
+  it('offers no completions inside a string literal value', () => {
+    expect(getWhereClauseContext("select id from users where name = 'al")).toBeNull();
+    expect(getSelectListContext("select 'par")).toBeNull();
+  });
+
+  it('ignores a quoted from keyword when deciding the select-list context', () => {
+    expect(getSelectListContext("select 'from users', na")).toEqual({ prefix: 'na' });
+  });
+
+  it('returns null while the cursor trails a numeric token', () => {
+    expect(getWhereClauseContext('select id from users where id = 12')).toBeNull();
+  });
+
+  it('offers columns after ORDER BY and GROUP BY without a WHERE clause', () => {
+    expect(getWhereClauseContext('select id from users order by na')).toEqual({ prefix: 'na' });
+    expect(getWhereClauseContext('select id from users group by ')).toEqual({ prefix: '' });
+  });
+
+  it('offers columns in JOIN ... ON conditions', () => {
+    expect(getWhereClauseContext('select id from users u join posts p on u.')).toEqual({
+      prefix: '',
+    });
+  });
+});
+
 describe('findFromTable', () => {
+  it('ignores a quoted from keyword inside a literal', () => {
+    expect(findFromTable("select 'x from fake' , id from users")).toBe('users');
+  });
+
   it('finds the table name after FROM', () => {
     expect(findFromTable('select id, name from users')).toBe('users');
   });

--- a/tests/ts-plugin-test-helpers.ts
+++ b/tests/ts-plugin-test-helpers.ts
@@ -1,10 +1,72 @@
 import ts from 'typescript';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+const PLUGIN_DIR = join(REPO_ROOT, 'src', 'ts-plugin');
+
+const PLUGIN_MODULES = ['index.cts', 'sql-context.cts', 'schema.cts', 'detect.cts'];
+
+export type PluginFactory = (modules: { typescript: typeof ts }) => {
+  create(info: unknown): ts.LanguageService;
+};
+
+export function loadPlugin(): { plugin: PluginFactory; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-build-'));
+
+  for (const moduleName of PLUGIN_MODULES) {
+    const source = readFileSync(join(PLUGIN_DIR, moduleName), 'utf8');
+    const output = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+      },
+      fileName: moduleName,
+    }).outputText;
+    writeFileSync(join(dir, moduleName.replace('.cts', '.cjs')), output);
+  }
+
+  const requireCompiled = createRequire(import.meta.url);
+  return { plugin: requireCompiled(join(dir, 'index.cjs')) as PluginFactory, dir };
+}
+
+export function buildLanguageService(
+  source: string,
+  fixturePrefix: string,
+): { languageService: ts.LanguageService; filePath: string; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), fixturePrefix));
+  const filePath = join(dir, 'fixture.ts');
+  writeFileSync(filePath, source, 'utf8');
+
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    baseUrl: REPO_ROOT,
+    paths: { '@owlsql/core': ['src/index.ts'] },
+  };
+
+  const host: ts.LanguageServiceHost = {
+    getScriptFileNames: () => [filePath],
+    getScriptVersion: () => '1',
+    getScriptSnapshot: (name) => {
+      const contents = ts.sys.readFile(name);
+      return contents === undefined ? undefined : ts.ScriptSnapshot.fromString(contents);
+    },
+    getCurrentDirectory: () => REPO_ROOT,
+    getCompilationSettings: () => compilerOptions,
+    getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+  };
+
+  return { languageService: ts.createLanguageService(host), filePath, dir };
+}
 
 export interface BuiltProgram {
   program: ts.Program;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "tests/ts-plugin-completions.test.ts",
     "tests/ts-plugin-hover.test.ts",
     "tests/ts-plugin-detect.test.ts",
-    "tests/ts-plugin-schema.test.ts"
+    "tests/ts-plugin-schema.test.ts",
+    "tests/ts-plugin-proxy.test.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "tests/ts-plugin-hover.test.ts",
     "tests/ts-plugin-detect.test.ts",
     "tests/ts-plugin-schema.test.ts",
-    "tests/ts-plugin-proxy.test.ts"
+    "tests/ts-plugin-proxy.test.ts",
+    "tests/ts-plugin-hover-crlf.test.ts"
   ]
 }

--- a/tsconfig.ts-plugin-tests.json
+++ b/tsconfig.ts-plugin-tests.json
@@ -21,6 +21,7 @@
     "tests/ts-plugin-hover.test.ts",
     "tests/ts-plugin-detect.test.ts",
     "tests/ts-plugin-schema.test.ts",
+    "tests/ts-plugin-proxy.test.ts",
     "tests/ts-plugin-test-helpers.ts"
   ]
 }

--- a/tsconfig.ts-plugin-tests.json
+++ b/tsconfig.ts-plugin-tests.json
@@ -22,6 +22,7 @@
     "tests/ts-plugin-detect.test.ts",
     "tests/ts-plugin-schema.test.ts",
     "tests/ts-plugin-proxy.test.ts",
+    "tests/ts-plugin-hover-crlf.test.ts",
     "tests/ts-plugin-test-helpers.ts"
   ]
 }


### PR DESCRIPTION
## Problem (#80)

Runtime tests ran on Node 22 only — no matrix — while `engines` claims `>=18`. The claimed range was never exercised. The workflow also ran with unrestricted default permissions, and there was no dependabot config.

## Fix

- **Node matrix 20 / 22 / 24** for the runtime job (`fail-fast: false`). The `node:sqlite`-dependent suites (adapter, CLI introspection, e2e generate, CLI UX) now go through a shared `tests/sqlite-availability.ts` probe and `describe.skipIf` when the builtin (Node ≥22.5) is missing — so Node 20 runs everything else instead of crashing on import, and nothing is silently skipped on 22/24.
- **`permissions: contents: read`** on the workflow.
- **`.github/dependabot.yml`**: weekly npm + github-actions updates.

Not done here, flagged for the maintainer: the npm-published `v0.1.4` still has no git tag (only you can tag the right commit), and a CHANGELOG remains a nice-to-have. The `engines` range itself is addressed in the packaging issue (#84). The TS matrix (5.0/5.3/5.6/6.0) is untouched; the CONTRIBUTING "latest" wording drift is part of #82.

## Tests

Full suite passes on Node 22 locally (142); the skip guards are exercised by the matrix itself.

Closes #80