### PR TITLE
fix(where): use CleanColumnToken for operands so function-call operands validate

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -41,7 +41,7 @@ type StripTrailingListPunctuation<S extends string> = S extends `${infer Rest})`
 
 export type CleanScanToken<S extends string> = StripTrailingListPunctuation<StripLeadingParens<S>>;
 
-type CleanColumnToken<S extends string> = StripLeadingParens<S> extends infer Stripped extends string
+export type CleanColumnToken<S extends string> = StripLeadingParens<S> extends infer Stripped extends string
   ? Stripped extends `${string}(${string}`
     ? Stripped
     : StripTrailingListPunctuation<Stripped>

--- a/src/where.ts
+++ b/src/where.ts
@@ -1,7 +1,7 @@
 import type { Trim, FirstWord, DropFirstWord, IsKeyword, ExtractParenGroup } from './string.js';
 import type { TakeUntilClauseBoundary } from './from.js';
 import type { AfterKeyword, SchemaLike, Source, ResolveColumnType, QueryTypeError } from './parse.js';
-import type { IsPlaceholder, CleanScanToken } from './params.js';
+import type { IsPlaceholder, CleanColumnToken } from './params.js';
 
 export type ExtractSelectWhereText<AfterFromRest extends string> = Trim<AfterFromRest> extends ''
   ? ''
@@ -83,12 +83,12 @@ type WhereScan<
     : IsTriggerOperator<Head> extends true
       ? ValidateWhereOperand<DB, Sources, Prev> extends infer Error
         ? [Error] extends [never]
-          ? WhereScan<DB, Sources, Tail, CleanScanToken<Head>>
+          ? WhereScan<DB, Sources, Tail, CleanColumnToken<Head>>
           : Error
         : never
       : IsTransparentToken<Head> extends true
         ? WhereScan<DB, Sources, Tail, Prev>
-        : WhereScan<DB, Sources, Tail, CleanScanToken<Head>>
+        : WhereScan<DB, Sources, Tail, CleanColumnToken<Head>>
   : never;
 
 export type WhereClauseError<

--- a/tests/where-strict.test-d.ts
+++ b/tests/where-strict.test-d.ts
@@ -88,6 +88,14 @@ type UnknownColumnOnNotLikeStillValidated = Expect<
   >
 >;
 
+type FunctionCallOperandResolves = Expect<
+  Equal<StrictQuery<DB, "select id from users where upper(name) = 'X'">, { id: number }[]>
+>;
+
+type LengthFunctionCallOperandResolves = Expect<
+  Equal<StrictQuery<DB, 'select id from users where length(name) > 3'>, { id: number }[]>
+>;
+
 type UnknownAliasInWhere = Expect<
   Equal<
     StrictQuery<
@@ -164,6 +172,8 @@ export type WhereStrictLock = [
   NotBetweenResolvesColumn,
   NotIlikeResolvesColumn,
   UnknownColumnOnNotLikeStillValidated,
+  FunctionCallOperandResolves,
+  LengthFunctionCallOperandResolves,
   UnknownAliasInWhere,
   AmbiguousUnqualifiedColumnInWhere,
   QualifiedColumnInWhereIsNotAmbiguous,


### PR DESCRIPTION
Fixes #130

`src/where.ts:80,83` cleaned operands with `CleanScanToken`, which strips a trailing `)` unconditionally — `upper(name)` became `upper(name` and got flagged as an unknown column. The fix swaps both sites to `CleanColumnToken` (which leaves tokens containing `(` intact), exactly as the issue suggests; `CleanColumnToken` existed in `params.ts` but wasn't exported, so the export is added (the issue foresaw this).

Type-level regression tests: the issue's `upper(name) = 'X'` repro plus `length(name) > 3`. Both fail on current master (tsc exit 2) and pass with the fix. One honesty note: a multi-arg `coalesce(...)` case was drafted and deliberately dropped — it passes even on unfixed master (only the last token is validated as the column), so it wouldn't lock this bug.

Gates: `tsc --noEmit -p tsconfig.json` exit 0; runtime vitest (excluding ts-plugin suites) 108 tests green.

Heads-up: shares the `WhereScan` recursion with #129's fix (#144) — whichever merges second has a trivial adjacent-edit conflict; happy to rebase it.

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)