### PR TITLE
fix(string): recognize backslash-escaped quotes inside string literals

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -25,10 +25,22 @@ type RemoveSemicolons<S extends string> = S extends `${infer Before};${infer Aft
   ? RemoveSemicolons<`${Before} ${After}`>
   : S;
 
-type SkipLiteralBody<S extends string> = S extends `${string}'${infer After}`
-  ? After extends `'${infer Rest}`
-    ? SkipLiteralBody<Rest>
-    : { rest: After }
+// A quote preceded by an odd run of backslashes is backslash-escaped (MySQL's
+// default `\'` literal-quote escape) and isn't a delimiter - the run must be
+// odd, not merely non-empty, since `\\'` is an escaped backslash followed by
+// a real closing quote.
+type EndsWithOddBackslashes<S extends string> = S extends `${infer Rest}\\`
+  ? Rest extends `${infer Rest2}\\`
+    ? EndsWithOddBackslashes<Rest2>
+    : true
+  : false;
+
+type SkipLiteralBody<S extends string> = S extends `${infer Before}'${infer After}`
+  ? EndsWithOddBackslashes<Before> extends true
+    ? SkipLiteralBody<After>
+    : After extends `'${infer Rest}`
+      ? SkipLiteralBody<Rest>
+      : { rest: After }
   : never;
 
 type AfterLineComment<S extends string> = S extends `${string}

--- a/tests/string-literal.test-d.ts
+++ b/tests/string-literal.test-d.ts
@@ -37,6 +37,27 @@ type EscapedQuoteInsideLiteral = Expect<
   >
 >;
 
+type BackslashEscapedQuoteInsideLiteral = Expect<
+  Equal<
+    Query<DB, "select id, 'a\\'b' as note from users where email = 'x'">,
+    { id: number; note: string }[]
+  >
+>;
+
+type BackslashEscapedQuoteStillFindsWhereClauseStrict = Expect<
+  Equal<
+    StrictRow<DB, "select id, 'a\\'b' as note from users where email = 'x'">,
+    { id: number; note: string }
+  >
+>;
+
+type EscapedBackslashThenRealCloseIsNotMistakenForEscape = Expect<
+  Equal<
+    Query<DB, "select id, 'a\\\\' as note from users where email = 'x'">,
+    { id: number; note: string }[]
+  >
+>;
+
 type DollarInsideLiteralIsNotPlaceholder = Expect<
   Equal<Params<DB, "select id from users where note = 'costs $5 today'">, []>
 >;
@@ -80,6 +101,9 @@ export type Assertions = [
   UnbalancedParenInsideLiteral,
   CommaInsideLiteral,
   EscapedQuoteInsideLiteral,
+  BackslashEscapedQuoteInsideLiteral,
+  BackslashEscapedQuoteStillFindsWhereClauseStrict,
+  EscapedBackslashThenRealCloseIsNotMistakenForEscape,
   DollarInsideLiteralIsNotPlaceholder,
   QuestionMarkInsideLiteralIsNotPlaceholder,
   AtInsideCteLiteralKeepsParamTyping,


### PR DESCRIPTION
Fixes #131

## Summary

`SkipLiteralBody` (`src/string.ts`) only recognized SQL's doubled-quote escape (`''`) as "the literal continues". MySQL's default `sql_mode` also treats `\'` as an escaped quote, but the parser had no notion of that: it read the `\'` as the literal's real closing quote, which flipped quote parity for the rest of the query. The final "unterminated literal" fallback then swallowed everything after it (including `from`/`where`) into the accumulated output, with no diagnostic at all - worse than a false positive, since nothing signals anything went wrong.

## Fix

Added `EndsWithOddBackslashes<S>`: a found quote is only treated as escaped when the text before it ends in an **odd** run of backslashes - `\'` escapes the quote, but `\'` doesn't (that's an escaped backslash followed by a genuinely unescaped closing quote). Verified this parity logic explicitly with a dedicated guard test.

### On dialect-awareness

The issue raised (correctly) that Postgres/standard SQL doesn't support backslash escapes by default, so this might need to be dialect-gated. I looked into threading a `Dialect` parameter through the whole compile-time parser (`Normalize` is invoked from ~7 places across `parse.ts`/`params.ts`, all the way up to the public `StrictQuery`/`Query`/`Params` types) and concluded that's disproportionate and, more importantly, contradicts this library's own documented design: the README's "Database support" section states the parser is deliberately mode-free - *"it stays permissive and recognizes each dialect's syntax by shape, not by a declared mode."* Adding a dialect flag here would be inconsistent with that.

Practically, the only way this regresses a non-MySQL query is a literal ending in an *odd*, undoubled run of backslashes immediately before its closing quote (e.g. `ESCAPE '\'`) - a shape that isn't part of this library's documented/tested SQL subset today (no `ESCAPE` clause support, nothing in the test suite exercises it). Given that, and the severity of the current bug (silent corruption with zero diagnostic for an extremely common MySQL idiom), I went with the same permissive-by-shape treatment the doubled-quote escape already gets.

## Test plan

- `BackslashEscapedQuoteInsideLiteral` - the issue's repro via `Query`.
- `BackslashEscapedQuoteStillFindsWhereClauseStrict` - same repro via `StrictRow`, confirming `from`/`where` survive and the row type resolves correctly end-to-end (not just that `string.ts` in isolation looks right).
- `EscapedBackslashThenRealCloseIsNotMistakenForEscape` - guard test for the parity logic (`'a\'` = escaped backslash + real close, must NOT be treated as an escaped quote).
- Reverted `src/string.ts` in isolation: the two regression tests fail exactly as expected (`Type 'false' does not satisfy 'true'`), the guard test passes on both old and new code (confirming it doesn't over-fire).
- `npm run test:types` clean, full `vitest run` 195/195 green.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>