### PR TITLE
fix(where): validate the trailing operand of a WHERE clause in strict mode

### DIFF
--- a/src/where.ts
+++ b/src/where.ts
@@ -89,7 +89,15 @@ type WhereScan<
       : IsTransparentToken<Head> extends true
         ? WhereScan<DB, Sources, Tail, Prev>
         : WhereScan<DB, Sources, Tail, CleanColumnToken<Head>>
-  : never;
+  : // Terminal case: no trailing space left, so `S` is the final token of the
+    // clause. Earlier operands are validated by the operator *after* them, but
+    // the trailing operand has no following operator to trigger the check — so
+    // validate it here, mirroring the operator branch's `CleanColumnToken`
+    // handling (issue #128). `not` is transparent, and empty/placeholder
+    // operands are already short-circuited inside `ValidateWhereOperand`.
+    IsTransparentToken<S> extends true
+    ? never
+    : ValidateWhereOperand<DB, Sources, CleanColumnToken<S>>;
 
 export type WhereClauseError<
   DB extends SchemaLike,

--- a/tests/where-strict.test-d.ts
+++ b/tests/where-strict.test-d.ts
@@ -158,6 +158,27 @@ type NonStrictModeIsUnaffectedByWhereTypos = Expect<
   Equal<Query<DB, "select id from users where naem = 'x'">, { id: number }[]>
 >;
 
+// Regression for #128: the trailing operand of a WHERE clause (the last word,
+// with no operator after it to trigger validation) must be validated too.
+// Symmetric to UnknownColumnOnComparisonLhs, but with the typo on the RHS.
+type UnknownColumnOnComparisonRhs = Expect<
+  Equal<
+    StrictQuery<DB, 'select id from users where age = naem'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+// Lock: a VALID trailing operand (a real column as the final token) still
+// passes — the terminal-case validation must not reject good queries.
+type ValidTrailingColumnOperandResolves = Expect<
+  Equal<StrictQuery<DB, 'select id from users where age = id'>, { id: number }[]>
+>;
+
+// Lock: a trailing literal is not a column and must not be flagged.
+type ValidTrailingLiteralOperandResolves = Expect<
+  Equal<StrictQuery<DB, 'select id from users where age = 5'>, { id: number }[]>
+>;
+
 export type WhereStrictLock = [
   ValidWhereStillResolves,
   UnknownColumnOnComparisonLhs,
@@ -182,4 +203,7 @@ export type WhereStrictLock = [
   WhereErrorInsideCte,
   ColumnErrorInSelectListTakesPrecedenceOverWhereError,
   NonStrictModeIsUnaffectedByWhereTypos,
+  UnknownColumnOnComparisonRhs,
+  ValidTrailingColumnOperandResolves,
+  ValidTrailingLiteralOperandResolves,
 ];


### PR DESCRIPTION
Fixes #128

`WhereScan` recurses on `${infer Head} ${infer Tail}`, which only fires while a trailing space remains — so the final token of a clause fell through to the unconditional `never` base case and was never fed to `ValidateWhereOperand` (the false negative from the issue: `where age = naem` passed strict mode). The base case is now a terminal branch: when no space remains, the remaining string IS the last operand — validated via `CleanColumnToken<S>`, mirroring how the operator branch validates `Prev`, with `not` kept transparent via `IsTransparentToken<S>`. (The issue's line refs predate today's #144/#145 merges; reconciled against current master, and both of those behaviors keep their locks green.)

Tests: `UnknownColumnOnComparisonRhs` (the repro — fails on current master with `Type 'false' does not satisfy 'true'`, passes with the fix) plus two over-rejection guards: a valid trailing column and a trailing literal both still resolve. All 23 pre-existing `WhereStrictLock` entries green.

Gates: `npx tsc --noEmit -p tsconfig.json` exit 0 (exit 2 before the fix, single new assert failing); runtime vitest (non-ts-plugin) 108 tests green.

One adjacent gap surfaced while working on this, deliberately NOT touched here — filing it as a separate issue: an RHS operand followed by `and`/`or` is also unvalidated mid-clause (`and`/`or` aren't transparent, so the operand before them never reaches validation).

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)