### PR TITLE
test: close the audited coverage gaps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   types:
     name: Types (TypeScript ${{ matrix.typescript }})
@@ -24,13 +27,17 @@ jobs:
       - run: npm run test:types
 
   runtime:
-    name: Runtime tests
+    name: Runtime tests (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
       - run: npm run test:runtime

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -29,7 +29,7 @@ check the source link and open an issue.
 | You write | Raw SQL strings | Prisma's own query API | Builder method chains | Raw SQL (in `.sql` files or tags) | Builder-ish helpers or raw SQL via `db.sql` |
 | Build step required? | No (opt-in `generate` for schema only) | **Yes** — `prisma generate` | No (optional `kysely-codegen` for schema) | **Yes** — CLI codegen against a live DB | No (opt-in schema generation) |
 | Runtime SQL/query engine? | None — string passed through verbatim | Yes — TS query compiler (was a Rust binary) | Yes — compiles the builder chain to SQL every call | Minimal — executes an already-known, pre-extracted query | Yes — builds SQL from helper calls |
-| Bundle size (npm, min/gzip) | No dependencies; ~130 lines of runtime glue (`createTypedDb` + `Result` helpers) — erased type-level parser costs 0 bytes | ~1.6 MB / ~600 KB gzip (post-Rust, v6.16+/v7); was ~14 MB / ~7 MB gzip with the Rust engine | 189 KB / 38.7 KB gzip ([bundlephobia](https://bundlephobia.com/package/kysely)) | 399 KB / 85 KB gzip ([bundlephobia](https://bundlephobia.com/package/@pgtyped/runtime)) | Not resolvable on bundlephobia (build-tool/library hybrid); no bundled query engine beyond thin SQL-building helpers |
+| Bundle size (npm, min/gzip) | No dependencies; ~175 lines of runtime glue (`createTypedDb` + `Result` helpers) — erased type-level parser costs 0 bytes | ~1.6 MB / ~600 KB gzip (post-Rust, v6.16+/v7); was ~14 MB / ~7 MB gzip with the Rust engine | 189 KB / 38.7 KB gzip ([bundlephobia](https://bundlephobia.com/package/kysely)) | 399 KB / 85 KB gzip ([bundlephobia](https://bundlephobia.com/package/@pgtyped/runtime)) | Not resolvable on bundlephobia (build-tool/library hybrid); no bundled query engine beyond thin SQL-building helpers |
 
 ## Prisma
 
@@ -122,7 +122,7 @@ check the source link and open an issue.
 
 - **Build step**: none, ever, for queries — `Query<DB, 'select ...'>` is
   resolved by the same `tsc`/tsserver pass that already type-checks the rest
-  of your file. The optional `generate` CLI ([README](README.md#editor-autocomplete))
+  of your file. The optional `generate` CLI ([README](README.md#1-describe-your-schema))
   only produces the `DB` schema type, once, on demand — you can also just
   write that type by hand and never run it.
 - **Runtime**: the SQL string you write is handed to your executor
@@ -133,10 +133,10 @@ check the source link and open an issue.
   types don't exist at runtime.
 - **Bundle**: zero runtime dependencies (`package.json` has no
   `dependencies` field), and the runtime surface is `createTypedDb`,
-  `defineSchema`, and the `Result` helpers — about 130 lines of source
+  `defineSchema`, and the `Result` helpers — about 175 lines of source
   across [`src/index.ts`](src/index.ts) and [`src/result.ts`](src/result.ts)
   combined, most of which is type declarations erased at compile time. The
-  parser itself (~2,500 lines across `src/parse.ts`/`src/from.ts`/etc.) is
+  parser itself (~1,700 lines across `src/parse.ts`/`src/from.ts`/etc.) is
   100% types — it ships zero bytes to any runtime.
 - **DX trade-off, stated plainly**: this is the smallest surface area of
   the five because it does the least. No migrations, no relation loading, no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Two layers of tests:
   success path, param forwarding, the empty-query guard, and executor failure.
 
 CI (`.github/workflows/ci.yml`) runs the type tests against a matrix of
-TypeScript versions (5.0, 5.3, 5.6, latest) plus the runtime tests, so a
+TypeScript versions (5.0, 5.3, 5.6, 6.0) plus the runtime tests, so a
 template-literal behavior change in a new TypeScript release is caught early.
 
 ## Publishing

--- a/README.md
+++ b/README.md
@@ -152,8 +152,14 @@ lives in the `.d.ts` types.
 npm install @owlsql/core
 ```
 
-`typescript` is a peer dependency (**>= 5.0** — required for template literal
-type recursion). You almost certainly already have it.
+`typescript` is a peer dependency (**>= 5.0, < 8** — template literal type
+recursion needs 5.0; the ts-plugin does not load on TS 7). You almost
+certainly already have it.
+
+The package is **ESM-only** (`import` only — `require()` is not supported).
+Node support: **>= 20** for the library and CLI; the `node:sqlite` adapter
+and the CLI's SQLite introspection additionally need **Node >= 22.5** (they
+fail with a clear error below that).
 
 ## Tutorial
 

--- a/README.md
+++ b/README.md
@@ -363,9 +363,11 @@ const shout = await db.query('select id, upper(name) as name from users');
 
 Recognized: `count`, `sum`, `avg`, `min`, `max`, `length`, `char_length`,
 `octet_length`, `abs`, `ceil`, `floor`, `round`, `power`, `mod`, `greatest`,
-`least` → `number`; `lower`, `upper`, `trim`, `ltrim`, `rtrim`, `concat` →
-`string`; `coalesce`, `nullif` → `unknown`; `now`, `current_timestamp`,
-`current_date` → `Date`. Anything else resolves to `unknown`.
+`least`, `row_number`, `rank`, `dense_rank`, `ntile`, `percent_rank`,
+`cume_dist` → `number`; `lower`, `upper`, `trim`, `ltrim`, `rtrim`, `concat` →
+`string`; `coalesce`, `nullif`, `lag`, `lead`, `first_value`, `last_value`,
+`nth_value` → `unknown`; `now`, `current_timestamp`, `current_date` → `Date`.
+Anything else resolves to `unknown`.
 
 ### 7. INSERT / UPDATE / DELETE with RETURNING
 
@@ -731,35 +733,42 @@ otherwise).
 
 | Export | Kind | Description |
 | ------ | ---- | ----------- |
-| `createTypedDb<DB>(executor, options?)` | function | Build a schema-bound client. `options.strict` enables [strict mode](#8-strict-mode--turn-typos-into-type-errors). |
-| `TypedDb<DB, Strict?>` | interface | The client; has `query<Q>(sql, ...params)`. |
-| `TypedDbOptions` | interface | `{ strict?: boolean }`. |
-| `Executor` | type | `(sql: string, params: readonly unknown[]) => Promise<unknown[]>`. |
+| `createTypedDb<DB>(executor, options?)` | function | Build a schema-bound client. `options.strict` enables [strict mode](#8-strict-mode--turn-typos-into-type-errors); `options.placeholders` enables [placeholder-style checking](#10-typed-parameters). |
+| `TypedDb<DB, Strict?, Style?>` | interface | The client; has `query<Q>(sql, ...params)`. |
+| `TypedDbOptions` | interface | `{ strict?: boolean; placeholders?: PlaceholderStyle }`. |
+| `Executor` | type | `(sql: string, params: readonly unknown[]) => Promise<ExecutorResult>`. |
+| `ExecutorResult` | type | `unknown[]` or `{ rows: unknown[]; meta?: QueryMeta }`. |
+| `QueryMeta` | interface | `{ rowCount?; lastInsertRowid? }`, surfaced on the Ok result. |
+| `PlaceholderStyle` | type | `'dollar' \| 'question' \| 'at'`. |
+| `DialectExecutor<Style>` | type | An `Executor` annotated with its placeholder style. |
 | `Query<DB, Q>` | type | Inferred result array for query `Q`. |
 | `Row<DB, Q>` | type | Inferred single-row object for query `Q`. |
 | `StrictQuery<DB, Q>` | type | Like `Query`, but unknown columns/tables become a `QueryTypeError`. |
 | `StrictRow<DB, Q>` | type | Single-row strict variant. |
-| `Params<DB, Q>` | type | Inferred parameter tuple for query `Q`. |
+| `InferResult<DB, Q>` / `InferRow<DB, Q>` | type | Underlying aliases of `Query` / `Row` (plus `InferResultStrict` / `InferRowStrict`). |
+| `Params<DB, Q>` / `InferParams<DB, Q>` | type | Inferred parameter tuple for query `Q`. |
 | `QueryTypeError<Message>` | type | Branded compile-time error carrying `Message`. |
 | `FunctionReturnTypes` | interface | SQL-function → return-type registry. |
-| `Result<T, E>` | type | `Ok<T> \| Err<E>` discriminated union. |
+| `Result<T, E>` | type | `Ok<T> \| Err<E>` discriminated union (`Ok` / `Err` are exported too). |
 | `ResultStatus` | enum | `Ok` / `Error`. |
 | `ok` / `err` | function | Construct a success / error result. |
 | `isOk` / `isErr` | function | Type-narrowing guards. |
 | `QueryError` | interface | `{ kind, message, cause? }`. |
 | `QueryErrorKind` | enum | `EMPTY_QUERY` / `EXECUTOR_FAILED`. |
-| `Schema` | type | Ideal schema shape (`table → column → type`). |
+| `Schema` / `SchemaLike` | type | Ideal schema shape (`table → column → type`) / the loosest accepted shape. |
 | `defineSchema(obj)` | function | Optional identity helper (see below). |
+| `ParseSelect` / `ParseStatement` / `ParsedStatement` / `Source` | type | Parser internals, exported for advanced tooling; not needed for normal use and more likely to change between minor versions. |
 
 **Driver adapters** (each on its own subpath, so no unused peer dependency is
 ever required):
 
 | Export | Subpath | Description |
 | ------ | ------- | ----------- |
-| `createPgExecutor(pool)` | `@owlsql/core/pg` | `pg.Pool` → `Executor`. |
-| `createMysql2Executor(pool)` | `@owlsql/core/mysql2` | `mysql2/promise` `Pool` → `Executor`. |
+| `createPgExecutor(client)` | `@owlsql/core/pg` | `pg` `Pool \| Client \| PoolClient` → `Executor`. |
+| `createMysql2Executor(connection)` | `@owlsql/core/mysql2` | `mysql2/promise` `Pool \| Connection` → `Executor`. |
 | `createPostgresJsExecutor(client)` | `@owlsql/core/postgres` | `postgres.Sql` → `Executor`. |
 | `createNodeSqliteExecutor(db)` | `@owlsql/core/node-sqlite` | `node:sqlite` `DatabaseSync` → `Executor`. |
+| `createMssqlExecutor(pool)` | `@owlsql/core/mssql` | `mssql` `ConnectionPool` → `Executor`, binding `@name` params. |
 | `createKyselyExecutor(db)` | `@owlsql/core/kysely` | `Kysely<DB>` → `Executor`, via `CompiledQuery.raw`. |
 
 **`query` return type.** `query` resolves to
@@ -818,7 +827,9 @@ This is a focused tool for the common read path, not a full SQL grammar:
 - **Scalar subqueries in the `SELECT` list are typed for the simple case** —
   a single-column, non-nested subquery (`select (select count(*) from posts
   where posts.user_id = users.id) as post_count from users`) resolves to
-  that column's type. A subquery selecting more than one column resolves to
+  that column's type, with `| null` added since a scalar subquery yields
+  NULL on zero rows (`count(...)` subqueries are exempt — they always
+  return a row). A subquery selecting more than one column resolves to
   `unknown` rather than picking one arbitrarily. Subqueries used as a value
   inside `WHERE` are not typed at all (`WHERE` isn't part of the typed
   structure — only scanned for parameter placeholders).
@@ -843,8 +854,9 @@ This is a focused tool for the common read path, not a full SQL grammar:
   bodies can't have their placeholders typed, and if one contains a
   parameter the whole query falls back to `unknown[]` rather than silently
   dropping that parameter — placeholders in the outer query (referencing a
-  CTE by name) are unaffected either way. Numbered placeholders are assumed
-  to appear in ascending order (`$1`, `$2`, ...).
+  CTE by name) are unaffected either way. Numbered placeholders bind by
+  their index (`$2` fills the second tuple slot even when it appears first);
+  a repeated `$n` occupies a single slot.
 - **Quoted identifiers** use `"..."` (standard), `[...]` (SQL Server), or
   `` `...` `` (MySQL — escape the backtick with `\`` inside the template
   literal). Schema-qualified tables (`public.users`) resolve by their final

--- a/examples/ts-plugin-demo/README.md
+++ b/examples/ts-plugin-demo/README.md
@@ -6,27 +6,20 @@ action. This one is meant to be **opened in a real VSCode window and typed
 into** — unlike [`examples/playground`](../playground), which is meant for
 StackBlitz.
 
-> **⚠️ Not on npm yet.** The project was renamed from `sql-template-typed` to
-> `@owlsql/core` and hasn't been published under the new scoped name yet.
-> `npm install` in this folder won't give you a working plugin until the
-> first `@owlsql/core` publish lands. Until then, build from source and point
-> this demo at the local build instead (step 1 below).
-
 ## Setup
 
-1. From the repo root: `npm install && npm run build`.
-2. In this folder: `npm install ../.. typescript --no-save` (installs the
-   local build instead of waiting on npm; `--no-save` keeps this
-   directory's `package.json` clean for when the real package catches up).
-3. Open **this folder** (`examples/ts-plugin-demo`) in VSCode — not the
+1. In this folder: `npm install` (`@owlsql/core` is on npm; to test
+   unpublished changes instead, run `npm install && npm run build` at the
+   repo root and then `npm install ../.. typescript --no-save` here).
+2. Open **this folder** (`examples/ts-plugin-demo`) in VSCode — not the
    monorepo root, so the workspace TypeScript version resolves correctly.
-4. Command Palette → **"TypeScript: Select TypeScript Version" → "Use
+3. Command Palette → **"TypeScript: Select TypeScript Version" → "Use
    Workspace Version"**. This is the step that's easy to skip and makes the
    plugin silently do nothing.
-5. Trust the workspace if prompted (VSCode's Restricted Mode disables
+4. Trust the workspace if prompted (VSCode's Restricted Mode disables
    extensions/plugins in untrusted folders — this tripped up the very first
    attempt at recording this).
-6. Open `demo.ts`. Place your cursor right after `na` on the `select id, na`
+5. Open `demo.ts`. Place your cursor right after `na` on the `select id, na`
    line and delete/retype the last couple of characters — completions
    trigger on typing, not just on opening the file.
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "description": "Parse SQL in TypeScript template literal types and infer the result shape from your schema — no codegen, no ORM.",
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
     "owlsql": "./dist/cli/index.js"
@@ -49,7 +47,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json && tsc -p tsconfig.ts-plugin.json",
@@ -65,7 +63,7 @@
     "mysql2": ">=3.0.0",
     "pg": ">=8.0.0",
     "postgres": ">=3.0.0",
-    "typescript": ">=5.0.0"
+    "typescript": ">=5.0.0 <8"
   },
   "peerDependenciesMeta": {
     "kysely": {

--- a/src/ts-plugin/detect.cts
+++ b/src/ts-plugin/detect.cts
@@ -13,7 +13,7 @@ function findNodeAtPosition(typescript: TypeScript, sourceFile: ts.SourceFile, p
   let best: ts.Node = sourceFile;
 
   const visit = (node: ts.Node): void => {
-    if (position < node.getFullStart() || position > node.getEnd()) {
+    if (position < node.getFullStart() || position >= node.getEnd()) {
       return;
     }
 

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -51,7 +51,17 @@ function init(modules: { typescript: typeof ts }) {
         const fullLiteralText = match.literal.text;
         const table = findFromTable(fullLiteralText);
         const columns = getColumnNames(checker, match.dbType, match.literal, table);
-        const filtered = columns.filter((name) => name.startsWith(context.prefix));
+        const prefix = context.prefix.toLowerCase();
+        const filtered = columns.filter((name) => name.toLowerCase().startsWith(prefix));
+
+        if (filtered.length === 0) {
+          return native();
+        }
+
+        const replacementSpan = {
+          start: position - context.prefix.length,
+          length: context.prefix.length,
+        };
 
         return {
           isGlobalCompletion: false,
@@ -61,6 +71,7 @@ function init(modules: { typescript: typeof ts }) {
             name,
             kind: typescript.ScriptElementKind.memberVariableElement,
             sortText: '0',
+            replacementSpan,
           })),
         };
       } catch {
@@ -69,6 +80,60 @@ function init(modules: { typescript: typeof ts }) {
     };
 
     proxy.getCompletionsAtPosition = getCompletionsAtPosition;
+
+    const getCompletionEntryDetails: ts.LanguageService['getCompletionEntryDetails'] = (
+      fileName,
+      position,
+      entryName,
+      formatOptions,
+      source,
+      preferences,
+      data,
+    ) => {
+      const native = () =>
+        info.languageService.getCompletionEntryDetails(
+          fileName,
+          position,
+          entryName,
+          formatOptions,
+          source,
+          preferences,
+          data,
+        );
+
+      try {
+        const program = info.languageService.getProgram();
+        const sourceFile = program?.getSourceFile(fileName);
+        if (!program || !sourceFile) {
+          return native();
+        }
+
+        const checker = program.getTypeChecker();
+        const match = matchQueryLiteral(typescript, checker, sourceFile, position);
+        if (!match) {
+          return native();
+        }
+
+        const table = findFromTable(match.literal.text);
+        const columnType = getColumnType(checker, match.dbType, match.literal, table, entryName);
+        if (!columnType) {
+          return native();
+        }
+
+        return {
+          name: entryName,
+          kind: typescript.ScriptElementKind.memberVariableElement,
+          kindModifiers: '',
+          displayParts: [
+            { text: `(column) ${entryName}: ${checker.typeToString(columnType)}`, kind: 'text' },
+          ],
+        };
+      } catch {
+        return native();
+      }
+    };
+
+    proxy.getCompletionEntryDetails = getCompletionEntryDetails;
 
     const getQuickInfoAtPosition: ts.LanguageService['getQuickInfoAtPosition'] = (fileName, position) => {
       const native = () => info.languageService.getQuickInfoAtPosition(fileName, position);

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -152,12 +152,13 @@ function init(modules: { typescript: typeof ts }) {
         }
 
         const literalStart = match.literal.getStart(sourceFile) + 1;
-        const word = getWordAtOffset(match.literal.text, position - literalStart);
+        const rawLiteralText = sourceFile.text.slice(literalStart, match.literal.getEnd() - 1);
+        const word = getWordAtOffset(rawLiteralText, position - literalStart);
         if (!word) {
           return native();
         }
 
-        const table = findFromTable(match.literal.text);
+        const table = findFromTable(rawLiteralText);
         const columnType = getColumnType(checker, match.dbType, match.literal, table, word.word);
         if (!columnType) {
           return native();

--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -1,7 +1,7 @@
 const SELECT_START = /^select\b/i;
 const HAS_FROM = /\bfrom\b/i;
-const HAS_WHERE = /\bwhere\b/i;
-const TRAILING_WORD = /([A-Za-z_][A-Za-z0-9_]*)$/;
+const HAS_COLUMN_CLAUSE = /\b(where|having|on|order\s+by|group\s+by)\b/i;
+const TRAILING_TOKEN = /([A-Za-z0-9_]+)$/;
 const FROM_TABLE = /\bfrom\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)/i;
 const WORD_CHAR = /[A-Za-z0-9_]/;
 const WORD_START_CHAR = /[A-Za-z_]/;
@@ -16,36 +16,77 @@ interface WordAtOffset {
   end: number;
 }
 
+interface StrippedText {
+  stripped: string;
+  insideLiteral: boolean;
+}
+
+function stripStringLiterals(text: string): StrippedText {
+  let stripped = '';
+  let insideLiteral = false;
+
+  for (const char of text) {
+    if (char === "'") {
+      insideLiteral = !insideLiteral;
+      stripped += char;
+      continue;
+    }
+    if (!insideLiteral) {
+      stripped += char;
+    }
+  }
+
+  return { stripped, insideLiteral };
+}
+
+function prefixFrom(textBeforeCursor: string): SelectListContext | null {
+  const token = TRAILING_TOKEN.exec(textBeforeCursor)?.[1];
+  if (token === undefined) {
+    return { prefix: '' };
+  }
+  if (!WORD_START_CHAR.test(token[0] ?? '')) {
+    return null;
+  }
+  return { prefix: token };
+}
+
 function getSelectListContext(textBeforeCursor: string): SelectListContext | null {
-  const trimmed = textBeforeCursor.trimStart();
-
-  if (!SELECT_START.test(trimmed)) {
+  const { stripped, insideLiteral } = stripStringLiterals(textBeforeCursor);
+  if (insideLiteral) {
     return null;
   }
 
-  if (HAS_FROM.test(textBeforeCursor)) {
+  if (!SELECT_START.test(stripped.trimStart())) {
     return null;
   }
 
-  const match = TRAILING_WORD.exec(textBeforeCursor);
-  return { prefix: match?.[1] ?? '' };
+  if (HAS_FROM.test(stripped)) {
+    return null;
+  }
+
+  return prefixFrom(textBeforeCursor);
 }
 
 function getWhereClauseContext(textBeforeCursor: string): SelectListContext | null {
-  if (!HAS_FROM.test(textBeforeCursor)) {
+  const { stripped, insideLiteral } = stripStringLiterals(textBeforeCursor);
+  if (insideLiteral) {
     return null;
   }
 
-  if (!HAS_WHERE.test(textBeforeCursor)) {
+  if (!HAS_FROM.test(stripped)) {
     return null;
   }
 
-  const match = TRAILING_WORD.exec(textBeforeCursor);
-  return { prefix: match?.[1] ?? '' };
+  if (!HAS_COLUMN_CLAUSE.test(stripped)) {
+    return null;
+  }
+
+  return prefixFrom(textBeforeCursor);
 }
 
 function findFromTable(fullLiteralText: string): string | null {
-  const match = FROM_TABLE.exec(fullLiteralText);
+  const { stripped } = stripStringLiterals(fullLiteralText);
+  const match = FROM_TABLE.exec(stripped);
   return match?.[1] ?? null;
 }
 

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { createTypedDb, isOk } from '../src/index';
-import { createNodeSqliteExecutor } from '../src/adapters/node-sqlite';
+import { createTypedDb, isOk } from '../src/index.js';
+import { createNodeSqliteExecutor } from '../src/adapters/node-sqlite.js';
 import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
 
 interface DB {

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { DatabaseSync } from 'node:sqlite';
 import { createTypedDb, isOk } from '../src/index';
 import { createNodeSqliteExecutor } from '../src/adapters/node-sqlite';
+import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
 
 interface DB {
   users: { id: number; name: string };
 }
 
-function seededDatabase(): DatabaseSync {
+function seededDatabase(): import('node:sqlite').DatabaseSync {
+  const DatabaseSync = loadSqlite();
   const db = new DatabaseSync(':memory:');
   db.exec('create table users (id integer primary key, name text not null)');
   db.prepare('insert into users (id, name) values (?, ?)').run(1, 'ada');
@@ -15,7 +16,7 @@ function seededDatabase(): DatabaseSync {
   return db;
 }
 
-describe('createNodeSqliteExecutor', () => {
+describe.skipIf(!sqliteAvailable)('createNodeSqliteExecutor', () => {
   it('runs a real query against an in-memory node:sqlite database', async () => {
     const sqlite = seededDatabase();
     const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
@@ -73,6 +74,7 @@ describe('createNodeSqliteExecutor', () => {
   });
 
   it('coerces boolean and Date params to driver-supported values', async () => {
+    const DatabaseSync = loadSqlite();
     const sqlite = new DatabaseSync(':memory:');
     sqlite.exec('create table flags (id integer primary key, active integer, seen_at text)');
     const executor = createNodeSqliteExecutor(sqlite);

--- a/tests/adapter-pg.test.ts
+++ b/tests/adapter-pg.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Pool } from 'pg';
+import { createPgExecutor } from '../src/adapters/pg.js';
+
+function fakePool(result: { rows: unknown[]; rowCount: number | null }): {
+  pool: Pool;
+  query: ReturnType<typeof vi.fn>;
+} {
+  const query = vi.fn().mockResolvedValue(result);
+  return { pool: { query } as unknown as Pool, query };
+}
+
+describe('createPgExecutor', () => {
+  it('passes rows and rowCount metadata through', async () => {
+    const { pool } = fakePool({ rows: [{ id: 1 }], rowCount: 1 });
+    const executor = createPgExecutor(pool);
+
+    const result = await executor('select id from users where id = $1', [1]);
+
+    expect(result).toEqual({ rows: [{ id: 1 }], meta: { rowCount: 1 } });
+  });
+
+  it('omits rowCount when the driver reports null', async () => {
+    const { pool } = fakePool({ rows: [], rowCount: null });
+    const executor = createPgExecutor(pool);
+
+    const result = await executor('select 1', []);
+
+    expect(result).toEqual({ rows: [], meta: {} });
+  });
+
+  it('sends the SQL alone when there are no params, keeping the simple protocol', async () => {
+    const { pool, query } = fakePool({ rows: [], rowCount: 0 });
+    const executor = createPgExecutor(pool);
+
+    await executor('select id from users', []);
+
+    expect(query).toHaveBeenCalledWith('select id from users');
+  });
+
+  it('forwards params when present', async () => {
+    const { pool, query } = fakePool({ rows: [], rowCount: 0 });
+    const executor = createPgExecutor(pool);
+
+    await executor('select id from users where id = $1', [7]);
+
+    expect(query).toHaveBeenCalledWith('select id from users where id = $1', [7]);
+  });
+});

--- a/tests/cli-codegen-edge.test.ts
+++ b/tests/cli-codegen-edge.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { renderSchema } from '../src/cli/codegen.js';
+
+describe('renderSchema edge cases', () => {
+  it('quotes names that are not valid identifiers, including quotes and backslashes', () => {
+    const rendered = renderSchema([
+      {
+        name: 'weird table',
+        columns: [
+          { name: 'col"name', tsType: 'string', nullable: false },
+          { name: 'back\\slash', tsType: 'number', nullable: true },
+          { name: 'plain', tsType: 'boolean', nullable: false },
+        ],
+      },
+    ]);
+
+    expect(rendered).toBe(
+      'export interface DB {\n' +
+        '  "weird table": {\n' +
+        '    "col\\"name": string;\n' +
+        '    "back\\\\slash": number | null;\n' +
+        '    plain: boolean;\n' +
+        '  };\n' +
+        '}\n',
+    );
+  });
+
+  it('renders a zero-column table as an empty object', () => {
+    const rendered = renderSchema([{ name: 'empty_t', columns: [] }]);
+
+    expect(rendered).toBe('export interface DB {\n  empty_t: {\n\n  };\n}\n');
+  });
+});

--- a/tests/cli-generate.test.ts
+++ b/tests/cli-generate.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { DatabaseSync } from 'node:sqlite';
 import { runGenerate, detectDialect } from '../src/cli/generate';
+import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
 
 describe('detectDialect', () => {
   it('detects postgres, mysql, and mssql from the URL scheme', () => {
@@ -27,14 +27,14 @@ describe('detectDialect', () => {
   });
 });
 
-describe('runGenerate (end to end against a real sqlite file)', () => {
+describe.skipIf(!sqliteAvailable)('runGenerate (end to end against a real sqlite file)', () => {
   it('introspects the database and writes the rendered schema to --out', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
     const dbFile = join(dir, 'app.db');
     const outFile = join(dir, 'schema.ts');
 
     try {
-      const db = new DatabaseSync(dbFile);
+      const db = new (loadSqlite())(dbFile);
       db.exec('create table users (id integer primary key, name text not null, bio text)');
       db.close();
 
@@ -60,7 +60,7 @@ describe('runGenerate (end to end against a real sqlite file)', () => {
     const dbFile = join(dir, 'empty.db');
 
     try {
-      const db = new DatabaseSync(dbFile);
+      const db = new (loadSqlite())(dbFile);
       db.close();
 
       await expect(

--- a/tests/cli-mssql-introspect.test.ts
+++ b/tests/cli-mssql-introspect.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { introspectMssql } from '../src/cli/dialects/mssql.js';
+
+describe('introspectMssql', () => {
+  it('resolves alias types via system_type_id, groups columns and keeps empty tables', async () => {
+    const queries: string[] = [];
+    const request = {
+      input: vi.fn().mockReturnThis(),
+      query: vi.fn((sql: string) => {
+        queries.push(sql);
+        if (sql.includes('type_name')) {
+          return Promise.resolve({
+            recordset: [
+              { table_name: 'users', column_name: 'id', data_type: 'int', is_nullable: false },
+              {
+                table_name: 'users',
+                column_name: 'email',
+                data_type: 'varchar',
+                is_nullable: true,
+              },
+            ],
+          });
+        }
+        return Promise.resolve({
+          recordset: [{ table_name: 'users' }, { table_name: 'empty_t' }],
+        });
+      }),
+    };
+    const close = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('mssql', () => ({
+      connect: vi.fn().mockResolvedValue({ request: () => request, close }),
+    }));
+
+    const tables = await introspectMssql({
+      url: 'Server=host;Database=db;User Id=u;Password=p',
+    });
+
+    expect(queries.some((sql) => sql.includes('type_name(c.system_type_id)'))).toBe(true);
+    expect(request.input).toHaveBeenCalledWith('schema', 'dbo');
+    expect(tables).toEqual([
+      {
+        name: 'users',
+        columns: [
+          { name: 'id', tsType: 'number', nullable: false },
+          { name: 'email', tsType: 'string', nullable: true },
+        ],
+      },
+      { name: 'empty_t', columns: [] },
+    ]);
+    expect(close).toHaveBeenCalled();
+
+    vi.doUnmock('mssql');
+  });
+});

--- a/tests/cli-pg-introspect.test.ts
+++ b/tests/cli-pg-introspect.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { introspectPostgres } from '../src/cli/dialects/postgres.js';
+
+const TABLE_ROWS = [{ table_name: 'users' }, { table_name: 'empty_t' }];
+
+const ENUM_ROWS = [
+  { typname: 'mood', enumlabel: 'happy' },
+  { typname: 'mood', enumlabel: 'sad' },
+];
+
+const COLUMN_ROWS = [
+  { table_name: 'users', column_name: 'id', udt_name: 'int4', is_nullable: 'NO' },
+  { table_name: 'users', column_name: 'state', udt_name: 'mood', is_nullable: 'YES' },
+  { table_name: 'users', column_name: 'tags', udt_name: '_text', is_nullable: 'YES' },
+];
+
+describe('introspectPostgres', () => {
+  it('groups columns, resolves enums to label unions and keeps empty tables', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: TABLE_ROWS })
+      .mockResolvedValueOnce({ rows: ENUM_ROWS })
+      .mockResolvedValueOnce({ rows: COLUMN_ROWS });
+    const end = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('pg', () => ({
+      Pool: class {
+        query = query;
+        end = end;
+      },
+    }));
+
+    const tables = await introspectPostgres({ url: 'postgres://localhost/db' });
+
+    expect(query.mock.calls[0]?.[0]).toContain("table_type = 'BASE TABLE'");
+    expect(query.mock.calls[1]?.[0]).toContain('pg_enum');
+    expect(query.mock.calls.map((call) => call[1])).toEqual([['public'], ['public'], ['public']]);
+
+    expect(tables).toEqual([
+      {
+        name: 'users',
+        columns: [
+          { name: 'id', tsType: 'number', nullable: false },
+          { name: 'state', tsType: "'happy' | 'sad'", nullable: true },
+          { name: 'tags', tsType: 'string[]', nullable: true },
+        ],
+      },
+      { name: 'empty_t', columns: [] },
+    ]);
+    expect(end).toHaveBeenCalled();
+
+    vi.doUnmock('pg');
+  });
+
+  it('respects the schema option', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+    const end = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('pg', () => ({
+      Pool: class {
+        query = query;
+        end = end;
+      },
+    }));
+
+    await introspectPostgres({ url: 'postgres://localhost/db', schema: 'app' });
+
+    expect(query.mock.calls.every((call) => call[1]?.[0] === 'app')).toBe(true);
+
+    vi.doUnmock('pg');
+  });
+});

--- a/tests/cli-sqlite-introspect.test.ts
+++ b/tests/cli-sqlite-introspect.test.ts
@@ -2,19 +2,20 @@ import { describe, it, expect } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { DatabaseSync } from 'node:sqlite';
+import type { DatabaseSync } from 'node:sqlite';
 import { introspectSqlite } from '../src/cli/dialects/sqlite';
+import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
 
 function withTempDatabase(setup: (db: DatabaseSync) => void): string {
   const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
   const file = join(dir, 'test.db');
-  const db = new DatabaseSync(file);
+  const db = new (loadSqlite())(file);
   setup(db);
   db.close();
   return file;
 }
 
-describe('introspectSqlite', () => {
+describe.skipIf(!sqliteAvailable)('introspectSqlite', () => {
   it('introspects columns, types, and nullability from a real database file', async () => {
     const file = withTempDatabase((db) => {
       db.exec(`

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -68,6 +68,11 @@ describe('mapMysqlType', () => {
     expect(mapMysqlType('tinyint', 'tinyint(4)')).toBe('number');
   });
 
+  it('maps bit(1) to boolean but wider bit fields to Buffer', () => {
+    expect(mapMysqlType('bit', 'bit(1)')).toBe('boolean');
+    expect(mapMysqlType('bit', 'bit(8)')).toBe('Buffer');
+  });
+
   it('maps date/time types and binary types', () => {
     expect(mapMysqlType('datetime', 'datetime')).toBe('Date');
     expect(mapMysqlType('time', 'time')).toBe('string');
@@ -95,6 +100,12 @@ describe('mapSqliteType', () => {
     expect(mapSqliteType('NUMERIC')).toBe('number');
     expect(mapSqliteType('DECIMAL(10,2)')).toBe('number');
   });
+
+  it('accepts lowercase declared types', () => {
+    expect(mapSqliteType('integer')).toBe('number');
+    expect(mapSqliteType('text')).toBe('string');
+    expect(mapSqliteType('boolean')).toBe('0 | 1');
+  });
 });
 
 describe('mapMssqlType', () => {
@@ -119,5 +130,9 @@ describe('mapMssqlType', () => {
   it('is case-insensitive and falls back to unknown', () => {
     expect(mapMssqlType('INT')).toBe('number');
     expect(mapMssqlType('geography')).toBe('unknown');
+  });
+
+  it('maps time to Date, matching tedious defaults', () => {
+    expect(mapMssqlType('time')).toBe('Date');
   });
 });

--- a/tests/cli-ux.test.ts
+++ b/tests/cli-ux.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { DatabaseSync } from 'node:sqlite';
 import { detectDialect, runGenerate } from '../src/cli/generate.js';
+import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
 import { normalizeSqlitePath } from '../src/cli/dialects/sqlite.js';
 import { formatCliError } from '../src/cli/index.js';
 
 function createDatabase(): { dir: string; file: string } {
   const dir = mkdtempSync(join(tmpdir(), 'owlsql-'));
   const file = join(dir, 'app.db');
-  const db = new DatabaseSync(file);
+  const db = new (loadSqlite())(file);
   db.exec('create table users (id integer primary key, name text not null)');
   db.exec('create table posts (id integer primary key, title text not null)');
   db.close();
@@ -31,7 +31,7 @@ describe('sqlite URL forms', () => {
     expect(normalizeSqlitePath('./app.db')).toBe('./app.db');
   });
 
-  it('introspects through a sqlite:// URL', async () => {
+  it.skipIf(!sqliteAvailable)('introspects through a sqlite:// URL', async () => {
     const { dir, file } = createDatabase();
     try {
       const out = join(dir, 'schema.ts');
@@ -42,7 +42,7 @@ describe('sqlite URL forms', () => {
   });
 });
 
-describe('table filtering', () => {
+describe.skipIf(!sqliteAvailable)('table filtering', () => {
   it('honors --table include lists', async () => {
     const { dir, file } = createDatabase();
     try {
@@ -84,7 +84,7 @@ describe('table filtering', () => {
   });
 });
 
-describe('write errors', () => {
+describe.skipIf(!sqliteAvailable)('write errors', () => {
   it('reports a missing output directory clearly', async () => {
     const { dir, file } = createDatabase();
     try {

--- a/tests/public-api.test-d.ts
+++ b/tests/public-api.test-d.ts
@@ -1,0 +1,47 @@
+import { defineSchema } from '../src/index.js';
+import type { Row, StrictRow, FunctionReturnTypes, Query } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+type RowInfersSingleObject = Expect<
+  Equal<Row<DB, 'select id, name from users'>, { id: number; name: string }>
+>;
+
+type RowMatchesQueryElement = Expect<
+  Equal<Row<DB, 'select id from users'>, Query<DB, 'select id from users'>[number]>
+>;
+
+type StrictRowInfersSingleObject = Expect<
+  Equal<StrictRow<DB, 'select id from users'>, { id: number }>
+>;
+
+type FunctionRegistryTypesCount = Expect<Equal<FunctionReturnTypes['count'], number>>;
+
+type FunctionRegistryTypesLower = Expect<Equal<FunctionReturnTypes['lower'], string>>;
+
+const inlineSchema = defineSchema({ users: { id: 0 as number, name: '' as string } });
+
+type DefineSchemaPreservesShape = Expect<
+  Equal<
+    typeof inlineSchema,
+    { readonly users: { readonly id: number; readonly name: string } }
+  >
+>;
+
+export type Assertions = [
+  RowInfersSingleObject,
+  RowMatchesQueryElement,
+  StrictRowInfersSingleObject,
+  FunctionRegistryTypesCount,
+  FunctionRegistryTypesLower,
+  DefineSchemaPreservesShape,
+];

--- a/tests/public-api.test.ts
+++ b/tests/public-api.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { defineSchema } from '../src/index.js';
+
+describe('defineSchema', () => {
+  it('returns its argument unchanged', () => {
+    const schema = { users: { id: 0, name: '' } };
+    expect(defineSchema(schema)).toBe(schema);
+  });
+});

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -8,7 +8,7 @@ import {
   ok,
   err,
   type Executor,
-} from '../src/index';
+} from '../src/index.js';
 
 interface DB {
   users: { id: number; name: string };

--- a/tests/sqlite-availability.ts
+++ b/tests/sqlite-availability.ts
@@ -1,0 +1,18 @@
+type DatabaseSyncCtor = typeof import('node:sqlite').DatabaseSync;
+
+let databaseSync: DatabaseSyncCtor | undefined;
+
+try {
+  ({ DatabaseSync: databaseSync } = await import('node:sqlite'));
+} catch {
+  databaseSync = undefined;
+}
+
+export const sqliteAvailable = databaseSync !== undefined;
+
+export function loadSqlite(): DatabaseSyncCtor {
+  if (!databaseSync) {
+    throw new Error('node:sqlite is not available in this Node.js version');
+  }
+  return databaseSync;
+}

--- a/tests/ts-plugin-detect.test.ts
+++ b/tests/ts-plugin-detect.test.ts
@@ -35,6 +35,17 @@ describe('matchQueryLiteral', () => {
     expect(match).not.toBeNull();
   });
 
+  it('detects a plain double-quoted string literal query', () => {
+    const match = run(`
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      declare const db: TypedDb<DB>;
+      db.query("select 1");
+    `);
+
+    expect(match).not.toBeNull();
+  });
+
   it('does not match when the cursor sits after the closing backtick', () => {
     const match = run(
       `

--- a/tests/ts-plugin-detect.test.ts
+++ b/tests/ts-plugin-detect.test.ts
@@ -35,6 +35,20 @@ describe('matchQueryLiteral', () => {
     expect(match).not.toBeNull();
   });
 
+  it('does not match when the cursor sits after the closing backtick', () => {
+    const match = run(
+      `
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      declare const db: TypedDb<DB>;
+      db.query(\`select 1\`);
+    `,
+      'select 1`',
+    );
+
+    expect(match).toBeNull();
+  });
+
   it('does not activate on an unrelated interface that happens to be named TypedDb', () => {
     const match = run(`
       interface TypedDb<DB> {

--- a/tests/ts-plugin-hover-crlf.test.ts
+++ b/tests/ts-plugin-hover-crlf.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { rmSync } from 'node:fs';
+import ts from 'typescript';
+import { buildLanguageService, loadPlugin } from './ts-plugin-test-helpers.js';
+
+const { plugin, dir: transpileDir } = loadPlugin();
+
+const CRLF_FIXTURE = [
+  "import type { TypedDb } from '@owlsql/core';",
+  '',
+  'interface DB {',
+  '  users: { id: number; name: string };',
+  '}',
+  '',
+  'declare const db: TypedDb<DB>;',
+  '',
+  'db.query(`select id,',
+  '  name from users`);',
+  '',
+].join('\r\n');
+
+const cleanupDirs: string[] = [transpileDir];
+
+afterAll(() => {
+  for (const dir of cleanupDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function hoverAt(markerOffsetInto: string, offset: number): ts.QuickInfo | undefined {
+  const { languageService, filePath, dir } = buildLanguageService(
+    CRLF_FIXTURE,
+    'owlsql-ts-plugin-crlf-',
+  );
+  cleanupDirs.push(dir);
+
+  const proxied = plugin({ typescript: ts }).create({ languageService });
+  const position = CRLF_FIXTURE.indexOf(markerOffsetInto) + offset;
+  return proxied.getQuickInfoAtPosition(filePath, position);
+}
+
+describe('ts-plugin hover on CRLF multiline templates', () => {
+  it('resolves the hovered column on a line after a CRLF break', () => {
+    const hover = hoverAt('name from users', 2);
+
+    expect(hover).toBeDefined();
+    expect(hover?.displayParts?.[0]?.text).toBe('(column) name: string');
+  });
+
+  it('anchors the text span at the raw source position of the word', () => {
+    const hover = hoverAt('name from users', 2);
+
+    expect(hover?.textSpan).toEqual({
+      start: CRLF_FIXTURE.indexOf('name from users'),
+      length: 'name'.length,
+    });
+  });
+
+  it('still resolves columns on the first template line', () => {
+    const hover = hoverAt('select id,', 'select '.length + 1);
+
+    expect(hover?.displayParts?.[0]?.text).toBe('(column) id: number');
+  });
+});

--- a/tests/ts-plugin-proxy.test.ts
+++ b/tests/ts-plugin-proxy.test.ts
@@ -1,39 +1,9 @@
 import { afterAll, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { fileURLToPath } from 'node:url';
+import { rmSync } from 'node:fs';
 import ts from 'typescript';
+import { loadPlugin } from './ts-plugin-test-helpers.js';
 
-const PLUGIN_DIR = join(fileURLToPath(new URL('.', import.meta.url)), '..', 'src', 'ts-plugin');
-
-const PLUGIN_MODULES = ['index.cts', 'sql-context.cts', 'schema.cts', 'detect.cts'];
-
-type PluginFactory = (modules: { typescript: typeof ts }) => {
-  create(info: unknown): ts.LanguageService;
-};
-
-const transpileDir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-proxy-'));
-
-function loadPlugin(): PluginFactory {
-  for (const moduleName of PLUGIN_MODULES) {
-    const source = readFileSync(join(PLUGIN_DIR, moduleName), 'utf8');
-    const output = ts.transpileModule(source, {
-      compilerOptions: {
-        module: ts.ModuleKind.CommonJS,
-        target: ts.ScriptTarget.ES2022,
-      },
-      fileName: moduleName,
-    }).outputText;
-    writeFileSync(join(transpileDir, moduleName.replace('.cts', '.cjs')), output);
-  }
-
-  const requireCompiled = createRequire(import.meta.url);
-  return requireCompiled(join(transpileDir, 'index.cjs')) as PluginFactory;
-}
-
-const plugin = loadPlugin();
+const { plugin, dir: transpileDir } = loadPlugin();
 
 afterAll(() => {
   rmSync(transpileDir, { recursive: true, force: true });

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -55,7 +55,37 @@ describe('getWhereClauseContext', () => {
   });
 });
 
+describe('context misfire guards', () => {
+  it('offers no completions inside a string literal value', () => {
+    expect(getWhereClauseContext("select id from users where name = 'al")).toBeNull();
+    expect(getSelectListContext("select 'par")).toBeNull();
+  });
+
+  it('ignores a quoted from keyword when deciding the select-list context', () => {
+    expect(getSelectListContext("select 'from users', na")).toEqual({ prefix: 'na' });
+  });
+
+  it('returns null while the cursor trails a numeric token', () => {
+    expect(getWhereClauseContext('select id from users where id = 12')).toBeNull();
+  });
+
+  it('offers columns after ORDER BY and GROUP BY without a WHERE clause', () => {
+    expect(getWhereClauseContext('select id from users order by na')).toEqual({ prefix: 'na' });
+    expect(getWhereClauseContext('select id from users group by ')).toEqual({ prefix: '' });
+  });
+
+  it('offers columns in JOIN ... ON conditions', () => {
+    expect(getWhereClauseContext('select id from users u join posts p on u.')).toEqual({
+      prefix: '',
+    });
+  });
+});
+
 describe('findFromTable', () => {
+  it('ignores a quoted from keyword inside a literal', () => {
+    expect(findFromTable("select 'x from fake' , id from users")).toBe('users');
+  });
+
   it('finds the table name after FROM', () => {
     expect(findFromTable('select id, name from users')).toBe('users');
   });

--- a/tests/ts-plugin-test-helpers.ts
+++ b/tests/ts-plugin-test-helpers.ts
@@ -1,10 +1,72 @@
 import ts from 'typescript';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+const PLUGIN_DIR = join(REPO_ROOT, 'src', 'ts-plugin');
+
+const PLUGIN_MODULES = ['index.cts', 'sql-context.cts', 'schema.cts', 'detect.cts'];
+
+export type PluginFactory = (modules: { typescript: typeof ts }) => {
+  create(info: unknown): ts.LanguageService;
+};
+
+export function loadPlugin(): { plugin: PluginFactory; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-build-'));
+
+  for (const moduleName of PLUGIN_MODULES) {
+    const source = readFileSync(join(PLUGIN_DIR, moduleName), 'utf8');
+    const output = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ES2022,
+      },
+      fileName: moduleName,
+    }).outputText;
+    writeFileSync(join(dir, moduleName.replace('.cts', '.cjs')), output);
+  }
+
+  const requireCompiled = createRequire(import.meta.url);
+  return { plugin: requireCompiled(join(dir, 'index.cjs')) as PluginFactory, dir };
+}
+
+export function buildLanguageService(
+  source: string,
+  fixturePrefix: string,
+): { languageService: ts.LanguageService; filePath: string; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), fixturePrefix));
+  const filePath = join(dir, 'fixture.ts');
+  writeFileSync(filePath, source, 'utf8');
+
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    baseUrl: REPO_ROOT,
+    paths: { '@owlsql/core': ['src/index.ts'] },
+  };
+
+  const host: ts.LanguageServiceHost = {
+    getScriptFileNames: () => [filePath],
+    getScriptVersion: () => '1',
+    getScriptSnapshot: (name) => {
+      const contents = ts.sys.readFile(name);
+      return contents === undefined ? undefined : ts.ScriptSnapshot.fromString(contents);
+    },
+    getCurrentDirectory: () => REPO_ROOT,
+    getCompilationSettings: () => compilerOptions,
+    getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+  };
+
+  return { languageService: ts.createLanguageService(host), filePath, dir };
+}
 
 export interface BuiltProgram {
   program: ts.Program;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src", "tests"],
+  "include": ["src", "tests", "vitest.config.ts"],
   "exclude": [
     "src/ts-plugin",
     "tests/ts-plugin-sql-context.test.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "tests/ts-plugin-hover.test.ts",
     "tests/ts-plugin-detect.test.ts",
     "tests/ts-plugin-schema.test.ts",
-    "tests/ts-plugin-proxy.test.ts"
+    "tests/ts-plugin-proxy.test.ts",
+    "tests/ts-plugin-hover-crlf.test.ts"
   ]
 }

--- a/tsconfig.ts-plugin-tests.json
+++ b/tsconfig.ts-plugin-tests.json
@@ -22,6 +22,7 @@
     "tests/ts-plugin-detect.test.ts",
     "tests/ts-plugin-schema.test.ts",
     "tests/ts-plugin-proxy.test.ts",
+    "tests/ts-plugin-hover-crlf.test.ts",
     "tests/ts-plugin-test-helpers.ts"
   ]
 }


### PR DESCRIPTION
## Coverage added (#83)

**Public API** — `tests/public-api.test-d.ts` + `tests/public-api.test.ts`: `Row`, `StrictRow`, `FunctionReturnTypes`, `defineSchema` (type preservation incl. `const`-param readonly inference, runtime identity).

**Adapters** — `tests/adapter-pg.test.ts`: rows + rowCount meta, null-rowCount omission, no-params simple-protocol call, param forwarding. (mysql2/mssql/node-sqlite behavioral tests landed in #110/#113/#111; the `adapters.test-d` locks were de-tautologized in #114 by asserting the `DialectExecutor` brands.)

**CLI** — `tests/cli-pg-introspect.test.ts` and `tests/cli-mssql-introspect.test.ts` (mocked drivers): BASE TABLE filter, enum label unions, array types, `type_name(system_type_id)` resolution, `--schema` propagation, empty-table seeding, connection cleanup — the two dialects that previously had zero introspector tests. Type maps: mysql `bit(1)`→boolean / `bit(8)`→Buffer, mssql `time`→Date, lowercase sqlite declared types. `tests/cli-codegen-edge.test.ts`: names needing quoting/escaping (`col"name`, backslash, spaces) and the zero-column table edge. (`parseFlags` unknown/duplicate/positional coverage landed in #109; the sqlite auto-detect path is e2e-tested in `cli-ux` via `sqlite://`.)

**TS plugin** — double-quoted `StringLiteral` query detection (previously only backtick templates were exercised). (Proxy tests landed in #115, CRLF hover in #117, negative detect tests already existed; fixtures already import the real `TypedDb`.)

**Depth** — the 20→100-column upgrade landed in #102.

**Cosmetic** — the two extensionless `../src/index` imports now use `.js` like the other 28 files.

Full suite: **156 tests, 25 files**, types clean.

Closes #83