### PR TITLE
fix(adapters): track dollar-quoted string bodies as literal regions

### DIFF
--- a/src/adapters/named-params.ts
+++ b/src/adapters/named-params.ts
@@ -1,4 +1,5 @@
 const NAMED_PARAM_BODY = /^[A-Za-z0-9_]+/;
+const DOLLAR_QUOTE_TAG = /^\$([A-Za-z0-9_]*)\$/;
 
 export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string>): string[] {
   const names: string[] = [];
@@ -13,6 +14,16 @@ export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string
     }
     if (insideLiteral) {
       continue;
+    }
+
+    if (char === '$') {
+      const open = DOLLAR_QUOTE_TAG.exec(sql.slice(index));
+      if (open) {
+        const closer = `$${open[1]}$`;
+        const closeIndex = sql.indexOf(closer, index + open[0].length);
+        index = closeIndex === -1 ? sql.length - 1 : closeIndex + closer.length - 1;
+        continue;
+      }
     }
 
     if (prefixes.has(char)) {

--- a/tests/named-params.test.ts
+++ b/tests/named-params.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { collectNamedParameters } from '../src/adapters/named-params.js';
+
+const AT_DOLLAR_COLON: ReadonlySet<string> = new Set(['@', '$', ':']);
+
+describe('collectNamedParameters', () => {
+  it('collects named parameters outside of literals and dollar-quoted bodies', () => {
+    expect(collectNamedParameters('select 1 where id = @id', AT_DOLLAR_COLON)).toEqual(['@id']);
+  });
+
+  it('does not treat a $word inside a $$ ... $$ dollar-quoted body as a parameter', () => {
+    const sql = "create function f() returns int as $$ select $foo from bar $$ language sql";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual([]);
+  });
+
+  it('does not treat a $word inside a $tag$ ... $tag$ dollar-quoted body as a parameter', () => {
+    const sql = "create function f() returns int as $body$ select $foo from bar $body$ language sql";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual([]);
+  });
+
+  it('still collects a real parameter that follows a dollar-quoted body', () => {
+    const sql = "create function f() returns int as $$ select 1 $$ language sql; select @id";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id']);
+  });
+
+  it('does not confuse a positional $1 placeholder for a dollar-quote opener', () => {
+    expect(collectNamedParameters('select * from t where id = $1', AT_DOLLAR_COLON)).toEqual([
+      '$1',
+    ]);
+  });
+
+  it('still skips parameters inside a plain string literal', () => {
+    expect(collectNamedParameters("select '@id' from t where x = @real", AT_DOLLAR_COLON)).toEqual(
+      ['@real'],
+    );
+  });
+
+  it('dedupes a repeated named parameter', () => {
+    expect(
+      collectNamedParameters('select * from t where a = @id or b = @id', AT_DOLLAR_COLON),
+    ).toEqual(['@id']);
+  });
+});


### PR DESCRIPTION
Fixes #140

## Summary

`collectNamedParameters` (`src/adapters/named-params.ts`) toggles `insideLiteral` only on a single quote (`'`). It has no awareness of Postgres dollar-quoted string bodies (`$$ ... $$` or `$tag$ ... $tag$`, commonly used to write function bodies inline), so a `$word`-shaped token inside such a body - or the opening tag itself for the `$tag$` form - gets misdetected as a real bind parameter, silently corrupting the parameter count/bindings for that query.

The existing `$$`-doubling shortcut (`if (sql[index + 1] === char)`) only skips the *opening* two characters and then resumes normal scanning through the body - it doesn't track the region as opaque at all, and doesn't handle the tagged `$tag$` form (whose tag itself gets misdetected as a parameter, e.g. `$body$` → phantom `$body`).

## Fix

On an unescaped `$`, check whether it opens a `$tag$` delimiter (tag may be empty, matching plain `$$`). If it does, jump straight to the matching closing delimiter for that *same* tag and treat everything in between as opaque - the same way string literals already are. This runs before the prefix-scanning logic and isn't gated on `$` being one of the caller's `prefixes`, so it applies uniformly regardless of which prefix set a given adapter passes (`node-sqlite.ts` includes `$` in its own prefix set).

## Test plan

New `tests/named-params.test.ts` exercising `collectNamedParameters` directly:
- A `$word` inside `$$ ... $$` and inside `$tag$ ... $tag$` is no longer collected (the two regression cases).
- A real parameter *after* a dollar-quoted body is still collected.
- A positional `$1` placeholder is unaffected (not mistaken for a dollar-quote opener).
- Parameters inside a plain `'...'` literal are still skipped, and repeated-name dedup still works (pre-existing behavior, unchanged).

Reverted `src/adapters/named-params.ts` in isolation and confirmed exactly the two regression tests fail (`$foo` / `$body` + `$foo` leak through as phantom params); the other five pass on both old and new code. `npm run test:types` clean, full `vitest run` 202/202 green.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>