### PR TITLE
fix(ts-plugin): mask SQL comments before FROM/JOIN detection

### DIFF
--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -50,17 +50,68 @@ interface StrippedText {
   insideLiteral: boolean;
 }
 
+// Mask string-literal bodies AND SQL comments (`-- line`, `/* block */`) with
+// spaces so that FROM/JOIN/column detection never matches text that isn't part
+// of the executable query, while preserving every character offset (each input
+// character maps to exactly one output character). Mirrors the type-level
+// parser's `StripCommentsAndMaskLiterals` in `src/string.ts`: string literals
+// take precedence, so a `--` or `/*` inside `'...'` is not treated as a comment.
 function stripStringLiterals(text: string): StrippedText {
   let stripped = '';
   let insideLiteral = false;
+  let i = 0;
 
-  for (const char of text) {
-    if (char === "'") {
-      insideLiteral = !insideLiteral;
-      stripped += char;
+  while (i < text.length) {
+    const char = text[i];
+
+    if (insideLiteral) {
+      if (char === "'") {
+        insideLiteral = false;
+        stripped += char;
+      } else {
+        stripped += ' ';
+      }
+      i += 1;
       continue;
     }
-    stripped += !insideLiteral ? char : ' ';
+
+    if (char === "'") {
+      insideLiteral = true;
+      stripped += char;
+      i += 1;
+      continue;
+    }
+
+    if (char === '-' && text[i + 1] === '-') {
+      // Line comment: mask the `--` and everything up to (not including) the
+      // newline, which is preserved by the outer loop.
+      stripped += '  ';
+      i += 2;
+      while (i < text.length && text[i] !== '\n') {
+        stripped += ' ';
+        i += 1;
+      }
+      continue;
+    }
+
+    if (char === '/' && text[i + 1] === '*') {
+      // Block comment: mask the `/*`, the body (newlines kept), and the closing
+      // `*/` if present; an unterminated block runs to the end of the text.
+      stripped += '  ';
+      i += 2;
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) {
+        stripped += text[i] === '\n' ? '\n' : ' ';
+        i += 1;
+      }
+      if (i < text.length) {
+        stripped += '  ';
+        i += 2;
+      }
+      continue;
+    }
+
+    stripped += char;
+    i += 1;
   }
 
   return { stripped, insideLiteral };

--- a/tests/ts-plugin-diagnostics.test.ts
+++ b/tests/ts-plugin-diagnostics.test.ts
@@ -91,4 +91,16 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
   it('does not run without a FROM clause', () => {
     expect(diagnosticsFor('select nope')).toEqual([]);
   });
+
+  it('ignores a table named inside a line comment (issue #138 repro)', () => {
+    expect(diagnosticsFor('select id -- from ghosts\nfrom users')).toEqual([]);
+  });
+
+  it('ignores a table named inside a block comment', () => {
+    expect(diagnosticsFor('select id /* from ghosts */ from users')).toEqual([]);
+  });
+
+  it('does not treat a -- inside a string literal as a comment', () => {
+    expect(diagnosticsFor("select name from users where name = 'a -- not a comment'")).toEqual([]);
+  });
 });

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -179,6 +179,36 @@ describe('findSources', () => {
     if (!users) return;
     expect(text.slice(users.tableStart, users.tableEnd)).toBe('users');
   });
+
+  it('ignores a source mentioned in a line comment', () => {
+    const sources = findSources('select id -- from ghosts\nfrom users');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('ignores a source mentioned in a block comment', () => {
+    const sources = findSources('select id /* from ghosts */ from users');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('does not treat a -- inside a string literal as a comment', () => {
+    const sources = findSources("select id from users where note = 'a -- from ghosts'");
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('reports the correct table span despite a preceding comment', () => {
+    const text = 'select id /* x */ from users';
+    const sources = findSources(text);
+    const [users] = sources;
+    expect(users).toBeDefined();
+    if (!users) return;
+    expect(text.slice(users.tableStart, users.tableEnd)).toBe('users');
+  });
 });
 
 describe('findSourceByAlias', () => {


### PR DESCRIPTION
Fixes #138

The runtime plugin didn't strip SQL comments before source detection, so a `-- comment` mentioning a table name produced a phantom FROM/JOIN source and a false diagnostic (the issue's repro). The fix extends `stripStringLiterals` in `src/ts-plugin/sql-context.cts` — the single masking function feeding all detection (`findSources`, `findFromTable`, select/where context, diagnostics) — to also mask `-- line` and `/* block */` comments, mirroring the type-level `StripCommentsAndMaskLiterals` in `src/string.ts`.

Two load-bearing details: comments are **masked with equal-length spaces**, not removed, so `tableStart`/`tableEnd`/`fromIndex` span math stays exact (there's a test asserting a correct table span despite a preceding comment); and string-literal precedence is respected — `'a -- not a comment'` is not treated as a comment (tested). The scanner moved from code-point `for...of` to index-based UTF-16 iteration for the two-char delimiter lookahead, which also matches TS's position semantics. `insideLiteral`'s contract is unchanged (string literals only) to keep completion behavior out of scope.

Both-ways: the four comment repro tests fail on master (phantom `ghosts`/`from` sources), pass with the fix — 49/49 in the two touched suites. Full `npx vitest run --testTimeout=60000`: 193 tests green, 26 files; `npm run test:types` clean. (The longer timeout is only because my box runs the real-`ts.Program` suites under heavy load — every default-timeout failure is a 5s timeout, never an assertion.)

No overlap with #143/#144/#145 — disjoint files.

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)