### PR TITLE
fix(parse): reject a non-trailing semicolon in strict mode

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -10,6 +10,7 @@ import type {
   ExtractParenGroup,
   ApplyParenDelta,
   SplitColumnList,
+  HasNonTrailingSemicolon,
 } from './string.js';
 import type {
   IsFunctionCall,
@@ -757,6 +758,16 @@ type ApplyWhereCheck<
   : Row;
 
 export type InferRowWith<
+  DB extends SchemaLike,
+  Q extends string,
+  Strict extends boolean,
+> = Strict extends true
+  ? HasNonTrailingSemicolon<Q> extends true
+    ? QueryTypeError<'multiple statements are not supported: found a semicolon before the end of the query'>
+    : InferRowWithChecked<DB, Q, Strict>
+  : InferRowWithChecked<DB, Q, Strict>;
+
+type InferRowWithChecked<
   DB extends SchemaLike,
   Q extends string,
   Strict extends boolean,

--- a/src/string.ts
+++ b/src/string.ts
@@ -78,6 +78,18 @@ export type Normalize<S extends string> = Trim<
   CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<StripCommentsAndMaskLiterals<S>>>>
 >;
 
+// RemoveSemicolons strips every semicolon, not just a single trailing one, so
+// a second statement after a non-trailing semicolon would otherwise be
+// silently merged into the first. Checked against the comment-stripped,
+// literal-masked text so a semicolon inside a comment or a string literal
+// (already reduced to '') is never mistaken for a statement separator.
+export type HasNonTrailingSemicolon<S extends string> =
+  Trim<StripCommentsAndMaskLiterals<S>> extends `${string};${infer After}`
+    ? Trim<After> extends ''
+      ? false
+      : true
+    : false;
+
 export type Unquote<S extends string> = S extends `"${infer Inner}"`
   ? Inner
   : S extends `[${infer Inner}]`

--- a/tests/semicolon.test-d.ts
+++ b/tests/semicolon.test-d.ts
@@ -1,0 +1,60 @@
+import type { Query, StrictRow, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+type SingleTrailingSemicolonIsFine = Expect<
+  Equal<StrictRow<DB, 'select id from users;'>, { id: number }>
+>;
+
+type TrailingSemicolonWithSpaceIsFine = Expect<
+  Equal<StrictRow<DB, 'select id from users; '>, { id: number }>
+>;
+
+type NoSemicolonIsFine = Expect<
+  Equal<StrictRow<DB, 'select id from users'>, { id: number }>
+>;
+
+type SemicolonInsideLiteralIsFine = Expect<
+  Equal<StrictRow<DB, "select id from users where name = 'a;b'">, { id: number }>
+>;
+
+type SemicolonInsideCommentIsFine = Expect<
+  Equal<
+    StrictRow<
+      DB,
+      `select id from users -- old query: select name from users;
+`
+    >,
+    { id: number }
+  >
+>;
+
+type NonTrailingSemicolonIsRejectedInStrictMode = Expect<
+  Equal<
+    StrictRow<DB, 'select id from users; select name from users'>,
+    QueryTypeError<'multiple statements are not supported: found a semicolon before the end of the query'>
+  >
+>;
+
+type NonStrictModeStillMergesNonTrailingSemicolon = Expect<
+  Equal<Query<DB, 'select id from users; select name from users'>, { id: number }[]>
+>;
+
+export type Assertions = [
+  SingleTrailingSemicolonIsFine,
+  TrailingSemicolonWithSpaceIsFine,
+  NoSemicolonIsFine,
+  SemicolonInsideLiteralIsFine,
+  SemicolonInsideCommentIsFine,
+  NonTrailingSemicolonIsRejectedInStrictMode,
+  NonStrictModeStillMergesNonTrailingSemicolon,
+];


### PR DESCRIPTION
Fixes #139

## Summary

`RemoveSemicolons` (`src/string.ts`) strips every semicolon in the input, not just a single trailing one - the only shape the README documents as supported. `from.ts`'s clause-boundary detection also has no `select` boundary keyword. Put together, a second statement after a real semicolon gets silently merged into the first:

```ts
type Q = StrictQuery<DB, 'select id from users; select name from users'>
```

The second `select` is absorbed as a bogus alias on `users`, the second statement's columns are discarded, and the type checker keeps returning the first statement's shape with no error - even though the *raw*, unnormalized string is what actually gets sent to the driver at execution time, so the runtime may well execute both statements.

## Fix

Added `HasNonTrailingSemicolon<S>` (`src/string.ts`), checked against the comment-stripped, literal-masked text (`StripCommentsAndMaskLiterals<S>`) so a semicolon inside a comment or a string literal is never mistaken for a statement separator. Wired into `InferRowWith` (`src/parse.ts`), gated on `Strict extends true` only - matching this codebase's existing convention where non-strict `Query`/`Row` stay permissive (best-effort, never a `QueryTypeError`) and only `StrictQuery`/`StrictRow` surface errors. Undefined multi-statement behavior is exactly the kind of thing strict mode exists to catch; non-strict mode's merge-and-drop behavior is left as-is.

## Test plan

New `tests/semicolon.test-d.ts`:
- A single trailing semicolon (with or without trailing space) and no semicolon at all still resolve fine.
- A semicolon inside a string literal or a line comment is not flagged.
- A non-trailing semicolon in `StrictRow` now resolves to the new `QueryTypeError`.
- Non-strict `Query` is confirmed unchanged (still silently merges, matching current documented-as-undefined behavior).

Reverted `src/string.ts` + `src/parse.ts` in isolation and confirmed exactly the new repro test fails (`Type 'false' does not satisfy 'true'`); all the guard tests pass on both old and new code, as expected. `npm run test:types` clean, full `vitest run` 195/195 green.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>