### PR TITLE
fix(where): treat NOT as a transparent token so NOT LIKE/IN/BETWEEN/ILIKE validate their column

### DIFF
--- a/src/where.ts
+++ b/src/where.ts
@@ -39,6 +39,12 @@ type IsTriggerOperator<Token extends string> = IsSymbolTriggerOperator<Token> ex
   ? true
   : IsWordTriggerOperator<Token>;
 
+// Mirrors `IsTransparentToken` in params.ts (which lists `not`): `not` must not
+// overwrite `Prev`, otherwise it clobbers the real column just before a word
+// operator (`like`/`in`/`between`/`ilike`) fires, so the validator checks the
+// literal word `not` instead of the column (`NOT LIKE` / `NOT IN` / `NOT BETWEEN`).
+type IsTransparentToken<Token extends string> = Lowercase<Token> extends 'not' ? true : false;
+
 type DropOneOpenParen<S extends string> = S extends `(${infer Rest}` ? Rest : S;
 
 type HeadStartsSubquery<Head extends string, Tail extends string> = Head extends `(${string}`
@@ -80,7 +86,9 @@ type WhereScan<
           ? WhereScan<DB, Sources, Tail, CleanScanToken<Head>>
           : Error
         : never
-      : WhereScan<DB, Sources, Tail, CleanScanToken<Head>>
+      : IsTransparentToken<Head> extends true
+        ? WhereScan<DB, Sources, Tail, Prev>
+        : WhereScan<DB, Sources, Tail, CleanScanToken<Head>>
   : never;
 
 export type WhereClauseError<

--- a/tests/where-strict.test-d.ts
+++ b/tests/where-strict.test-d.ts
@@ -65,6 +65,29 @@ type UnknownColumnOnIsDistinctFrom = Expect<
   >
 >;
 
+type NotLikeResolvesColumn = Expect<
+  Equal<StrictQuery<DB, "select id from users where name not like 'x%'">, { id: number }[]>
+>;
+
+type NotInResolvesColumn = Expect<
+  Equal<StrictQuery<DB, 'select id from users where id not in (1, 2)'>, { id: number }[]>
+>;
+
+type NotBetweenResolvesColumn = Expect<
+  Equal<StrictQuery<DB, 'select id from users where age not between 1 and 2'>, { id: number }[]>
+>;
+
+type NotIlikeResolvesColumn = Expect<
+  Equal<StrictQuery<DB, "select id from users where name not ilike 'x%'">, { id: number }[]>
+>;
+
+type UnknownColumnOnNotLikeStillValidated = Expect<
+  Equal<
+    StrictQuery<DB, "select id from users where naem not like 'x%'">,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
 type UnknownAliasInWhere = Expect<
   Equal<
     StrictQuery<
@@ -136,6 +159,11 @@ export type WhereStrictLock = [
   UnknownColumnOnIsNull,
   UnknownColumnOnIsNotNull,
   UnknownColumnOnIsDistinctFrom,
+  NotLikeResolvesColumn,
+  NotInResolvesColumn,
+  NotBetweenResolvesColumn,
+  NotIlikeResolvesColumn,
+  UnknownColumnOnNotLikeStillValidated,
   UnknownAliasInWhere,
   AmbiguousUnqualifiedColumnInWhere,
   QualifiedColumnInWhereIsNotAmbiguous,


### PR DESCRIPTION
Fixes #129

`WhereScan`'s general operand branch overwrote `Prev` with `not`, so by the time the word operator (`like`/`in`/`between`/`ilike`) fired, the real column was gone and got flagged as unknown. This adds `IsTransparentToken<Token>` in `src/where.ts` (`Lowercase<Token> extends 'not'`), mirroring the transparent-token treatment `params.ts` already implements — `not` is skipped without clobbering `Prev`. `IS NOT NULL` is unaffected (`is` triggers first).

Type-level regression tests: the issue's three repros (NOT LIKE / NOT IN / NOT BETWEEN) plus NOT ILIKE, and a negative lock proving a genuinely bad column in a NOT form still errors (`unknown column: naem`). All five fail on current master (`Type 'false' does not satisfy 'true'`, tsc exit 2) and pass with the fix; the retained non-NOT locks stay green.

Gates: `tsc --noEmit -p tsconfig.json` exit 0; runtime vitest (excluding the ts-plugin suites) 108 tests green.

Heads-up: this touches the same `WhereScan` recursion as #130's fix (PR incoming) — merging either first leaves the other a trivial adjacent-edit conflict; happy to rebase whichever lands second.

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)