### PR TITLE
fix(ts-plugin): resolve native diagnostics lazily inside the guard in getSemanticDiagnostics

### DIFF
--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -206,13 +206,13 @@ function init(modules: { typescript: typeof ts }) {
     proxy.getQuickInfoAtPosition = getQuickInfoAtPosition;
 
     const getSemanticDiagnostics: ts.LanguageService['getSemanticDiagnostics'] = (fileName) => {
-      const native = info.languageService.getSemanticDiagnostics(fileName);
+      const native = () => info.languageService.getSemanticDiagnostics(fileName);
 
       try {
         const program = info.languageService.getProgram();
         const sourceFile = program?.getSourceFile(fileName);
         if (!program || !sourceFile) {
-          return native;
+          return native();
         }
 
         const checker = program.getTypeChecker();
@@ -233,9 +233,10 @@ function init(modules: { typescript: typeof ts }) {
           }
         }
 
-        return extra.length === 0 ? native : [...native, ...extra];
+        const nativeDiagnostics = native();
+        return extra.length === 0 ? nativeDiagnostics : [...nativeDiagnostics, ...extra];
       } catch {
-        return native;
+        return native();
       }
     };
 

--- a/tests/ts-plugin-proxy.test.ts
+++ b/tests/ts-plugin-proxy.test.ts
@@ -1,12 +1,31 @@
 import { afterAll, describe, expect, it, vi } from 'vitest';
 import { rmSync } from 'node:fs';
 import ts from 'typescript';
-import { loadPlugin } from './ts-plugin-test-helpers.js';
+import { buildProgram, loadPlugin } from './ts-plugin-test-helpers.js';
 
 const { plugin, dir: transpileDir } = loadPlugin();
 
+const DIAGNOSTICS_FIXTURE = `
+import type { TypedDb } from '@owlsql/core';
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+declare const db: TypedDb<DB>;
+
+db.query(\`select id from users\`);
+`;
+
+// Built once at module scope so the cost of ts.createProgram + the initial
+// getTypeChecker() (which loads lib.d.ts) is paid outside any individual
+// test's timeout budget, mirroring how loadPlugin() runs here.
+const diagnosticsBuild = buildProgram(DIAGNOSTICS_FIXTURE, 'owlsql-ts-plugin-proxy-');
+diagnosticsBuild.program.getTypeChecker();
+
 afterAll(() => {
   rmSync(transpileDir, { recursive: true, force: true });
+  rmSync(diagnosticsBuild.dir, { recursive: true, force: true });
 });
 
 const NATIVE_COMPLETIONS = {
@@ -90,10 +109,24 @@ describe('ts-plugin proxy error handling', () => {
   });
 
   it('computes native diagnostics lazily, only after the plugin path has run', () => {
+    // Drive the NORMAL plugin path (valid program + source file) so the plugin
+    // reaches query-literal scanning before resolving native diagnostics —
+    // rather than short-circuiting through the no-program early return.
+    const realProgram = diagnosticsBuild.program;
     const calls: string[] = [];
+    const program = {
+      getSourceFile: (name: string) => realProgram.getSourceFile(name),
+      // getTypeChecker is the entry point into the plugin's query-literal
+      // scanning; recording it proves native diagnostics resolve AFTER the
+      // plugin has begun inspecting the program, not before.
+      getTypeChecker: () => {
+        calls.push('getTypeChecker');
+        return realProgram.getTypeChecker();
+      },
+    } as unknown as ts.Program;
     const getProgram = vi.fn(() => {
       calls.push('getProgram');
-      return undefined;
+      return program;
     });
     const getSemanticDiagnostics = vi.fn(() => {
       calls.push('getSemanticDiagnostics');
@@ -101,12 +134,13 @@ describe('ts-plugin proxy error handling', () => {
     });
     const proxy = createProxy({ getProgram, getSemanticDiagnostics });
 
-    const result = proxy.getSemanticDiagnostics('file.ts');
+    const result = proxy.getSemanticDiagnostics(diagnosticsBuild.filePath);
 
     expect(result).toBe(NATIVE_DIAGNOSTICS);
-    // The native diagnostics must be resolved inside the try block (after the
-    // plugin inspects the program), never eagerly before it — an eager call
-    // outside the try/catch lets an underlying throw escape the proxy.
-    expect(calls).toEqual(['getProgram', 'getSemanticDiagnostics']);
+    // The native diagnostics must be resolved inside the try block AFTER the
+    // plugin has scanned the program (getTypeChecker → query-literal scan),
+    // never eagerly before it — an eager call lets an underlying throw escape
+    // the proxy, and evaluating it before the scan wastes work on every call.
+    expect(calls).toEqual(['getProgram', 'getTypeChecker', 'getSemanticDiagnostics']);
   });
 });

--- a/tests/ts-plugin-proxy.test.ts
+++ b/tests/ts-plugin-proxy.test.ts
@@ -22,10 +22,13 @@ const NATIVE_QUICK_INFO = {
   textSpan: { start: 0, length: 0 },
 };
 
+const NATIVE_DIAGNOSTICS: ts.Diagnostic[] = [];
+
 function createProxy(languageServiceOverrides: Record<string, unknown>): ts.LanguageService {
   const languageService = {
     getCompletionsAtPosition: vi.fn().mockReturnValue(NATIVE_COMPLETIONS),
     getQuickInfoAtPosition: vi.fn().mockReturnValue(NATIVE_QUICK_INFO),
+    getSemanticDiagnostics: vi.fn().mockReturnValue(NATIVE_DIAGNOSTICS),
     getProgram: vi.fn().mockReturnValue(undefined),
     ...languageServiceOverrides,
   };
@@ -71,5 +74,39 @@ describe('ts-plugin proxy error handling', () => {
 
     expect(proxy.getCompletionsAtPosition('file.ts', 10, undefined)).toBe(NATIVE_COMPLETIONS);
     expect(proxy.getQuickInfoAtPosition('file.ts', 10)).toBe(NATIVE_QUICK_INFO);
+  });
+
+  it('falls back to native diagnostics when the plugin path throws', () => {
+    const getProgram = vi.fn(() => {
+      throw new Error('checker exploded');
+    });
+    const getSemanticDiagnostics = vi.fn().mockReturnValue(NATIVE_DIAGNOSTICS);
+    const proxy = createProxy({ getProgram, getSemanticDiagnostics });
+
+    const result = proxy.getSemanticDiagnostics('file.ts');
+
+    expect(result).toBe(NATIVE_DIAGNOSTICS);
+    expect(getProgram).toHaveBeenCalled();
+  });
+
+  it('computes native diagnostics lazily, only after the plugin path has run', () => {
+    const calls: string[] = [];
+    const getProgram = vi.fn(() => {
+      calls.push('getProgram');
+      return undefined;
+    });
+    const getSemanticDiagnostics = vi.fn(() => {
+      calls.push('getSemanticDiagnostics');
+      return NATIVE_DIAGNOSTICS;
+    });
+    const proxy = createProxy({ getProgram, getSemanticDiagnostics });
+
+    const result = proxy.getSemanticDiagnostics('file.ts');
+
+    expect(result).toBe(NATIVE_DIAGNOSTICS);
+    // The native diagnostics must be resolved inside the try block (after the
+    // plugin inspects the program), never eagerly before it — an eager call
+    // outside the try/catch lets an underlying throw escape the proxy.
+    expect(calls).toEqual(['getProgram', 'getSemanticDiagnostics']);
   });
 });


### PR DESCRIPTION
Fixes #136

`getSemanticDiagnostics` was the one override of the four that resolved the native language-service call eagerly, outside its try/catch — the other three (completions/hover/etc.) already use the lazy-closure pattern. This makes the fourth override consistent: `native` is now a closure resolved inside the guard, so the plugin path inspects the program before the native call happens.

One honest note on semantics: for this override the merge path always needs the native diagnostics, and the catch re-invokes `native()`, so a throw from the underlying service still propagates — the observable difference the fix buys is **eagerness/call order** (native no longer runs before the plugin's no-program guard). The regression test asserts exactly that: with the eager version the observed call order is `['getSemanticDiagnostics', 'getProgram']` and the test fails; with the fix it's `['getProgram', 'getSemanticDiagnostics']` (verified both ways before committing). A second test locks the native-fallback path, mirroring the sibling tests.

Gates: `npm run test:types` clean; `tests/ts-plugin-proxy.test.ts` 6/6; full vitest 187 passed (one 16.7s schema test trips the default 5s timeout on my box in a full run — passes 8/8 in isolation with a higher timeout; untouched by this change).

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved semantic diagnostic handling so native TypeScript diagnostics remain available when plugin processing encounters an error.
  - Ensured diagnostic lookups occur at the appropriate time, improving reliability of error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->