### PR TITLE
Close four ROADMAP gaps: nested CASE, multi-column subqueries, CTE-body params, ts-plugin v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,22 +693,26 @@ pick up `tsconfig.json` plugins automatically.
 **What it does:** suggests column names right after `SELECT`/a comma in the
 column list or after `WHERE`/`AND`/`OR`, and shows a column's resolved type
 on hover, for `db.query(...)` calls made through a client built with
-`createTypedDb<DB>`. If a `FROM <table>` is already present anywhere later
-in the same string, completions and hover are scoped to that table;
-otherwise `SELECT`-list completions fall back to the deduplicated union of
-every table's columns in `DB` — which is exactly what covers the example
-above before you've typed `FROM` at all. `WHERE`-position completions
-require a `FROM` to already be present (there's no table to scope to
-otherwise).
+`createTypedDb<DB>`. It is `JOIN`/alias-aware: every table introduced by a
+`FROM` or `JOIN` in the same string is in scope, and typing an alias
+qualifier (`u.` in `... from users u`) narrows completions and hover to that
+one source. With no qualifier, completions/hover union columns across all
+sources present so far — the deduplicated union of every table in `DB` before
+any `FROM` is typed at all, exactly what covers the example above. `WHERE`-
+position completions require a `FROM` to already be present (there's no
+table to scope to otherwise). It also reports unknown columns, unknown
+tables, unknown aliases, and ambiguous unqualified columns (present in more
+than one joined table) as live editor diagnostics in the `SELECT` list and
+`FROM`/`JOIN` clause — the same checks strict mode (`{ strict: true }`)
+applies at compile time, surfaced as a squiggle while you type instead of
+only once the query is finished.
 
 **What it does not do** (documented scope, not bugs):
 
-- No inline diagnostics/squiggles for unknown columns or tables — hover
-  and completions only. Strict mode (`{ strict: true }`) still catches
-  these as a compile-time `QueryTypeError`, just not as a live squiggle.
-- No `JOIN`/alias awareness — only the first `FROM <table>` in the string is
-  used to scope both completions and hover; a second table from a `JOIN` is
-  not offered.
+- No diagnostics for the `WHERE` clause or other expressions — only the
+  `SELECT` list and `FROM`/`JOIN` table names are checked, matching what the
+  type-level parser itself validates (`WHERE` is scanned only for
+  parameter placeholders, never typed).
 - No table-name completions after `FROM`/`JOIN` — only column names, after
   `SELECT`/`WHERE`, are suggested.
 - The first `FROM <table>` is found with a regex, not a real SQL parser: a
@@ -830,12 +834,14 @@ This is a focused tool for the common read path, not a full SQL grammar:
   that column's type, with `| null` added since a scalar subquery yields
   NULL on zero rows (`count(...)` subqueries are exempt — they always
   return a row). A subquery selecting more than one column resolves to
-  `unknown` rather than picking one arbitrarily. Subqueries used as a value
-  inside `WHERE` are not typed at all (`WHERE` isn't part of the typed
-  structure — only scanned for parameter placeholders).
-- **`CASE` does not support nested `CASE`.** The parser looks for the first
-  top-level `END`; a `CASE` nested inside another `CASE`'s branch is not
-  supported.
+  `unknown` in normal mode (rather than picking one arbitrarily) and to a
+  `QueryTypeError` in strict mode, since selecting more than one column
+  from a scalar subquery is invalid SQL. Subqueries used as a value inside
+  `WHERE` are not typed at all (`WHERE` isn't part of the typed structure —
+  only scanned for parameter placeholders).
+- **Nested `CASE` is supported** — a `CASE` expression inside another
+  `CASE`'s `WHEN`/`THEN`/`ELSE` branch is parsed and typed like any other
+  branch expression.
 - **Window `OVER (...)` clauses are only used as a boundary**, not parsed for
   their own typing — `PARTITION BY`/`ORDER BY` content inside `OVER (...)` is
   discarded, not validated.
@@ -850,11 +856,11 @@ This is a focused tool for the common read path, not a full SQL grammar:
   `where id=$1` is not. `INSERT ... VALUES` parameters are matched
   positionally against the INSERT's column list — `insert into t (a, b)
   values ($1, $2)` types `$1`/`$2` as `a`/`b`; without an explicit column
-  list they fall back to a flexible `unknown[]`. A query's own `WITH` CTE
-  bodies can't have their placeholders typed, and if one contains a
-  parameter the whole query falls back to `unknown[]` rather than silently
-  dropping that parameter — placeholders in the outer query (referencing a
-  CTE by name) are unaffected either way. Numbered placeholders bind by
+  list they fall back to a flexible `unknown[]`. Placeholders inside a
+  `WITH` CTE's own body are typed against that CTE's own `FROM` source (and
+  earlier CTEs it references), in the same textual order they appear in the
+  query, ahead of placeholders in the outer query that follows the `WITH`
+  clause. Numbered placeholders bind by
   their index (`$2` fills the second tuple slot even when it appears first);
   a repeated `$n` occupies a single slot.
 - **Quoted identifiers** use `"..."` (standard), `[...]` (SQL Server), or

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,8 +18,20 @@ the editor tooling, not a promise of dates.
   Kysely) and a documented Drizzle recipe.
 - `npx @owlsql/core generate` — schema introspection CLI for all four
   databases.
-- `@owlsql/core/ts-plugin` — in-editor column-name autocomplete and
-  hover info (resolved column type on hover).
+- `@owlsql/core/ts-plugin` — in-editor column-name autocomplete and hover
+  info, `JOIN`/alias-aware, plus live diagnostics for unknown columns,
+  unknown tables, unknown aliases, and ambiguous unqualified columns in the
+  `SELECT` list and `FROM`/`JOIN` clause.
+- Scalar subqueries in the `SELECT` list — single-column subqueries are
+  typed; a multi-column subquery resolves to `unknown` in normal mode and a
+  `QueryTypeError` in strict mode (selecting more than one column from a
+  scalar subquery is invalid SQL). See [README limitations](README.md#limitations).
+- Typed params inside a `WITH` CTE's own body — a placeholder in a CTE's
+  own definition is typed against that CTE's own `FROM` source, in textual
+  order alongside `INSERT ... VALUES` params and params in the outer query
+  referencing a CTE by name.
+- Nested `CASE` — a `CASE` nested inside another `CASE`'s `WHEN`/`THEN`/
+  `ELSE` branch is parsed and typed like any other branch expression.
 - [COMPARISON.md](COMPARISON.md) — sourced comparison vs Prisma/Kysely/
   pgTyped/Zapatos on build step, runtime cost, bundle size, and DX.
 
@@ -28,23 +40,9 @@ the editor tooling, not a promise of dates.
 Bigger pieces that need real parser or compiler-API design work — not
 first-timer-sized, but open if you want to dig in:
 
-- **Scalar subqueries in `WHERE`** (still resolve to `unknown` — `WHERE`
+- **Scalar subqueries in `WHERE`** still resolve to `unknown` — `WHERE`
   isn't part of the typed structure at all right now, only scanned for
-  parameter placeholders). Single-column `SELECT`-list scalar subqueries are
-  typed now — see [README limitations](README.md#limitations). Multi-column
-  `SELECT`-list subqueries still resolve to `unknown` too, by design.
-- **`ts-plugin` v2**: inline diagnostics for unknown columns/tables (reusing
-  strict-mode's `QueryTypeError` logic but surfaced as a `tsserver`
-  diagnostic instead of a type), and `JOIN`/alias-aware completions and
-  hover (right now only the first `FROM <table>` is used to scope both).
-- **Typed params inside a `WITH` CTE's own subquery body** — a placeholder
-  written inside a CTE's own definition still can't be typed; the whole
-  query falls back to `unknown[]` rather than mistyping it. (`INSERT ...
-  VALUES` params against an explicit column list, and params in a query's
-  outer `SELECT` referencing a CTE by name, are both typed now — see
-  [README limitations](README.md#limitations).)
-- **Nested `CASE`** — the parser currently finds the first top-level `END`
-  only.
+  parameter placeholders.
 - **`ts-plugin` on TypeScript 7+** — TS 7's native (Go) compiler dropped the
   classic JS Compiler API entirely (no `ts.Node`/`ts.forEachChild`/
   `ts.createProgram` in the package anymore, replaced by a still-`unstable/`-

--- a/src/case.ts
+++ b/src/case.ts
@@ -3,12 +3,22 @@ import type { SchemaLike, Source, ResolveColumnType } from './parse.js';
 
 export type IsCaseExpression<Expr extends string> = IsKeyword<FirstWord<Trim<Expr>>, 'case'>;
 
-type FindEnd<S extends string, Accumulated extends string = ''> = S extends `${infer Head} ${infer Tail}`
-  ? IsKeyword<Head, 'end'> extends true
-    ? { body: Trim<Accumulated>; rest: Trim<Tail> }
-    : FindEnd<Tail, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+type FindEnd<
+  S extends string,
+  Depth extends unknown[] = [],
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? IsKeyword<Head, 'case'> extends true
+    ? FindEnd<Tail, [...Depth, unknown], Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+    : IsKeyword<Head, 'end'> extends true
+      ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
+        ? FindEnd<Tail, DepthRest, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+        : { body: Trim<Accumulated>; rest: Trim<Tail> }
+      : FindEnd<Tail, Depth, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
   : IsKeyword<S, 'end'> extends true
-    ? { body: Trim<Accumulated>; rest: '' }
+    ? Depth extends []
+      ? { body: Trim<Accumulated>; rest: '' }
+      : never
     : never;
 
 export type SplitCaseExpression<Expr extends string> = DropFirstWord<Trim<Expr>> extends infer AfterCase extends string
@@ -31,14 +41,23 @@ type ScanCaseSegments<
   CurrentKind extends 'when' | 'then' | 'else',
   CurrentText extends string,
   Accumulated extends CaseSegment[],
+  Depth extends unknown[] = [],
 > = S extends `${infer Head} ${infer Tail}`
-  ? IsKeyword<Head, 'when'> extends true
-    ? ScanCaseSegments<Tail, 'when', '', [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText> }]>
-    : IsKeyword<Head, 'then'> extends true
-      ? ScanCaseSegments<Tail, 'then', '', [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText> }]>
-      : IsKeyword<Head, 'else'> extends true
-        ? ScanCaseSegments<Tail, 'else', '', [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText> }]>
-        : ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated>
+  ? IsKeyword<Head, 'case'> extends true
+    ? ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated, [...Depth, unknown]>
+    : IsKeyword<Head, 'end'> extends true
+      ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
+        ? ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated, DepthRest>
+        : ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated, Depth>
+      : Depth extends []
+        ? IsKeyword<Head, 'when'> extends true
+          ? ScanCaseSegments<Tail, 'when', '', [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText> }], Depth>
+          : IsKeyword<Head, 'then'> extends true
+            ? ScanCaseSegments<Tail, 'then', '', [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText> }], Depth>
+            : IsKeyword<Head, 'else'> extends true
+              ? ScanCaseSegments<Tail, 'else', '', [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText> }], Depth>
+              : ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated, Depth>
+        : ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated, Depth>
   : [...Accumulated, { kind: CurrentKind; text: Trim<CurrentText extends '' ? S : `${CurrentText} ${S}`> }];
 
 type HasElseBranch<Segments extends CaseSegment[]> = Segments extends [

--- a/src/params.ts
+++ b/src/params.ts
@@ -135,7 +135,7 @@ type AddParam<
       : never
   : never;
 
-type ScanParams<
+type ScanParamsRaw<
   S extends string,
   DB extends SchemaLike,
   Sources extends Source[],
@@ -149,21 +149,40 @@ type ScanParams<
         indexed: infer NextIndexed extends unknown[];
         sequential: infer NextSequential extends unknown[];
       }
-      ? ScanParams<Tail, DB, Sources, PrevPrev, Prev, NextIndexed, NextSequential>
+      ? ScanParamsRaw<Tail, DB, Sources, PrevPrev, Prev, NextIndexed, NextSequential>
       : never
     : IsTransparentToken<Head> extends true
-      ? ScanParams<Tail, DB, Sources, PrevPrev, Prev, Indexed, Sequential>
-      : ScanParams<Tail, DB, Sources, Prev, CleanColumnToken<Head>, Indexed, Sequential>
+      ? ScanParamsRaw<Tail, DB, Sources, PrevPrev, Prev, Indexed, Sequential>
+      : ScanParamsRaw<Tail, DB, Sources, Prev, CleanColumnToken<Head>, Indexed, Sequential>
   : S extends ''
-    ? [...Indexed, ...Sequential]
+    ? { indexed: Indexed; sequential: Sequential }
     : IsPlaceholder<S> extends true
-      ? AddParam<S, ParamType<DB, Sources, PrevPrev, Prev>, Indexed, Sequential> extends {
-          indexed: infer NextIndexed extends unknown[];
-          sequential: infer NextSequential extends unknown[];
-        }
-        ? [...NextIndexed, ...NextSequential]
-        : never
-      : [...Indexed, ...Sequential];
+      ? AddParam<S, ParamType<DB, Sources, PrevPrev, Prev>, Indexed, Sequential>
+      : { indexed: Indexed; sequential: Sequential };
+
+type ScanParams<
+  S extends string,
+  DB extends SchemaLike,
+  Sources extends Source[],
+  PrevPrev extends string = '',
+  Prev extends string = '',
+  Indexed extends unknown[] = [],
+  Sequential extends unknown[] = [],
+> = ScanParamsRaw<S, DB, Sources, PrevPrev, Prev, Indexed, Sequential> extends {
+  indexed: infer FinalIndexed extends unknown[];
+  sequential: infer FinalSequential extends unknown[];
+}
+  ? [...FinalIndexed, ...FinalSequential]
+  : never;
+
+type ZipIntersectIndexed<A extends unknown[], B extends unknown[]> = A extends [
+  infer AHead,
+  ...infer ATail extends unknown[],
+]
+  ? B extends [infer BHead, ...infer BTail extends unknown[]]
+    ? [AHead & BHead, ...ZipIntersectIndexed<ATail, BTail>]
+    : A
+  : B;
 
 type InsertColumnList<S extends string> = AfterKeyword<S, 'into'> extends infer AfterInto extends string
   ? Trim<DropFirstWord<AfterInto>> extends `(${infer AfterOpen}`
@@ -245,29 +264,28 @@ type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<
       : unknown[]
   : unknown[];
 
-type ContainsPlaceholderLikeChar<S extends string> = S extends
-  | `${string}$${string}`
-  | `${string}?${string}`
-  | `${string}@${string}`
-  ? true
-  : false;
-
 type CteScanEntry = [name: string, query: string, columns: string[] | null];
 
-type AnyCteBodyHasPlaceholder<Ctes extends CteScanEntry[]> = Ctes extends [
+type CteBodyParamScan<DB extends SchemaLike, Ctes extends CteScanEntry[]> = Ctes extends [
   infer Head extends CteScanEntry,
   ...infer Tail extends CteScanEntry[],
 ]
-  ? ContainsPlaceholderLikeChar<Head[1]> extends true
-    ? true
-    : AnyCteBodyHasPlaceholder<Tail>
-  : false;
-
-type CteBodiesHavePlaceholder<Q extends string> = [ParseWithClause<Normalize<Q>>] extends [never]
-  ? false
-  : ParseWithClause<Normalize<Q>> extends { ctes: infer Ctes extends CteScanEntry[] }
-    ? AnyCteBodyHasPlaceholder<Ctes>
-    : false;
+  ? [ParseStatement<Head[1]>] extends [never]
+    ? CteBodyParamScan<DB, Tail>
+    : ParseStatement<Head[1]> extends { sources: infer Sources extends Source[] }
+      ? ScanParamsRaw<Head[1], DB, Sources> extends {
+          indexed: infer HeadIndexed extends unknown[];
+          sequential: infer HeadSequential extends unknown[];
+        }
+        ? CteBodyParamScan<DB, Tail> extends {
+            indexed: infer TailIndexed extends unknown[];
+            sequential: infer TailSequential extends unknown[];
+          }
+          ? { indexed: ZipIntersectIndexed<HeadIndexed, TailIndexed>; sequential: [...HeadSequential, ...TailSequential] }
+          : never
+        : never
+      : CteBodyParamScan<DB, Tail>
+  : { indexed: []; sequential: [] };
 
 type StripDoubledAt<S extends string> = S extends `${infer Before}@@${infer After}`
   ? StripDoubledAt<`${Before}${After}`>
@@ -280,18 +298,38 @@ export type UsedPlaceholderStyles<Q extends string> = Normalize<Q> extends infer
       | (StripDoubledAt<Text> extends `${string}@${string}` ? 'at' : never)
   : never;
 
+type OuterAndCteParams<
+  DB extends SchemaLike,
+  Q extends string,
+  CteDB extends SchemaLike,
+  EffectiveQuery extends string,
+  Sources extends Source[],
+> = ScanParamsRaw<EffectiveQuery, CteDB, Sources> extends {
+  indexed: infer OuterIndexed extends unknown[];
+  sequential: infer OuterSequential extends unknown[];
+}
+  ? [ParseWithClause<Normalize<Q>>] extends [never]
+    ? [...OuterIndexed, ...OuterSequential]
+    : ParseWithClause<Normalize<Q>> extends { ctes: infer Ctes extends CteScanEntry[] }
+      ? CteBodyParamScan<CteDB, Ctes> extends {
+          indexed: infer CteIndexed extends unknown[];
+          sequential: infer CteSequential extends unknown[];
+        }
+        ? [...ZipIntersectIndexed<CteIndexed, OuterIndexed>, ...CteSequential, ...OuterSequential]
+        : unknown[]
+      : unknown[]
+  : unknown[];
+
 export type InferParams<DB extends SchemaLike, Q extends string> =
   IsKeyword<FirstWord<Normalize<Q>>, 'insert'> extends true
     ? InsertParamTypes<DB, Normalize<Q>>
-    : CteBodiesHavePlaceholder<Q> extends true
-      ? unknown[]
-      : ResolveCteContext<DB, Q, false> extends {
-            db: infer CteDB extends SchemaLike;
-            query: infer EffectiveQuery extends string;
-          }
-        ? [ParseStatement<EffectiveQuery>] extends [never]
-          ? unknown[]
-          : ParseStatement<EffectiveQuery> extends { sources: infer Sources extends Source[] }
-            ? ScanParams<EffectiveQuery, CteDB, Sources>
-            : unknown[]
-        : unknown[];
+    : ResolveCteContext<DB, Q, false> extends {
+          db: infer CteDB extends SchemaLike;
+          query: infer EffectiveQuery extends string;
+        }
+      ? [ParseStatement<EffectiveQuery>] extends [never]
+        ? unknown[]
+        : ParseStatement<EffectiveQuery> extends { sources: infer Sources extends Source[] }
+          ? OuterAndCteParams<DB, Q, CteDB, EffectiveQuery, Sources>
+          : unknown[]
+      : unknown[];

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -496,7 +496,9 @@ type ScalarSubqueryType<
     : Row extends QueryTypeError<string>
       ? Row
       : IsUnion<keyof Row> extends true
-        ? unknown
+        ? Strict extends true
+          ? QueryTypeError<'scalar subquery must select exactly one column'>
+          : unknown
         : IsCountSubquery<Q> extends true
           ? Row[keyof Row]
           : Row[keyof Row] | null

--- a/src/ts-plugin/detect.cts
+++ b/src/ts-plugin/detect.cts
@@ -109,13 +109,11 @@ function findTypedDbTypeReference(
   return null;
 }
 
-function matchQueryLiteral(
+function matchQueryLiteralNode(
   typescript: TypeScript,
   checker: ts.TypeChecker,
-  sourceFile: ts.SourceFile,
-  position: number,
+  node: ts.Node,
 ): QueryLiteralMatch | null {
-  const node = findNodeAtPosition(typescript, sourceFile, position);
   if (!isSqlLiteral(typescript, node)) {
     return null;
   }
@@ -144,4 +142,35 @@ function matchQueryLiteral(
   return { literal: node, dbType };
 }
 
-export = { matchQueryLiteral };
+function matchQueryLiteral(
+  typescript: TypeScript,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  position: number,
+): QueryLiteralMatch | null {
+  const node = findNodeAtPosition(typescript, sourceFile, position);
+  return matchQueryLiteralNode(typescript, checker, node);
+}
+
+function findAllQueryLiterals(
+  typescript: TypeScript,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+): QueryLiteralMatch[] {
+  const matches: QueryLiteralMatch[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (isSqlLiteral(typescript, node)) {
+      const match = matchQueryLiteralNode(typescript, checker, node);
+      if (match) {
+        matches.push(match);
+      }
+    }
+    typescript.forEachChild(node, visit);
+  };
+
+  typescript.forEachChild(sourceFile, visit);
+  return matches;
+}
+
+export = { matchQueryLiteral, findAllQueryLiterals };

--- a/src/ts-plugin/diagnostics.cts
+++ b/src/ts-plugin/diagnostics.cts
@@ -1,0 +1,177 @@
+import type * as ts from 'typescript';
+import sqlContext = require('./sql-context.cjs');
+import schemaModule = require('./schema.cjs');
+
+const { findSources, findSourceByAlias, stripStringLiterals } = sqlContext;
+const { getColumnNames } = schemaModule;
+
+const SELECT_KEYWORD = /^\s*select\b/i;
+const DISTINCT_KEYWORD = /^\s*distinct\b/i;
+const LITERAL_TOKEN = /^(?:-?\d+(?:\.\d+)?|true|false|null)$/i;
+const QUOTE_CHAR = /['"`[\]]/;
+const AS_KEYWORD = /^as$/i;
+
+interface ColumnEntry {
+  text: string;
+  start: number;
+}
+
+interface DiagnosticSpan {
+  start: number;
+  length: number;
+  message: string;
+}
+
+function findTopLevelFromIndex(text: string): number | null {
+  const fromPattern = /\bfrom\b/gi;
+  let match: RegExpExecArray | null;
+  while ((match = fromPattern.exec(text)) !== null) {
+    let depth = 0;
+    for (let i = 0; i < match.index; i += 1) {
+      if (text[i] === '(') depth += 1;
+      else if (text[i] === ')') depth -= 1;
+    }
+    if (depth === 0) {
+      return match.index;
+    }
+  }
+  return null;
+}
+
+function splitTopLevelCommas(text: string): ColumnEntry[] {
+  const entries: ColumnEntry[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    if (char === '(') depth += 1;
+    else if (char === ')') depth -= 1;
+    else if (char === ',' && depth === 0) {
+      entries.push({ text: text.slice(start, i), start });
+      start = i + 1;
+    }
+  }
+  entries.push({ text: text.slice(start), start });
+
+  return entries;
+}
+
+function skipLeadingKeyword(text: string, keyword: RegExp): string {
+  const match = keyword.exec(text);
+  return match ? text.slice(match[0].length) : text;
+}
+
+function columnTokenFromEntry(entry: ColumnEntry): { token: string; offset: number } | null {
+  const leadingWhitespace = entry.text.length - entry.text.trimStart().length;
+  const trimmed = entry.text.trim();
+
+  if (trimmed === '' || trimmed === '*' || trimmed.includes('(')) {
+    return null;
+  }
+  if (QUOTE_CHAR.test(trimmed[0] ?? '')) {
+    return null;
+  }
+  if (LITERAL_TOKEN.test(trimmed)) {
+    return null;
+  }
+
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  const token = parts[0];
+  if (!token) {
+    return null;
+  }
+  if (parts.length > 1 && !(parts.length === 2 || (parts.length === 3 && AS_KEYWORD.test(parts[1] ?? '')))) {
+    return null;
+  }
+  if (QUOTE_CHAR.test(token) || /[*+/%^<>=|-]/.test(token)) {
+    return null;
+  }
+
+  return { token, offset: leadingWhitespace };
+}
+
+function getQueryDiagnostics(
+  checker: ts.TypeChecker,
+  dbType: ts.Type,
+  literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral,
+): DiagnosticSpan[] {
+  const literalStart = literal.getStart() + 1;
+  const text = literal.text;
+  const { stripped } = stripStringLiterals(text);
+
+  const fromIndex = findTopLevelFromIndex(stripped);
+  if (fromIndex === null || !SELECT_KEYWORD.test(stripped)) {
+    return [];
+  }
+
+  const sources = findSources(text);
+  const diagnostics: DiagnosticSpan[] = [];
+
+  for (const source of sources) {
+    if (!checker.getPropertyOfType(dbType, source.table)) {
+      diagnostics.push({
+        start: literalStart + source.tableStart,
+        length: source.tableEnd - source.tableStart,
+        message: `unknown table: ${source.table}`,
+      });
+    }
+  }
+
+  const beforeFrom = stripped.slice(0, fromIndex);
+  const afterSelect = skipLeadingKeyword(beforeFrom, SELECT_KEYWORD);
+  const selectList = skipLeadingKeyword(afterSelect, DISTINCT_KEYWORD);
+  const selectListOffset = beforeFrom.length - selectList.length;
+
+  for (const entry of splitTopLevelCommas(selectList)) {
+    const parsed = columnTokenFromEntry(entry);
+    if (!parsed) {
+      continue;
+    }
+
+    const dotIndex = parsed.token.indexOf('.');
+    const qualifier = dotIndex === -1 ? null : parsed.token.slice(0, dotIndex);
+    const columnName = dotIndex === -1 ? parsed.token : parsed.token.slice(dotIndex + 1);
+    if (columnName === '' || columnName === '*') {
+      continue;
+    }
+
+    const tokenStart = literalStart + selectListOffset + entry.start + parsed.offset;
+    const columnStart = tokenStart + (dotIndex === -1 ? 0 : dotIndex + 1);
+
+    if (qualifier) {
+      const matchedSource = findSourceByAlias(sources, qualifier);
+      if (!matchedSource) {
+        diagnostics.push({ start: tokenStart, length: qualifier.length, message: `unknown alias: ${qualifier}` });
+        continue;
+      }
+      if (!checker.getPropertyOfType(dbType, matchedSource.table)) {
+        continue;
+      }
+      const names = getColumnNames(checker, dbType, literal, matchedSource.table);
+      if (!names.includes(columnName)) {
+        diagnostics.push({ start: columnStart, length: columnName.length, message: `unknown column: ${columnName}` });
+      }
+      continue;
+    }
+
+    const knownTables = sources.filter((source) => checker.getPropertyOfType(dbType, source.table));
+    if (knownTables.length === 0) {
+      continue;
+    }
+
+    const containingTables = knownTables.filter((source) =>
+      getColumnNames(checker, dbType, literal, source.table).includes(columnName),
+    );
+
+    if (containingTables.length === 0) {
+      diagnostics.push({ start: columnStart, length: columnName.length, message: `unknown column: ${columnName}` });
+    } else if (containingTables.length > 1) {
+      diagnostics.push({ start: columnStart, length: columnName.length, message: `ambiguous column: ${columnName}` });
+    }
+  }
+
+  return diagnostics;
+}
+
+export = { getQueryDiagnostics };

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -2,10 +2,34 @@ import type * as ts from 'typescript/lib/tsserverlibrary';
 import sqlContext = require('./sql-context.cjs');
 import schemaModule = require('./schema.cjs');
 import detectModule = require('./detect.cjs');
+import diagnosticsModule = require('./diagnostics.cjs');
 
-const { getSelectListContext, getWhereClauseContext, findFromTable, getWordAtOffset } = sqlContext;
+const {
+  getSelectListContext,
+  getWhereClauseContext,
+  findSources,
+  findSourceByAlias,
+  getQualifierBefore,
+  getWordAtOffset,
+} = sqlContext;
 const { getColumnNames, getColumnType } = schemaModule;
-const { matchQueryLiteral } = detectModule;
+const { matchQueryLiteral, findAllQueryLiterals } = detectModule;
+const { getQueryDiagnostics } = diagnosticsModule;
+
+const OWLSQL_DIAGNOSTIC_SOURCE = 'owlsql';
+const OWLSQL_DIAGNOSTIC_CODE = 990001;
+
+function resolveTableScope(
+  sources: ReturnType<typeof findSources>,
+  qualifier: string | null,
+): string | string[] | null {
+  if (qualifier) {
+    const source = findSourceByAlias(sources, qualifier);
+    return source ? source.table : [];
+  }
+
+  return sources.length > 0 ? sources.map((source) => source.table) : null;
+}
 
 function init(modules: { typescript: typeof ts }) {
   const typescript = modules.typescript;
@@ -49,7 +73,8 @@ function init(modules: { typescript: typeof ts }) {
         }
 
         const fullLiteralText = match.literal.text;
-        const table = findFromTable(fullLiteralText);
+        const sources = findSources(fullLiteralText);
+        const table = resolveTableScope(sources, context.qualifier);
         const columns = getColumnNames(checker, match.dbType, match.literal, table);
         const prefix = context.prefix.toLowerCase();
         const filtered = columns.filter((name) => name.toLowerCase().startsWith(prefix));
@@ -114,7 +139,7 @@ function init(modules: { typescript: typeof ts }) {
           return native();
         }
 
-        const table = findFromTable(match.literal.text);
+        const table = resolveTableScope(findSources(match.literal.text), null);
         const columnType = getColumnType(checker, match.dbType, match.literal, table, entryName);
         if (!columnType) {
           return native();
@@ -158,7 +183,8 @@ function init(modules: { typescript: typeof ts }) {
           return native();
         }
 
-        const table = findFromTable(rawLiteralText);
+        const qualifier = getQualifierBefore(rawLiteralText, word.start);
+        const table = resolveTableScope(findSources(rawLiteralText), qualifier);
         const columnType = getColumnType(checker, match.dbType, match.literal, table, word.word);
         if (!columnType) {
           return native();
@@ -178,6 +204,42 @@ function init(modules: { typescript: typeof ts }) {
     };
 
     proxy.getQuickInfoAtPosition = getQuickInfoAtPosition;
+
+    const getSemanticDiagnostics: ts.LanguageService['getSemanticDiagnostics'] = (fileName) => {
+      const native = info.languageService.getSemanticDiagnostics(fileName);
+
+      try {
+        const program = info.languageService.getProgram();
+        const sourceFile = program?.getSourceFile(fileName);
+        if (!program || !sourceFile) {
+          return native;
+        }
+
+        const checker = program.getTypeChecker();
+        const matches = findAllQueryLiterals(typescript, checker, sourceFile);
+        const extra: ts.Diagnostic[] = [];
+
+        for (const match of matches) {
+          for (const span of getQueryDiagnostics(checker, match.dbType, match.literal)) {
+            extra.push({
+              file: sourceFile,
+              start: span.start,
+              length: span.length,
+              messageText: span.message,
+              category: typescript.DiagnosticCategory.Warning,
+              code: OWLSQL_DIAGNOSTIC_CODE,
+              source: OWLSQL_DIAGNOSTIC_SOURCE,
+            });
+          }
+        }
+
+        return extra.length === 0 ? native : [...native, ...extra];
+      } catch {
+        return native;
+      }
+    };
+
+    proxy.getSemanticDiagnostics = getSemanticDiagnostics;
 
     return proxy as unknown as ts.LanguageService;
   }

--- a/src/ts-plugin/schema.cts
+++ b/src/ts-plugin/schema.cts
@@ -2,20 +2,21 @@ import type * as ts from 'typescript';
 
 function scopeToTable(
   tableSymbols: ts.Symbol[],
-  onlyTable: string | null,
+  onlyTable: string | string[] | null,
 ): ts.Symbol[] {
   if (!onlyTable) {
     return tableSymbols;
   }
 
-  return tableSymbols.filter((symbol) => symbol.getName() === onlyTable);
+  const wanted = new Set(Array.isArray(onlyTable) ? onlyTable : [onlyTable]);
+  return tableSymbols.filter((symbol) => wanted.has(symbol.getName()));
 }
 
 function getColumnNames(
   checker: ts.TypeChecker,
   dbType: ts.Type,
   node: ts.Node,
-  onlyTable: string | null,
+  onlyTable: string | string[] | null,
 ): string[] {
   const tables = scopeToTable(dbType.getProperties(), onlyTable);
 
@@ -35,7 +36,7 @@ function getColumnType(
   checker: ts.TypeChecker,
   dbType: ts.Type,
   node: ts.Node,
-  onlyTable: string | null,
+  onlyTable: string | string[] | null,
   columnName: string,
 ): ts.Type | null {
   const tables = scopeToTable(dbType.getProperties(), onlyTable);

--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -1,13 +1,42 @@
 const SELECT_START = /^select\b/i;
 const HAS_FROM = /\bfrom\b/i;
 const HAS_COLUMN_CLAUSE = /\b(where|having|on|order\s+by|group\s+by)\b/i;
-const TRAILING_TOKEN = /([A-Za-z0-9_]+)$/;
+const QUALIFIED_TRAILING_TOKEN = /(?:([A-Za-z_][A-Za-z0-9_]*)\.)?([A-Za-z0-9_]*)$/;
 const FROM_TABLE = /\bfrom\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)/i;
+const FROM_OR_JOIN_SOURCE = /\b(from|join)\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)(?:\s+(as\s+)?([A-Za-z_][A-Za-z0-9_]*))?/gid;
 const WORD_CHAR = /[A-Za-z0-9_]/;
 const WORD_START_CHAR = /[A-Za-z_]/;
 
+const RESERVED_AFTER_SOURCE = new Set([
+  'on',
+  'where',
+  'join',
+  'inner',
+  'left',
+  'right',
+  'full',
+  'outer',
+  'cross',
+  'group',
+  'order',
+  'having',
+  'limit',
+  'offset',
+  'union',
+  'set',
+  'as',
+]);
+
 interface SelectListContext {
   prefix: string;
+  qualifier: string | null;
+}
+
+interface QuerySource {
+  table: string;
+  alias: string;
+  tableStart: number;
+  tableEnd: number;
 }
 
 interface WordAtOffset {
@@ -31,23 +60,20 @@ function stripStringLiterals(text: string): StrippedText {
       stripped += char;
       continue;
     }
-    if (!insideLiteral) {
-      stripped += char;
-    }
+    stripped += !insideLiteral ? char : ' ';
   }
 
   return { stripped, insideLiteral };
 }
 
 function prefixFrom(textBeforeCursor: string): SelectListContext | null {
-  const token = TRAILING_TOKEN.exec(textBeforeCursor)?.[1];
-  if (token === undefined) {
-    return { prefix: '' };
-  }
-  if (!WORD_START_CHAR.test(token[0] ?? '')) {
+  const match = QUALIFIED_TRAILING_TOKEN.exec(textBeforeCursor);
+  const qualifier = match?.[1] ?? null;
+  const token = match?.[2] ?? '';
+  if (token !== '' && !WORD_START_CHAR.test(token[0] ?? '')) {
     return null;
   }
-  return { prefix: token };
+  return { prefix: token, qualifier };
 }
 
 function getSelectListContext(textBeforeCursor: string): SelectListContext | null {
@@ -90,6 +116,45 @@ function findFromTable(fullLiteralText: string): string | null {
   return match?.[1] ?? null;
 }
 
+function findSources(fullLiteralText: string): QuerySource[] {
+  const { stripped } = stripStringLiterals(fullLiteralText);
+  const sources: QuerySource[] = [];
+
+  FROM_OR_JOIN_SOURCE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = FROM_OR_JOIN_SOURCE.exec(stripped)) !== null) {
+    const table = match[2];
+    const tableSpan = (match as unknown as { indices?: Array<[number, number] | undefined> }).indices?.[2];
+    if (!table || !tableSpan) {
+      continue;
+    }
+    const rawAlias = match[4] ?? null;
+    const alias = rawAlias && !RESERVED_AFTER_SOURCE.has(rawAlias.toLowerCase()) ? rawAlias : table;
+    sources.push({ table, alias, tableStart: tableSpan[0], tableEnd: tableSpan[1] });
+  }
+
+  return sources;
+}
+
+function findSourceByAlias(sources: QuerySource[], alias: string): QuerySource | null {
+  const lowerAlias = alias.toLowerCase();
+  return sources.find((source) => source.alias.toLowerCase() === lowerAlias) ?? null;
+}
+
+function getQualifierBefore(text: string, wordStart: number): string | null {
+  if (text[wordStart - 1] !== '.') {
+    return null;
+  }
+
+  let start = wordStart - 1;
+  while (start > 0 && WORD_CHAR.test(text[start - 1] ?? '')) {
+    start -= 1;
+  }
+
+  const qualifier = text.slice(start, wordStart - 1);
+  return qualifier !== '' && WORD_START_CHAR.test(qualifier[0] ?? '') ? qualifier : null;
+}
+
 function getWordAtOffset(text: string, offset: number): WordAtOffset | null {
   if (offset < 0 || offset > text.length) {
     return null;
@@ -117,4 +182,13 @@ function getWordAtOffset(text: string, offset: number): WordAtOffset | null {
   return { word, start, end };
 }
 
-export = { getSelectListContext, getWhereClauseContext, findFromTable, getWordAtOffset };
+export = {
+  getSelectListContext,
+  getWhereClauseContext,
+  findFromTable,
+  findSources,
+  findSourceByAlias,
+  getQualifierBefore,
+  getWordAtOffset,
+  stripStringLiterals,
+};

--- a/tests/case.test-d.ts
+++ b/tests/case.test-d.ts
@@ -56,6 +56,26 @@ type CaseWithUnknownColumnFallsBackToUnknown = Expect<
   >
 >;
 
+type NestedCase = Expect<
+  Equal<
+    Query<
+      DB,
+      "select case when active then case when age < 18 then 'minor' else 'adult' end else 'inactive' end as status from users"
+    >,
+    { status: string }[]
+  >
+>;
+
+type NestedCaseFollowedByOuterElse = Expect<
+  Equal<
+    Query<
+      DB,
+      "select case when active then 'yes' end as flag, case when age < 18 then case when name = 'x' then 1 else 2 end else 3 end as bracket from users"
+    >,
+    { flag: string | null; bracket: number }[]
+  >
+>;
+
 export type CaseLock = [
   CaseWithLiterals,
   CaseWithoutElseIsNullable,
@@ -63,4 +83,6 @@ export type CaseLock = [
   CaseWithColumnBranch,
   CaseWithoutAliasDefaultsToCase,
   CaseWithUnknownColumnFallsBackToUnknown,
+  NestedCase,
+  NestedCaseFollowedByOuterElse,
 ];

--- a/tests/cte.test-d.ts
+++ b/tests/cte.test-d.ts
@@ -91,10 +91,20 @@ type ParamAfterMultipleCtesStillResolves = Expect<
   >
 >;
 
-type ParamInsideCteBodyFallsBackSafelyInsteadOfClaimingZeroParams = Expect<
+type ParamInsideCteBodyIsTypedAgainstItsOwnSource = Expect<
   Equal<
     Params<DB, 'with popular as (select id from posts where views > $1) select id from popular'>,
-    unknown[]
+    [number]
+  >
+>;
+
+type ParamsInsideAndAfterCteBodyBothTypeInTextualOrder = Expect<
+  Equal<
+    Params<
+      DB,
+      'with popular as (select id from posts where views > $1) select id from popular where id = $2'
+    >,
+    [number, number]
   >
 >;
 
@@ -109,5 +119,6 @@ export type CteLock = [
   CteMultiColumnListRenamesPositionally,
   ParamAfterCteResolvesAgainstCteShape,
   ParamAfterMultipleCtesStillResolves,
-  ParamInsideCteBodyFallsBackSafelyInsteadOfClaimingZeroParams,
+  ParamInsideCteBodyIsTypedAgainstItsOwnSource,
+  ParamsInsideAndAfterCteBodyBothTypeInTextualOrder,
 ];

--- a/tests/scalar-subquery.test-d.ts
+++ b/tests/scalar-subquery.test-d.ts
@@ -54,6 +54,13 @@ type PlainParenthesizedExpressionIsUnaffected = Expect<
   Equal<Query<DB, 'select (views * 2) as total, id from posts'>, { total: unknown; id: number }[]>
 >;
 
+type StrictModeRejectsMultiColumnSubquery = Expect<
+  Equal<
+    StrictQuery<DB, 'select (select id, views from posts) as bad from users'>,
+    QueryTypeError<'scalar subquery must select exactly one column'>[]
+  >
+>;
+
 export type ScalarSubqueryLock = [
   ScalarSubqueryFromTheIssueExample,
   ScalarSubqueryAliasedColumnFromInnerTable,
@@ -61,4 +68,5 @@ export type ScalarSubqueryLock = [
   MultiColumnSubqueryFallsBackToUnknown,
   StrictModeSurfacesTheInnerColumnError,
   PlainParenthesizedExpressionIsUnaffected,
+  StrictModeRejectsMultiColumnSubquery,
 ];

--- a/tests/ts-plugin-completions.test.ts
+++ b/tests/ts-plugin-completions.test.ts
@@ -59,7 +59,7 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
 
     const textBeforeCursor = sourceFile.text.slice(literalStart, cursor);
     const context = getSelectListContext(textBeforeCursor);
-    expect(context).toEqual({ prefix: 'na' });
+    expect(context).toEqual({ prefix: 'na', qualifier: null });
     if (!context) return;
 
     const table = findFromTable(match.literal.text);
@@ -106,7 +106,7 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
 
     const textBeforeCursor = sourceFile.text.slice(literalStart, cursor);
     const context = getSelectListContext(textBeforeCursor) ?? getWhereClauseContext(textBeforeCursor);
-    expect(context).toEqual({ prefix: 'na' });
+    expect(context).toEqual({ prefix: 'na', qualifier: null });
     if (!context) return;
 
     const table = findFromTable(match.literal.text);

--- a/tests/ts-plugin-diagnostics.test.ts
+++ b/tests/ts-plugin-diagnostics.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterAll, afterEach } from 'vitest';
+import { rmSync } from 'node:fs';
+import ts from 'typescript';
+import detectModule from '../src/ts-plugin/detect.cts';
+import { buildProgram, loadDiagnostics } from './ts-plugin-test-helpers.js';
+
+const { findAllQueryLiterals } = detectModule;
+const { diagnostics: diagnosticsModule, dir: diagnosticsDir } = loadDiagnostics();
+const { getQueryDiagnostics } = diagnosticsModule;
+
+afterAll(() => {
+  rmSync(diagnosticsDir, { recursive: true, force: true });
+});
+
+const FIXTURE = `
+import type { TypedDb } from '@owlsql/core';
+
+interface DB {
+  users: { id: number; name: string };
+  posts: { id: number; title: string; user_id: number };
+}
+
+declare const db: TypedDb<DB>;
+`;
+
+function diagnosticsFor(query: string): { message: string; text: string }[] {
+  const source = `${FIXTURE}\ndb.query(\`${query}\`);\n`;
+  const { program, sourceFile, dir } = buildProgram(source, 'owlsql-ts-plugin-diagnostics-');
+  try {
+    const checker = program.getTypeChecker();
+    const matches = findAllQueryLiterals(ts, checker, sourceFile);
+    expect(matches).toHaveLength(1);
+    const [match] = matches;
+    if (!match) return [];
+    return getQueryDiagnostics(checker, match.dbType, match.literal).map((span) => ({
+      message: span.message,
+      text: sourceFile.text.slice(span.start, span.start + span.length),
+    }));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
+  it('reports no diagnostics for a valid query', () => {
+    expect(diagnosticsFor('select id, name from users')).toEqual([]);
+  });
+
+  it('reports an unknown column in the SELECT list', () => {
+    expect(diagnosticsFor('select id, nope from users')).toEqual([
+      { message: 'unknown column: nope', text: 'nope' },
+    ]);
+  });
+
+  it('reports an unknown table in the FROM clause', () => {
+    expect(diagnosticsFor('select id from ghosts')).toEqual([
+      { message: 'unknown table: ghosts', text: 'ghosts' },
+    ]);
+  });
+
+  it('resolves a qualified column against its JOINed alias', () => {
+    expect(
+      diagnosticsFor('select u.id, p.title from users u join posts p on p.user_id = u.id'),
+    ).toEqual([]);
+  });
+
+  it('reports an unknown column on a specific alias', () => {
+    expect(
+      diagnosticsFor('select u.nope from users u join posts p on p.user_id = u.id'),
+    ).toEqual([{ message: 'unknown column: nope', text: 'nope' }]);
+  });
+
+  it('reports an unknown alias qualifier', () => {
+    expect(diagnosticsFor('select z.id from users u')).toEqual([
+      { message: 'unknown alias: z', text: 'z' },
+    ]);
+  });
+
+  it('reports an ambiguous unqualified column across a join', () => {
+    expect(diagnosticsFor('select id from users u join posts p on p.user_id = u.id')).toEqual([
+      { message: 'ambiguous column: id', text: 'id' },
+    ]);
+  });
+
+  it('skips validation for function calls, literals, and star', () => {
+    expect(
+      diagnosticsFor("select *, count(*), 'literal', 1, name from users"),
+    ).toEqual([]);
+  });
+
+  it('does not run without a FROM clause', () => {
+    expect(diagnosticsFor('select nope')).toEqual([]);
+  });
+});

--- a/tests/ts-plugin-schema.test.ts
+++ b/tests/ts-plugin-schema.test.ts
@@ -76,4 +76,41 @@ describe('getColumnNames / getColumnType scoping', () => {
 
     expect(getColumnType(checker, dbType, node, null, 'id')).toBeNull();
   });
+
+  it('unions columns across an explicit array of tables, for JOIN scoping', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB {
+        users: { id: number; name: string };
+        posts: { id: number; title: string };
+        comments: { id: number; body: string };
+      }
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnNames(checker, dbType, node, ['users', 'posts']).sort()).toEqual([
+      'id',
+      'name',
+      'title',
+    ]);
+    expect(getColumnNames(checker, dbType, node, ['users', 'posts'])).not.toContain('body');
+  });
+
+  it('resolves a column type unambiguously across a joined table array', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB { users: { id: number; name: string }; posts: { id: number; title: string } }
+      declare const dbValue: DB;
+    `);
+
+    const columnType = getColumnType(checker, dbType, node, ['users', 'posts'], 'name');
+    expect(columnType && checker.typeToString(columnType)).toBe('string');
+  });
+
+  it('refuses to guess a column type when joined tables in the array disagree on it', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB { users: { id: number }; accounts: { id: string } }
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnType(checker, dbType, node, ['users', 'accounts'], 'id')).toBeNull();
+  });
 });

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -1,16 +1,23 @@
 import { describe, it, expect } from 'vitest';
 import sqlContext from '../src/ts-plugin/sql-context.cts';
 
-const { getSelectListContext, getWhereClauseContext, findFromTable } = sqlContext;
+const {
+  getSelectListContext,
+  getWhereClauseContext,
+  findFromTable,
+  findSources,
+  findSourceByAlias,
+  getQualifierBefore,
+} = sqlContext;
 
 describe('getSelectListContext', () => {
   it('extracts the partial word being typed in a SELECT list', () => {
-    expect(getSelectListContext('select id, na')).toEqual({ prefix: 'na' });
+    expect(getSelectListContext('select id, na')).toEqual({ prefix: 'na', qualifier: null });
   });
 
   it('returns an empty prefix right after SELECT or a comma', () => {
-    expect(getSelectListContext('select ')).toEqual({ prefix: '' });
-    expect(getSelectListContext('select id, ')).toEqual({ prefix: '' });
+    expect(getSelectListContext('select ')).toEqual({ prefix: '', qualifier: null });
+    expect(getSelectListContext('select id, ')).toEqual({ prefix: '', qualifier: null });
   });
 
   it('returns null once a FROM clause has already been typed', () => {
@@ -23,23 +30,31 @@ describe('getSelectListContext', () => {
   });
 
   it('is case-insensitive on the SELECT keyword', () => {
-    expect(getSelectListContext('SELECT id, na')).toEqual({ prefix: 'na' });
+    expect(getSelectListContext('SELECT id, na')).toEqual({ prefix: 'na', qualifier: null });
+  });
+
+  it('captures an alias qualifier in front of the partial word', () => {
+    expect(getSelectListContext('select u.na')).toEqual({ prefix: 'na', qualifier: 'u' });
   });
 });
 
 describe('getWhereClauseContext', () => {
   it('extracts the partial word being typed after WHERE', () => {
-    expect(getWhereClauseContext('select id from users where na')).toEqual({ prefix: 'na' });
+    expect(getWhereClauseContext('select id from users where na')).toEqual({
+      prefix: 'na',
+      qualifier: null,
+    });
   });
 
   it('extracts the partial word being typed after AND/OR', () => {
     expect(getWhereClauseContext('select id from users where active = true and na')).toEqual({
       prefix: 'na',
+      qualifier: null,
     });
   });
 
   it('returns an empty prefix right after WHERE', () => {
-    expect(getWhereClauseContext('select id from users where ')).toEqual({ prefix: '' });
+    expect(getWhereClauseContext('select id from users where ')).toEqual({ prefix: '', qualifier: null });
   });
 
   it('returns null when there is no FROM clause yet', () => {
@@ -51,7 +66,10 @@ describe('getWhereClauseContext', () => {
   });
 
   it('is case-insensitive on the WHERE keyword', () => {
-    expect(getWhereClauseContext('select id from users WHERE na')).toEqual({ prefix: 'na' });
+    expect(getWhereClauseContext('select id from users WHERE na')).toEqual({
+      prefix: 'na',
+      qualifier: null,
+    });
   });
 });
 
@@ -62,7 +80,7 @@ describe('context misfire guards', () => {
   });
 
   it('ignores a quoted from keyword when deciding the select-list context', () => {
-    expect(getSelectListContext("select 'from users', na")).toEqual({ prefix: 'na' });
+    expect(getSelectListContext("select 'from users', na")).toEqual({ prefix: 'na', qualifier: null });
   });
 
   it('returns null while the cursor trails a numeric token', () => {
@@ -70,13 +88,20 @@ describe('context misfire guards', () => {
   });
 
   it('offers columns after ORDER BY and GROUP BY without a WHERE clause', () => {
-    expect(getWhereClauseContext('select id from users order by na')).toEqual({ prefix: 'na' });
-    expect(getWhereClauseContext('select id from users group by ')).toEqual({ prefix: '' });
+    expect(getWhereClauseContext('select id from users order by na')).toEqual({
+      prefix: 'na',
+      qualifier: null,
+    });
+    expect(getWhereClauseContext('select id from users group by ')).toEqual({
+      prefix: '',
+      qualifier: null,
+    });
   });
 
-  it('offers columns in JOIN ... ON conditions', () => {
+  it('offers columns in JOIN ... ON conditions, capturing the alias qualifier', () => {
     expect(getWhereClauseContext('select id from users u join posts p on u.')).toEqual({
       prefix: '',
+      qualifier: 'u',
     });
   });
 });
@@ -104,5 +129,76 @@ describe('findFromTable', () => {
 
   it('finds the table name when an alias follows it', () => {
     expect(findFromTable('select u.id from users u where u.name = 1')).toBe('users');
+  });
+});
+
+describe('findSources', () => {
+  it('returns a single source for a plain FROM with no alias', () => {
+    const sources = findSources('select id from users');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('captures the alias when one follows the table', () => {
+    const sources = findSources('select u.id from users u');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'u' },
+    ]);
+  });
+
+  it('captures the alias when introduced with AS', () => {
+    const sources = findSources('select u.id from users as u');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'u' },
+    ]);
+  });
+
+  it('captures every JOINed source, defaulting alias to the table name', () => {
+    const sources = findSources(
+      'select u.id, p.title from users u join posts p on p.user_id = u.id',
+    );
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'u' },
+      { table: 'posts', alias: 'p' },
+    ]);
+  });
+
+  it('does not mistake a trailing clause keyword for an alias', () => {
+    const sources = findSources('select id from users where id = 1');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('reports the table token span for each source', () => {
+    const text = 'select id from users';
+    const sources = findSources(text);
+    const [users] = sources;
+    expect(users).toBeDefined();
+    if (!users) return;
+    expect(text.slice(users.tableStart, users.tableEnd)).toBe('users');
+  });
+});
+
+describe('findSourceByAlias', () => {
+  it('finds a source by its alias, case-insensitively', () => {
+    const sources = findSources('select u.id from users u');
+    expect(findSourceByAlias(sources, 'U')?.table).toBe('users');
+  });
+
+  it('returns null for an alias that is not present', () => {
+    const sources = findSources('select u.id from users u');
+    expect(findSourceByAlias(sources, 'p')).toBeNull();
+  });
+});
+
+describe('getQualifierBefore', () => {
+  it('returns the identifier immediately before a dot', () => {
+    expect(getQualifierBefore('select u.name from users u', 9)).toBe('u');
+  });
+
+  it('returns null when the preceding character is not a dot', () => {
+    expect(getQualifierBefore('select name from users', 9)).toBeNull();
   });
 });

--- a/tests/ts-plugin-test-helpers.ts
+++ b/tests/ts-plugin-test-helpers.ts
@@ -9,13 +9,19 @@ const REPO_ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
 
 const PLUGIN_DIR = join(REPO_ROOT, 'src', 'ts-plugin');
 
-const PLUGIN_MODULES = ['index.cts', 'sql-context.cts', 'schema.cts', 'detect.cts'];
+const PLUGIN_MODULES = [
+  'index.cts',
+  'sql-context.cts',
+  'schema.cts',
+  'detect.cts',
+  'diagnostics.cts',
+];
 
 export type PluginFactory = (modules: { typescript: typeof ts }) => {
   create(info: unknown): ts.LanguageService;
 };
 
-export function loadPlugin(): { plugin: PluginFactory; dir: string } {
+function transpilePluginModules(): string {
   const dir = mkdtempSync(join(tmpdir(), 'owlsql-ts-plugin-build-'));
 
   for (const moduleName of PLUGIN_MODULES) {
@@ -30,8 +36,21 @@ export function loadPlugin(): { plugin: PluginFactory; dir: string } {
     writeFileSync(join(dir, moduleName.replace('.cts', '.cjs')), output);
   }
 
+  return dir;
+}
+
+export function loadPlugin(): { plugin: PluginFactory; dir: string } {
+  const dir = transpilePluginModules();
   const requireCompiled = createRequire(import.meta.url);
   return { plugin: requireCompiled(join(dir, 'index.cjs')) as PluginFactory, dir };
+}
+
+export type DiagnosticsModule = typeof import('../src/ts-plugin/diagnostics.cts');
+
+export function loadDiagnostics(): { diagnostics: DiagnosticsModule; dir: string } {
+  const dir = transpilePluginModules();
+  const requireCompiled = createRequire(import.meta.url);
+  return { diagnostics: requireCompiled(join(dir, 'diagnostics.cjs')) as DiagnosticsModule, dir };
 }
 
 export function buildLanguageService(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,8 @@
     "tests/ts-plugin-detect.test.ts",
     "tests/ts-plugin-schema.test.ts",
     "tests/ts-plugin-proxy.test.ts",
-    "tests/ts-plugin-hover-crlf.test.ts"
+    "tests/ts-plugin-hover-crlf.test.ts",
+    "tests/ts-plugin-diagnostics.test.ts",
+    "tests/ts-plugin-test-helpers.ts"
   ]
 }

--- a/tsconfig.ts-plugin-tests.json
+++ b/tsconfig.ts-plugin-tests.json
@@ -23,6 +23,7 @@
     "tests/ts-plugin-schema.test.ts",
     "tests/ts-plugin-proxy.test.ts",
     "tests/ts-plugin-hover-crlf.test.ts",
+    "tests/ts-plugin-diagnostics.test.ts",
     "tests/ts-plugin-test-helpers.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- **Nested `CASE`**: `FindEnd`/`ScanCaseSegments` in `src/case.ts` now track `case`/`end` depth instead of stopping at the first `END`, so a `CASE` nested inside another `CASE`'s branch parses and types correctly.
- **Multi-column scalar subqueries**: strict mode now surfaces a `QueryTypeError('scalar subquery must select exactly one column')` instead of silently falling back to `unknown` — selecting more than one column from a scalar subquery is invalid SQL, so strict mode should catch it like every other invalid construct.
- **Params inside a CTE's own body**: a placeholder written inside a `WITH` CTE's own definition is now typed against that CTE's own `FROM` source (and any earlier CTEs it references), in textual order alongside `INSERT ... VALUES` params and outer-query params referencing a CTE by name — instead of forcing the whole query's params to `unknown[]`.
- **ts-plugin v2**: completions/hover are now `JOIN`/alias-aware (typing an alias qualifier like `u.` scopes suggestions/hover to that one source instead of only the first `FROM <table>`), and a new `getSemanticDiagnostics` proxy (`src/ts-plugin/diagnostics.cts`) reports unknown columns, unknown tables, unknown aliases, and ambiguous unqualified columns as live editor diagnostics — the same checks strict mode already applies at compile time, now surfaced as a squiggle while typing.

`ROADMAP.md` and `README.md` updated to move these from "in progress" to "shipped" and document the new behavior/limitations.

## Test plan
- [x] `npm run test:types` (tsconfig.json + tsconfig.ts-plugin.json + tsconfig.ts-plugin-tests.json) — clean
- [x] `npm run test:runtime` (vitest) — 179/179 passing
- [x] New/updated test coverage: `tests/case.test-d.ts` (nested CASE), `tests/scalar-subquery.test-d.ts` (strict-mode multi-column error), `tests/cte.test-d.ts` (CTE-body param typing), `tests/ts-plugin-sql-context.test.ts`/`ts-plugin-schema.test.ts` (JOIN/alias scoping), new `tests/ts-plugin-diagnostics.test.ts` (unknown column/table/alias/ambiguous diagnostics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SQL editor autocomplete and hover information across `FROM` and `JOIN` tables, including aliases and qualified columns.
  * Added live diagnostics for unknown tables, aliases, columns, and ambiguous column references.
  * Added support for nested `CASE` expressions.
  * Improved type inference for parameters inside CTEs.
  * Strict mode now reports multi-column scalar subqueries as errors.

* **Documentation**
  * Updated documentation and roadmap to reflect these capabilities and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->