### PR TITLE
fix(cli): reject malformed connection URL instead of leaking password / defaulting to sqlite (#134)

### DIFF
--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -21,19 +21,26 @@ const ADO_MSSQL_PATTERN = /(^|;)\s*(server|data source|address|addr|network addr
 
 // A connection URL whose "//" was mistyped as a single "/" (e.g.
 // "postgres:/user:pass@host/db") still carries embedded credentials but matches
-// neither SCHEME_PATTERN (needs "://") nor ADO_MSSQL_PATTERN.
-const MISTYPED_URL_CREDENTIALS_PATTERN = /^[a-z][a-z0-9+.-]*:\/{1,2}[^/@\s]*@/i;
+// neither SCHEME_PATTERN (needs "://") nor ADO_MSSQL_PATTERN. The leading
+// negative lookahead excludes Windows drive-letter paths ("C:/app@prod.db"),
+// which are valid SQLite file paths, not mistyped URLs.
+const MISTYPED_URL_CREDENTIALS_PATTERN = /^(?![a-z]:[/\\])[a-z][a-z0-9+.-]*:\/{1,2}[^/@\s]*@/i;
 
 // An ADO / DSN key=value connection string that omits a "server="-style keyword
 // (e.g. "Uid=sa;Pwd=secret;Initial Catalog=db"). Not a SQLite file path either.
 const ADO_CREDENTIALS_PATTERN =
   /(^|;)\s*(uid|user id|pwd|password|database|initial catalog|trusted_connection|integrated security|driver|dsn)\s*=/i;
 
-// URL userinfo ("//user:pass@" or a mistyped single-slash ":/user:pass@").
-const URL_CREDENTIALS_PATTERN = /(\/\/|:\/)[^@/]+@/;
+// URL userinfo ("//user:pass@" or a mistyped single-slash ":/user:pass@"). The
+// single-slash form requires a multi-character scheme before the ":/" so that
+// Windows drive-letter paths ("C:/app@prod.db") are not treated as URL userinfo.
+const URL_CREDENTIALS_PATTERN = /(\/\/|(?<=[a-z][a-z0-9+.-]):\/)[^@/]+@/i;
 
-// The password value of an ADO / DSN "Pwd="/"Password=" pair.
-const DSN_PASSWORD_PATTERN = /((?:^|;)\s*(?:pwd|password)\s*=)[^;]*/gi;
+// The password value of an ADO / DSN "Pwd="/"Password=" pair. The value may be
+// wrapped in double quotes, braces, or single quotes (so an embedded ";" does
+// not terminate it); an unquoted value runs to the next ";" delimiter.
+const DSN_PASSWORD_PATTERN =
+  /((?:^|;)\s*(?:pwd|password)\s*=)("[^"]*"|\{[^}]*\}|'[^']*'|[^;]*)/gi;
 
 export function redactCredentials(url: string): string {
   return url

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -19,10 +19,32 @@ const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
 
 const ADO_MSSQL_PATTERN = /(^|;)\s*(server|data source|address|addr|network address)\s*=/i;
 
-const CREDENTIALS_PATTERN = /\/\/[^@/]+@/;
+// A connection URL whose "//" was mistyped as a single "/" (e.g.
+// "postgres:/user:pass@host/db") still carries embedded credentials but matches
+// neither SCHEME_PATTERN (needs "://") nor ADO_MSSQL_PATTERN.
+const MISTYPED_URL_CREDENTIALS_PATTERN = /^[a-z][a-z0-9+.-]*:\/{1,2}[^/@\s]*@/i;
+
+// An ADO / DSN key=value connection string that omits a "server="-style keyword
+// (e.g. "Uid=sa;Pwd=secret;Initial Catalog=db"). Not a SQLite file path either.
+const ADO_CREDENTIALS_PATTERN =
+  /(^|;)\s*(uid|user id|pwd|password|database|initial catalog|trusted_connection|integrated security|driver|dsn)\s*=/i;
+
+// URL userinfo ("//user:pass@" or a mistyped single-slash ":/user:pass@").
+const URL_CREDENTIALS_PATTERN = /(\/\/|:\/)[^@/]+@/;
+
+// The password value of an ADO / DSN "Pwd="/"Password=" pair.
+const DSN_PASSWORD_PATTERN = /((?:^|;)\s*(?:pwd|password)\s*=)[^;]*/gi;
 
 export function redactCredentials(url: string): string {
-  return url.replace(CREDENTIALS_PATTERN, '//***@');
+  return url
+    .replace(URL_CREDENTIALS_PATTERN, (_match, separator: string) => `${separator}***@`)
+    .replace(DSN_PASSWORD_PATTERN, '$1***');
+}
+
+function unrecognizedUrlError(url: string): Error {
+  return new Error(
+    `Unrecognized connection URL "${redactCredentials(url)}". Expected postgres://, postgresql://, mysql://, mssql://, sqlserver://, or a path to a SQLite database file.`,
+  );
 }
 
 export function detectDialect(url: string): Dialect {
@@ -47,9 +69,14 @@ export function detectDialect(url: string): Dialect {
   }
 
   if (SCHEME_PATTERN.test(url)) {
-    throw new Error(
-      `Unrecognized connection URL "${redactCredentials(url)}". Expected postgres://, postgresql://, mysql://, mssql://, sqlserver://, or a path to a SQLite database file.`,
-    );
+    throw unrecognizedUrlError(url);
+  }
+
+  // A mistyped connection URL (single-slash scheme, or an ADO/DSN string missing
+  // a "server=" keyword) must not fall through to sqlite: introspectSqlite would
+  // then echo the raw string — password included — verbatim to stderr (#134).
+  if (MISTYPED_URL_CREDENTIALS_PATTERN.test(url) || ADO_CREDENTIALS_PATTERN.test(url)) {
+    throw unrecognizedUrlError(url);
   }
 
   return 'sqlite';

--- a/tests/cli-generate.test.ts
+++ b/tests/cli-generate.test.ts
@@ -25,6 +25,32 @@ describe('detectDialect', () => {
     );
     expect(() => detectDialect('mongodb://user:pass@host/db')).toThrow('Unrecognized connection URL');
   });
+
+  it('rejects a mistyped single-slash URL without leaking the password or defaulting to sqlite (#134)', () => {
+    let message = '';
+    try {
+      detectDialect('postgres:/user:S3cretPass@host/db');
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('Unrecognized connection URL');
+    expect(message).toContain('postgres:/***@host/db');
+    expect(message).not.toContain('S3cretPass');
+    expect(message).not.toContain('user:');
+  });
+
+  it('rejects an ADO/DSN string missing a server keyword without leaking the password (#134)', () => {
+    let message = '';
+    try {
+      detectDialect('Uid=sa;Pwd=S3cretPass;Initial Catalog=mydb;');
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('Unrecognized connection URL');
+    expect(message).not.toContain('S3cretPass');
+  });
 });
 
 describe.skipIf(!sqliteAvailable)('runGenerate (end to end against a real sqlite file)', () => {

--- a/tests/cli-generate.test.ts
+++ b/tests/cli-generate.test.ts
@@ -50,6 +50,41 @@ describe('detectDialect', () => {
 
     expect(message).toContain('Unrecognized connection URL');
     expect(message).not.toContain('S3cretPass');
+    expect(message).toContain('Uid=sa;Pwd=***;Initial Catalog=mydb;');
+  });
+
+  it('treats Windows drive-letter paths containing "@" as sqlite, not a mistyped URL', () => {
+    expect(detectDialect('C:/app@prod.db')).toBe('sqlite');
+    expect(detectDialect('D:\\data@backup.db')).toBe('sqlite');
+    expect(detectDialect('c:/Users/me@work/app.db')).toBe('sqlite');
+  });
+
+  it('redacts a quoted DSN password containing a semicolon without leaking it', () => {
+    let message = '';
+    try {
+      detectDialect('Uid=sa;Pwd="S3;cretPass";Initial Catalog=mydb;');
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('Unrecognized connection URL');
+    expect(message).toContain('Uid=sa;Pwd=***;Initial Catalog=mydb;');
+    expect(message).not.toContain('S3;cretPass');
+    expect(message).not.toContain('cretPass');
+  });
+
+  it('redacts a brace-wrapped DSN password containing a semicolon without leaking it', () => {
+    let message = '';
+    try {
+      detectDialect('Uid=sa;Pwd={S3;cretPass};Initial Catalog=mydb;');
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('Unrecognized connection URL');
+    expect(message).toContain('Uid=sa;Pwd=***;Initial Catalog=mydb;');
+    expect(message).not.toContain('S3;cretPass');
+    expect(message).not.toContain('cretPass');
   });
 });
 

--- a/tests/cli-redact.test.ts
+++ b/tests/cli-redact.test.ts
@@ -10,6 +10,19 @@ describe('redactCredentials', () => {
     expect(redactCredentials('mysql://root@host/db')).toBe('mysql://***@host/db');
   });
 
+  it('replaces credentials in a mistyped single-slash URL', () => {
+    expect(redactCredentials('postgres:/user:S3cret@host/db')).toBe('postgres:/***@host/db');
+  });
+
+  it('replaces the password in an ADO/DSN connection string', () => {
+    expect(redactCredentials('Uid=sa;Pwd=S3cret;Initial Catalog=db')).toBe(
+      'Uid=sa;Pwd=***;Initial Catalog=db',
+    );
+    expect(redactCredentials('Server=host;Password=S3cret;Database=db')).toBe(
+      'Server=host;Password=***;Database=db',
+    );
+  });
+
   it('leaves credential-free URLs untouched', () => {
     expect(redactCredentials('postgres://host/db')).toBe('postgres://host/db');
     expect(redactCredentials('./local.sqlite')).toBe('./local.sqlite');


### PR DESCRIPTION
Fixes #134.

A typo'd connection URL — a single-slash scheme carrying credentials (`postgres:/user:pass@host/db`) or an ADO/DSN string with no `server=` keyword (`Uid=sa;Pwd=secret;…`) — silently fell through `detectDialect`'s unguarded `return "sqlite"`, and the sqlite introspector then echoed the raw string (password included) to stderr.

`detectDialect` now rejects those shapes with the same redacted `Unrecognized connection URL` error used for other bad schemes (via a shared `unrecognizedUrlError` helper). `redactCredentials` was extended to also scrub single-slash `:/user:pass@` userinfo and ADO `Pwd=`/`Password=` values — the old `//…@`-only pattern missed both, so the password would have leaked even through the thrown error. Mirrors the repo's prior same-class fixes (#21 no-sqlite-fallback, #69 redaction).

Scope kept tight to credential-bearing malformed shapes (the two documented repros): a credential-free single-slash typo is left alone so legitimate SQLite file paths aren't false-positived. Added 4 tests (throws + redaction for both shapes). typecheck + build pass; the new tests pass.

---
Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed and unsupported connection URLs.
  * Prevented passwords and other credentials from appearing in error messages across additional URL and connection-string formats.
  * Ensured suspicious connection strings are rejected instead of incorrectly falling back to SQLite.

* **Tests**
  * Added coverage for credential redaction and invalid URL handling, including mistyped Postgres URLs and ADO/DSN-style strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->