### PR TITLE
fix(mssql): accept a Transaction or Request, not just a ConnectionPool

### DIFF
--- a/src/adapters/mssql.ts
+++ b/src/adapters/mssql.ts
@@ -1,12 +1,23 @@
-import type { ConnectionPool } from 'mssql';
+import type { ConnectionPool, Transaction, Request } from 'mssql';
 import type { DialectExecutor, QueryMeta } from '../index.js';
 import { collectNamedParameters } from './named-params.js';
 
 const MSSQL_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@']);
 
-export function createMssqlExecutor(pool: ConnectionPool): DialectExecutor<'at'> {
+export type MssqlQueryable = ConnectionPool | Transaction | Request;
+
+function isRequestSource(source: MssqlQueryable): source is ConnectionPool | Transaction {
+  return typeof (source as { request?: unknown }).request === 'function';
+}
+
+export function createMssqlExecutor(source: MssqlQueryable): DialectExecutor<'at'> {
   return async (sql, params) => {
-    const request = pool.request();
+    // A ConnectionPool or an already-open Transaction each need `.request()`
+    // called to get a Request bound to that connection/transaction; a
+    // Request passed directly is already bound and used as-is - this is what
+    // lets a caller route a query through an open transaction instead of
+    // always implicitly starting a new, separately-committed request.
+    const request = isRequestSource(source) ? source.request() : source;
 
     collectNamedParameters(sql, MSSQL_PARAM_PREFIXES).forEach((name, index) => {
       request.input(name.slice(1), params[index] ?? null);

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ConnectionPool } from 'mssql';
+import type { ConnectionPool, Request, Transaction } from 'mssql';
 import { createMssqlExecutor } from '../src/adapters/mssql.js';
 
 interface FakeRequest {
@@ -7,13 +7,23 @@ interface FakeRequest {
   query: ReturnType<typeof vi.fn>;
 }
 
-function fakePool(result: unknown): { pool: ConnectionPool; request: FakeRequest } {
-  const request: FakeRequest = {
+function fakeRequest(result: unknown): FakeRequest {
+  return {
     input: vi.fn(),
     query: vi.fn().mockResolvedValue(result),
   };
+}
+
+function fakePool(result: unknown): { pool: ConnectionPool; request: FakeRequest } {
+  const request = fakeRequest(result);
   const pool = { request: () => request } as unknown as ConnectionPool;
   return { pool, request };
+}
+
+function fakeTransaction(result: unknown): { transaction: Transaction; request: FakeRequest } {
+  const request = fakeRequest(result);
+  const transaction = { request: () => request } as unknown as Transaction;
+  return { transaction, request };
 }
 
 describe('createMssqlExecutor', () => {
@@ -58,5 +68,25 @@ describe('createMssqlExecutor', () => {
     const result = await executor('update users set name = @name where id = @id', ['ada', 1]);
 
     expect(result).toEqual({ rows: [], meta: { rowCount: 3 } });
+  });
+
+  it('routes the query through an open transaction instead of a fresh pool request', async () => {
+    const { transaction, request } = fakeTransaction({ recordset: [{ id: 1 }] });
+    const executor = createMssqlExecutor(transaction);
+
+    const result = await executor('select id from users where id = @id', [1]);
+
+    expect(request.input.mock.calls).toEqual([['id', 1]]);
+    expect(result).toEqual({ rows: [{ id: 1 }], meta: {} });
+  });
+
+  it('accepts an already-bound Request directly, without calling .request() on it', async () => {
+    const request = fakeRequest({ recordset: [{ id: 1 }] }) as unknown as Request;
+    const executor = createMssqlExecutor(request);
+
+    const result = await executor('select id from users where id = @id', [1]);
+
+    expect((request as unknown as FakeRequest).input.mock.calls).toEqual([['id', 1]]);
+    expect(result).toEqual({ rows: [{ id: 1 }], meta: {} });
   });
 });

--- a/tests/adapters.test-d.ts
+++ b/tests/adapters.test-d.ts
@@ -4,11 +4,13 @@ import type { Pool as Mysql2Pool, Connection as Mysql2Connection } from 'mysql2/
 import type postgres from 'postgres';
 import type { DatabaseSync } from 'node:sqlite';
 import type { Kysely } from 'kysely';
+import type { ConnectionPool, Transaction, Request as MssqlRequest } from 'mssql';
 import { createPgExecutor } from '../src/adapters/pg.js';
 import { createMysql2Executor } from '../src/adapters/mysql2.js';
 import { createPostgresJsExecutor } from '../src/adapters/postgres.js';
 import { createNodeSqliteExecutor } from '../src/adapters/node-sqlite.js';
 import { createKyselyExecutor } from '../src/adapters/kysely.js';
+import { createMssqlExecutor } from '../src/adapters/mssql.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -40,6 +42,10 @@ type KyselyExecutorMatchesShape = Expect<
   Equal<ReturnType<typeof createKyselyExecutor<{ users: { id: number } }>>, Executor>
 >;
 
+type MssqlExecutorMatchesShape = Expect<
+  Equal<ReturnType<typeof createMssqlExecutor>, DialectExecutor<'at'>>
+>;
+
 export function adapterCallSites() {
   createPgExecutor({} as PgPool);
   createPgExecutor({} as PgClient);
@@ -49,6 +55,12 @@ export function adapterCallSites() {
   createPostgresJsExecutor({} as postgres.Sql);
   createNodeSqliteExecutor({} as DatabaseSync);
   createKyselyExecutor({} as Kysely<{ users: { id: number } }>);
+  // A ConnectionPool, an open Transaction, or an already-bound Request must
+  // all be accepted so a caller can route a query through an open
+  // transaction instead of always implicitly starting a new one (#133).
+  createMssqlExecutor({} as ConnectionPool);
+  createMssqlExecutor({} as Transaction);
+  createMssqlExecutor({} as MssqlRequest);
 }
 
 export type AdaptersLock = [
@@ -57,4 +69,5 @@ export type AdaptersLock = [
   PostgresJsExecutorMatchesShape,
   NodeSqliteExecutorMatchesShape,
   KyselyExecutorMatchesShape,
+  MssqlExecutorMatchesShape,
 ];


### PR DESCRIPTION
Fixes #133

## Summary

`createMssqlExecutor` hardcoded `pool.request()` and only typed its parameter as `ConnectionPool`. Per `@types/mssql`, `Transaction` is a separate class with its own `.request()`; a `Request` must come from the `Transaction` instance to actually participate in it. There was no way to route a query through an open transaction with this executor at all - every statement auto-committed independently, so a caller rolling back on error after some writes would find those writes already committed, with no exception anywhere to signal it.

By contrast, `src/adapters/pg.ts` accepts `Pool | Client | PoolClient` and `src/adapters/mysql2.ts` accepts `Pool | Connection` - both already let the caller supply a transaction-bound handle.

## Fix

Widened the parameter to `ConnectionPool | Transaction | Request`. A `ConnectionPool` or `Transaction` still needs `.request()` called on it to get a bound `Request`; a `Request` passed directly is already bound and used as-is. `Request` has no `.request()` method of its own, so a runtime duck-type check (`typeof source.request === 'function'`) discriminates the two cases cleanly without needing a class/`instanceof` check.

## Test plan

- `tests/adapter-mssql.test.ts`: new cases for routing through a `Transaction` and for accepting an already-bound `Request` directly (input binding + result shape both verified).
- `tests/adapters.test-d.ts`: added `createMssqlExecutor` to the existing `adapterCallSites()` type-level smoke test (calling it with `ConnectionPool`/`Transaction`/`Request`), matching how every other adapter's accepted-handle-type union is locked in there.
- Reverted `src/adapters/mssql.ts` in isolation: confirmed the old signature genuinely rejects `Transaction`/`Request` at compile time (`tsc` error, not just a runtime gap) in both new test files - 4 real type errors on old code, all gone after restoring the fix.
- `npm run test:types` clean, full `vitest run` 197/197 green.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>