### PR TITLE
fix(where): validate the final WHERE operand when the clause ends without a trigger

### DIFF
--- a/src/where.ts
+++ b/src/where.ts
@@ -70,6 +70,9 @@ type ValidateWhereOperand<
   ? QueryTypeError<Message>
   : never;
 
+// The `${Head} ${Tail}` pattern below only recurses while a trailing space
+// remains, so the clause's last token never reaches a trigger operator that
+// would validate it. The base case below validates it directly.
 type WhereScan<
   DB extends SchemaLike,
   Sources extends Source[],
@@ -89,7 +92,9 @@ type WhereScan<
       : IsTransparentToken<Head> extends true
         ? WhereScan<DB, Sources, Tail, Prev>
         : WhereScan<DB, Sources, Tail, CleanColumnToken<Head>>
-  : never;
+  : IsTransparentToken<S> extends true
+    ? never
+    : ValidateWhereOperand<DB, Sources, CleanColumnToken<S>>;
 
 export type WhereClauseError<
   DB extends SchemaLike,

--- a/tests/where-strict.test-d.ts
+++ b/tests/where-strict.test-d.ts
@@ -88,6 +88,21 @@ type UnknownColumnOnNotLikeStillValidated = Expect<
   >
 >;
 
+type UnknownColumnOnTrailingComparisonRhs = Expect<
+  Equal<
+    StrictQuery<DB, 'select id from users where age = naem'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+type ValidTrailingComparisonRhsResolves = Expect<
+  Equal<StrictQuery<DB, 'select id from users where age = id'>, { id: number }[]>
+>;
+
+type TrailingIsNotNullStillResolves = Expect<
+  Equal<StrictQuery<DB, 'select id from users where deleted_at is not null'>, { id: number }[]>
+>;
+
 type FunctionCallOperandResolves = Expect<
   Equal<StrictQuery<DB, "select id from users where upper(name) = 'X'">, { id: number }[]>
 >;
@@ -172,6 +187,9 @@ export type WhereStrictLock = [
   NotBetweenResolvesColumn,
   NotIlikeResolvesColumn,
   UnknownColumnOnNotLikeStillValidated,
+  UnknownColumnOnTrailingComparisonRhs,
+  ValidTrailingComparisonRhsResolves,
+  TrailingIsNotNullStillResolves,
   FunctionCallOperandResolves,
   LengthFunctionCallOperandResolves,
   UnknownAliasInWhere,


### PR DESCRIPTION
Fixes #128

## Summary

`WhereScan`'s recursive pattern `S extends \`${infer Head} ${infer Tail}\`` only advances while there's a trailing space in the remaining text, so the clause's very last token never reaches a trigger operator (`=`, `LIKE`, `IN`, `BETWEEN`, `IS`, ...) - there's no operator *after* it to fire `ValidateWhereOperand` on the accumulated `Prev`. Any typo landing as the final operand of a WHERE clause was silently accepted:

```ts
type Q = StrictQuery<DB, 'select id from users where age = naem'>
// naem is unknown, but resolved to { id: number }[] - no error
```

The symmetric LHS case (`where naem = 'x'`) was already correctly caught - only operand order mattered, which defeats strict mode's core promise.

## Fix

Added an explicit base case for when the recursion runs out of tokens: validate the last one directly via the same `ValidateWhereOperand`, skipping it only if it's the transparent `not` token (a dangling `not` with nothing after it). `LiteralType` already recognizes bare `null`/`true`/`false`/numbers/quoted strings as literals rather than columns, so trailing `IS NOT NULL` is unaffected - its final token `null` resolves as a literal, not a column lookup.

## Test plan

- Added `UnknownColumnOnTrailingComparisonRhs` (the issue's repro), plus two guard tests: `ValidTrailingComparisonRhsResolves` (a genuinely valid trailing column still resolves) and `TrailingIsNotNullStillResolves` (confirms the fix doesn't false-positive on `IS NOT NULL`'s trailing `null` literal).
- Reverted `src/where.ts` in isolation and confirmed exactly the new repro test fails (the two guard tests pass on both old and new code, as expected - they exist to catch over-firing, not under-firing).
- `npm run test:types` clean, full `vitest run` 195/195 green.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>