### PR TITLE
fix(where): validate the RHS operand at AND/OR boundaries in strict mode

### DIFF
--- a/src/where.ts
+++ b/src/where.ts
@@ -45,6 +45,17 @@ type IsTriggerOperator<Token extends string> = IsSymbolTriggerOperator<Token> ex
 // literal word `not` instead of the column (`NOT LIKE` / `NOT IN` / `NOT BETWEEN`).
 type IsTransparentToken<Token extends string> = Lowercase<Token> extends 'not' ? true : false;
 
+// `and`/`or` separate comparisons in a WHERE clause. They are neither trigger
+// operators nor transparent tokens, so without special handling the RHS operand
+// of the comparison immediately before them (held in `Prev`) would be silently
+// overwritten by the next token and never reach `ValidateWhereOperand` (issue
+// #148). Treat them as validation boundaries: validate the accumulated `Prev`
+// exactly the way the operator branch does, then reset scanning state so the
+// next comparison's LHS operand starts fresh. `between`'s syntactic `and`
+// (`x between 1 and 2`) is validated too, but its bounds are literals or real
+// columns, so the check is harmless there.
+type IsAndOr<Token extends string> = Lowercase<Token> extends 'and' | 'or' ? true : false;
+
 type DropOneOpenParen<S extends string> = S extends `(${infer Rest}` ? Rest : S;
 
 type HeadStartsSubquery<Head extends string, Tail extends string> = Head extends `(${string}`
@@ -86,9 +97,15 @@ type WhereScan<
           ? WhereScan<DB, Sources, Tail, CleanColumnToken<Head>>
           : Error
         : never
-      : IsTransparentToken<Head> extends true
-        ? WhereScan<DB, Sources, Tail, Prev>
-        : WhereScan<DB, Sources, Tail, CleanColumnToken<Head>>
+      : IsAndOr<Head> extends true
+        ? ValidateWhereOperand<DB, Sources, Prev> extends infer Error
+          ? [Error] extends [never]
+            ? WhereScan<DB, Sources, Tail>
+            : Error
+          : never
+        : IsTransparentToken<Head> extends true
+          ? WhereScan<DB, Sources, Tail, Prev>
+          : WhereScan<DB, Sources, Tail, CleanColumnToken<Head>>
   : // Terminal case: no trailing space left, so `S` is the final token of the
     // clause. Earlier operands are validated by the operator *after* them, but
     // the trailing operand has no following operator to trigger the check — so

--- a/tests/where-strict.test-d.ts
+++ b/tests/where-strict.test-d.ts
@@ -179,6 +179,50 @@ type ValidTrailingLiteralOperandResolves = Expect<
   Equal<StrictQuery<DB, 'select id from users where age = 5'>, { id: number }[]>
 >;
 
+// Regression for #148: the RHS operand of a comparison immediately before
+// `and`/`or` (mid-clause, not the trailing token) must be validated too.
+// Before the fix this typo passed strict mode because `and` overwrote `Prev`
+// without ever validating it.
+type UnknownColumnOnRhsBeforeAnd = Expect<
+  Equal<
+    StrictQuery<DB, 'select id from users where age = naem and id = 1'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+// Lock: the same clause with a VALID RHS column before `and` still resolves —
+// the boundary validation must not reject good queries.
+type ValidRhsBeforeAndResolves = Expect<
+  Equal<StrictQuery<DB, 'select id from users where age = id and id = 1'>, { id: number }[]>
+>;
+
+// `or` variant of the mid-clause RHS check.
+type UnknownColumnOnRhsBeforeOr = Expect<
+  Equal<
+    StrictQuery<DB, 'select id from users where age = naem or id = 1'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+// The LHS operand of the comparison *after* `and`/`or` must still be validated
+// by the existing flow (the operator following it triggers the check).
+type UnknownColumnOnLhsAfterAnd = Expect<
+  Equal<
+    StrictQuery<DB, 'select id from users where age = 1 and naem = 2'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+// NOT-form interaction: `not like 'x'` validates `age`, the `and` boundary
+// validates the string literal `'x'` (harmless) and resets, and the LHS `naem`
+// of the next comparison is then validated.
+type NotFormComposesWithAndBoundary = Expect<
+  Equal<
+    StrictQuery<DB, "select id from users where age not like 'x' and naem = 1">,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
 export type WhereStrictLock = [
   ValidWhereStillResolves,
   UnknownColumnOnComparisonLhs,
@@ -206,4 +250,9 @@ export type WhereStrictLock = [
   UnknownColumnOnComparisonRhs,
   ValidTrailingColumnOperandResolves,
   ValidTrailingLiteralOperandResolves,
+  UnknownColumnOnRhsBeforeAnd,
+  ValidRhsBeforeAndResolves,
+  UnknownColumnOnRhsBeforeOr,
+  UnknownColumnOnLhsAfterAnd,
+  NotFormComposesWithAndBoundary,
 ];


### PR DESCRIPTION
Fixes #148 (follow-up to #147 — the mid-clause half of the same false-negative family)

`and`/`or` were neither transparent tokens nor word operators in `WhereScan`, so the RHS operand of a comparison sitting immediately before them replaced `Prev` without ever reaching `ValidateWhereOperand`: `where age = naem and id = 1` passed strict mode while the trailing form was caught by #147. The fix adds an `IsAndOr` boundary branch (slotted after `IsTriggerOperator`, before `IsTransparentToken`): consuming `and`/`or` validates the accumulated `Prev` exactly the way the word-operator branch does, then resets `Prev` so the next comparison's LHS flows through the existing validation.

Composition, verified by locks: disjoint from and additive to #147's terminal branch; NOT transparency intact (`age not like 'x' and naem = 1` errors on `naem`); `BETWEEN`'s syntactic `and` is harmless (bounds normalize via `CleanColumnToken` to literals → `never`); IN-list/paren operands likewise. Five new `WhereStrictLock` entries: the `and`/`or` bad-RHS repro pair (both fail on current master — `Type 'false' does not satisfy 'true'` at exactly those two asserts — and pass with the fix), a valid-RHS guard, an LHS-after-boundary lock, and the NOT-form interaction. All 26 pre-existing locks stay green.

Gates: full `npm run test:types` (all three tsconfigs) exit 0; runtime vitest (non-ts-plugin) 108 tests green. Diff: `where.ts` +23/−3, tests +49.

Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (implementation)