### PR TITLE
fix(params): dedupe repeated named placeholders at the type level

### DIFF
--- a/src/adapters/named-params.ts
+++ b/src/adapters/named-params.ts
@@ -45,3 +45,72 @@ export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string
 
   return names;
 }
+
+export interface MixedParameters {
+  named: Record<string, unknown>;
+  positional: unknown[];
+}
+
+// Params<DB, Q> types one tuple slot per placeholder in first-occurrence
+// order, with repeated named placeholders (@id, $id, ...) deduped to their
+// first slot - matching collectNamedParameters' own dedup. A bare `?` is
+// never deduped: each occurrence consumes its own slot. This walks the SQL
+// once, in that same order, so `values` (built from that tuple) is
+// partitioned back into a named bag and an ordered positional list.
+export function resolveMixedParameters(
+  sql: string,
+  prefixes: ReadonlySet<string>,
+  values: readonly unknown[],
+): MixedParameters {
+  const named: Record<string, unknown> = {};
+  const positional: unknown[] = [];
+  let insideLiteral = false;
+  let valueIndex = 0;
+
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index] as string;
+
+    if (char === "'") {
+      insideLiteral = !insideLiteral;
+      continue;
+    }
+    if (insideLiteral) {
+      continue;
+    }
+
+    if (char === '$') {
+      const open = DOLLAR_QUOTE_TAG.exec(sql.slice(index));
+      if (open) {
+        const closer = `$${open[1]}$`;
+        const closeIndex = sql.indexOf(closer, index + open[0].length);
+        index = closeIndex === -1 ? sql.length - 1 : closeIndex + closer.length - 1;
+        continue;
+      }
+    }
+
+    if (char === '?') {
+      positional.push(values[valueIndex] ?? null);
+      valueIndex += 1;
+      continue;
+    }
+
+    if (prefixes.has(char)) {
+      if (sql[index + 1] === char) {
+        index += 1;
+        continue;
+      }
+
+      const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
+      if (body) {
+        const name = `${char}${body[0]}`;
+        if (!(name in named)) {
+          named[name] = values[valueIndex] ?? null;
+          valueIndex += 1;
+        }
+        index += body[0].length;
+      }
+    }
+  }
+
+  return { named, positional };
+}

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import type { DialectExecutor } from '../index.js';
-import { collectNamedParameters } from './named-params.js';
+import { resolveMixedParameters } from './named-params.js';
 
 type SqliteParam = null | number | bigint | string | NodeJS.ArrayBufferView;
 
@@ -25,16 +25,12 @@ export function createNodeSqliteExecutor(
   return async (sql, params) => {
     const statement = db.prepare(sql);
     const values = params.map(toSqliteValue);
-    const namedParameters = collectNamedParameters(sql, SQLITE_PARAM_PREFIXES);
+    const { named, positional } = resolveMixedParameters(sql, SQLITE_PARAM_PREFIXES, values);
 
-    if (namedParameters.length > 0) {
-      const bag: Record<string, SqliteParam> = {};
-      namedParameters.forEach((name, index) => {
-        bag[name] = values[index] ?? null;
-      });
-      return statement.all(bag);
+    if (Object.keys(named).length > 0) {
+      return statement.all(named as Record<string, SqliteParam>, ...(positional as SqliteParam[]));
     }
 
-    return statement.all(...values);
+    return statement.all(...(positional as SqliteParam[]));
   };
 }

--- a/src/params.ts
+++ b/src/params.ts
@@ -99,6 +99,24 @@ type PlaceholderPosition<Token extends string> =
       : never
     : never;
 
+// A bare `?` is never named - each occurrence is a distinct positional slot.
+// Anything else that reaches here (a non-numeric `$name`/`@name`) is a real
+// name, used as the dedup key: a repeated `@id` must bind once (README), not
+// grow a new tuple slot per occurrence.
+type PlaceholderName<Token extends string> = CleanScanToken<Token> extends '?'
+  ? never
+  : CleanScanToken<Token>;
+
+type FindNameIndex<
+  Names extends string[],
+  Name extends string,
+  Position extends unknown[] = [],
+> = Names extends [infer Head extends string, ...infer Tail extends string[]]
+  ? Head extends Name
+    ? Position
+    : FindNameIndex<Tail, Name, [...Position, unknown]>
+  : never;
+
 type SetSlot<
   Tuple extends unknown[],
   Position extends unknown[],
@@ -127,11 +145,38 @@ type AddParam<
   Type,
   Indexed extends unknown[],
   Sequential extends unknown[],
+  SequentialNames extends string[],
 > = PlaceholderPosition<Token> extends infer Position
   ? [Position] extends [never]
-    ? { indexed: Indexed; sequential: [...Sequential, Type] }
+    ? [PlaceholderName<Token>] extends [never]
+      ? // A bare `?` still needs a same-length filler pushed onto
+        // SequentialNames, or a later named placeholder's FindNameIndex
+        // result (an index into SequentialNames) would no longer line up
+        // with that same placeholder's real slot in Sequential. '?' itself
+        // is a safe filler: PlaceholderName never resolves to '?', so it can
+        // never be produced as a search target and accidentally matched.
+        { indexed: Indexed; sequential: [...Sequential, Type]; sequentialNames: [...SequentialNames, '?'] }
+      : FindNameIndex<SequentialNames, PlaceholderName<Token>> extends infer Existing
+        ? [Existing] extends [never]
+          ? {
+              indexed: Indexed;
+              sequential: [...Sequential, Type];
+              sequentialNames: [...SequentialNames, PlaceholderName<Token>];
+            }
+          : Existing extends unknown[]
+            ? {
+                indexed: Indexed;
+                sequential: SetSlot<Sequential, Existing, Type>;
+                sequentialNames: SequentialNames;
+              }
+            : never
+        : never
     : Position extends unknown[]
-      ? { indexed: SetSlot<Indexed, Position, Type>; sequential: Sequential }
+      ? {
+          indexed: SetSlot<Indexed, Position, Type>;
+          sequential: Sequential;
+          sequentialNames: SequentialNames;
+        }
       : never
   : never;
 
@@ -143,22 +188,30 @@ type ScanParamsRaw<
   Prev extends string = '',
   Indexed extends unknown[] = [],
   Sequential extends unknown[] = [],
+  SequentialNames extends string[] = [],
 > = S extends `${infer Head} ${infer Tail}`
   ? IsPlaceholder<Head> extends true
-    ? AddParam<Head, ParamType<DB, Sources, PrevPrev, Prev>, Indexed, Sequential> extends {
+    ? AddParam<
+        Head,
+        ParamType<DB, Sources, PrevPrev, Prev>,
+        Indexed,
+        Sequential,
+        SequentialNames
+      > extends {
         indexed: infer NextIndexed extends unknown[];
         sequential: infer NextSequential extends unknown[];
+        sequentialNames: infer NextSequentialNames extends string[];
       }
-      ? ScanParamsRaw<Tail, DB, Sources, PrevPrev, Prev, NextIndexed, NextSequential>
+      ? ScanParamsRaw<Tail, DB, Sources, PrevPrev, Prev, NextIndexed, NextSequential, NextSequentialNames>
       : never
     : IsTransparentToken<Head> extends true
-      ? ScanParamsRaw<Tail, DB, Sources, PrevPrev, Prev, Indexed, Sequential>
-      : ScanParamsRaw<Tail, DB, Sources, Prev, CleanColumnToken<Head>, Indexed, Sequential>
+      ? ScanParamsRaw<Tail, DB, Sources, PrevPrev, Prev, Indexed, Sequential, SequentialNames>
+      : ScanParamsRaw<Tail, DB, Sources, Prev, CleanColumnToken<Head>, Indexed, Sequential, SequentialNames>
   : S extends ''
-    ? { indexed: Indexed; sequential: Sequential }
+    ? { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames }
     : IsPlaceholder<S> extends true
-      ? AddParam<S, ParamType<DB, Sources, PrevPrev, Prev>, Indexed, Sequential>
-      : { indexed: Indexed; sequential: Sequential };
+      ? AddParam<S, ParamType<DB, Sources, PrevPrev, Prev>, Indexed, Sequential, SequentialNames>
+      : { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames };
 
 type ScanParams<
   S extends string,
@@ -168,7 +221,8 @@ type ScanParams<
   Prev extends string = '',
   Indexed extends unknown[] = [],
   Sequential extends unknown[] = [],
-> = ScanParamsRaw<S, DB, Sources, PrevPrev, Prev, Indexed, Sequential> extends {
+  SequentialNames extends string[] = [],
+> = ScanParamsRaw<S, DB, Sources, PrevPrev, Prev, Indexed, Sequential, SequentialNames> extends {
   indexed: infer FinalIndexed extends unknown[];
   sequential: infer FinalSequential extends unknown[];
 }
@@ -211,18 +265,34 @@ type MatchInsertValues<
   Values extends string[],
   Indexed extends unknown[],
   Sequential extends unknown[],
+  SequentialNames extends string[],
 > = Values extends [infer Head extends string, ...infer ValuesTail extends string[]]
   ? Columns extends [infer ColumnHead extends string, ...infer ColumnsTail extends string[]]
     ? IsPlaceholder<Trim<Head>> extends true
-      ? AddParam<Trim<Head>, ColumnTypeAt<DB, Table, ColumnHead>, Indexed, Sequential> extends {
+      ? AddParam<
+          Trim<Head>,
+          ColumnTypeAt<DB, Table, ColumnHead>,
+          Indexed,
+          Sequential,
+          SequentialNames
+        > extends {
           indexed: infer NextIndexed extends unknown[];
           sequential: infer NextSequential extends unknown[];
+          sequentialNames: infer NextSequentialNames extends string[];
         }
-        ? MatchInsertValues<DB, Table, ColumnsTail, ValuesTail, NextIndexed, NextSequential>
+        ? MatchInsertValues<
+            DB,
+            Table,
+            ColumnsTail,
+            ValuesTail,
+            NextIndexed,
+            NextSequential,
+            NextSequentialNames
+          >
         : never
-      : MatchInsertValues<DB, Table, ColumnsTail, ValuesTail, Indexed, Sequential>
-    : { indexed: Indexed; sequential: Sequential }
-  : { indexed: Indexed; sequential: Sequential };
+      : MatchInsertValues<DB, Table, ColumnsTail, ValuesTail, Indexed, Sequential, SequentialNames>
+    : { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames }
+  : { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames };
 
 type ScanValuesGroups<
   S extends string,
@@ -231,18 +301,33 @@ type ScanValuesGroups<
   Columns extends string[],
   Indexed extends unknown[],
   Sequential extends unknown[],
+  SequentialNames extends string[],
 > = Trim<S> extends `(${infer AfterOpen}`
   ? ExtractParenGroup<AfterOpen> extends { inner: infer Vals extends string; rest: infer Rest extends string }
-    ? MatchInsertValues<DB, Table, Columns, SplitColumnList<Vals>, Indexed, Sequential> extends {
+    ? MatchInsertValues<
+        DB,
+        Table,
+        Columns,
+        SplitColumnList<Vals>,
+        Indexed,
+        Sequential,
+        SequentialNames
+      > extends {
         indexed: infer NextIndexed extends unknown[];
         sequential: infer NextSequential extends unknown[];
+        sequentialNames: infer NextSequentialNames extends string[];
       }
       ? Trim<Rest> extends `,${infer NextGroup}`
-        ? ScanValuesGroups<NextGroup, DB, Table, Columns, NextIndexed, NextSequential>
-        : { indexed: NextIndexed; sequential: NextSequential; rest: Trim<Rest> }
+        ? ScanValuesGroups<NextGroup, DB, Table, Columns, NextIndexed, NextSequential, NextSequentialNames>
+        : {
+            indexed: NextIndexed;
+            sequential: NextSequential;
+            sequentialNames: NextSequentialNames;
+            rest: Trim<Rest>;
+          }
       : never
-    : { indexed: Indexed; sequential: Sequential; rest: Trim<S> }
-  : { indexed: Indexed; sequential: Sequential; rest: Trim<S> };
+    : { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames; rest: Trim<S> }
+  : { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames; rest: Trim<S> };
 
 type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<Q> extends {
   sources: [infer Src extends Source];
@@ -252,12 +337,13 @@ type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<
     : InsertColumnList<Q> extends { columns: infer Columns extends string[]; rest: infer AfterColumns extends string }
       ? AfterKeyword<AfterColumns, 'values'> extends infer AfterValues
         ? AfterValues extends string
-          ? ScanValuesGroups<AfterValues, DB, Src['table'], Columns, [], []> extends {
+          ? ScanValuesGroups<AfterValues, DB, Src['table'], Columns, [], [], []> extends {
               indexed: infer Indexed extends unknown[];
               sequential: infer Sequential extends unknown[];
+              sequentialNames: infer SequentialNames extends string[];
               rest: infer Rest extends string;
             }
-            ? ScanParams<Rest, DB, [Src], '', '', Indexed, Sequential>
+            ? ScanParams<Rest, DB, [Src], '', '', Indexed, Sequential, SequentialNames>
             : unknown[]
           : unknown[]
         : unknown[]

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -59,4 +59,23 @@ describe('createMssqlExecutor', () => {
 
     expect(result).toEqual({ rows: [], meta: { rowCount: 3 } });
   });
+
+  it('binds a repeated @name once, without misaligning the parameter after it', async () => {
+    const { pool, request } = fakePool({ recordset: [] });
+    const executor = createMssqlExecutor(pool);
+
+    // @now is used twice (deduped to one slot) and @id is a distinct third
+    // occurrence. Params<> now types this as two arguments; passing them
+    // straight through must bind @now to the first and @id to the second -
+    // not shift @id onto a duplicated @now value.
+    await executor('update users set last_login = @now, updated_at = @now where id = @id', [
+      'now-value',
+      7,
+    ]);
+
+    expect(request.input.mock.calls).toEqual([
+      ['now', 'now-value'],
+      ['id', 7],
+    ]);
+  });
 });

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -86,6 +86,41 @@ describe.skipIf(!sqliteAvailable)('createNodeSqliteExecutor', () => {
     expect(rows).toEqual([{ active: 1, seen_at: '2026-01-02T03:04:05.000Z' }]);
   });
 
+  it('binds ? and a named parameter together without dropping the positional value', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const result = await db.query('select id, name from users where name = ? and id = @id', 'ada', 1);
+
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value).toEqual([{ id: 1, name: 'ada' }]);
+    }
+  });
+
+  it('binds a repeated named parameter once, without misaligning the parameter after it', async () => {
+    const DatabaseSync = loadSqlite();
+    const sqlite = new DatabaseSync(':memory:');
+    sqlite.exec('create table events (id integer primary key, note text, note2 text)');
+    sqlite.prepare('insert into events (id, note, note2) values (1, ?, ?)').run('old', 'old');
+    sqlite.prepare('insert into events (id, note, note2) values (2, ?, ?)').run('untouched', 'untouched');
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    // note and note2 both bind to the same @note occurrence, deduped to one
+    // slot; @id is a distinct third occurrence. If the previously-buggy
+    // type demanded a slot per *occurrence* instead of per distinct name,
+    // a caller following it would pass an extra positional value here,
+    // shifting @id onto that extra value instead of the real id - and
+    // event 1 would never actually be matched/updated.
+    await executor('update events set note = @note, note2 = @note where id = @id', ['new', 1]);
+
+    const rows = await executor('select id, note, note2 from events order by id', []);
+    expect(rows).toEqual([
+      { id: 1, note: 'new', note2: 'new' },
+      { id: 2, note: 'untouched', note2: 'untouched' },
+    ]);
+  });
+
   it('supports an INSERT round-trip through the typed client', async () => {
     const sqlite = seededDatabase();
     const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));

--- a/tests/params-index.test-d.ts
+++ b/tests/params-index.test-d.ts
@@ -53,6 +53,21 @@ type NamedAtParamsStaySequential = Expect<
   >
 >;
 
+type RepeatedNamedAtPlaceholderOccupiesOneSlot = Expect<
+  Equal<Params<DB, 'select id from users where id = @id or parent_id = @id'>, [number]>
+>;
+
+type RepeatedNamedDollarPlaceholderOccupiesOneSlot = Expect<
+  Equal<Params<DB, 'select id from users where id = $id or parent_id = $id'>, [number]>
+>;
+
+type MixedQuestionMarksAndRepeatedNamedPlaceholderBindCorrectly = Expect<
+  Equal<
+    Params<DB, 'select id from users where name = ? and id = @id or parent_id = @id'>,
+    [string, number]
+  >
+>;
+
 type SystemVariableIsNotPlaceholder = Expect<
   Equal<Params<DB, 'select id from users where id = @@rowcount'>, []>
 >;
@@ -78,6 +93,9 @@ export type Assertions = [
   DoubleDigitIndexResolves,
   QuestionMarksStaySequential,
   NamedAtParamsStaySequential,
+  RepeatedNamedAtPlaceholderOccupiesOneSlot,
+  RepeatedNamedDollarPlaceholderOccupiesOneSlot,
+  MixedQuestionMarksAndRepeatedNamedPlaceholderBindCorrectly,
   SystemVariableIsNotPlaceholder,
   InsertOutOfOrderPlaceholdersBindByIndex,
   InsertInOrderStillWorks,


### PR DESCRIPTION
Fixes #132

## Summary

The README documents that a repeated `@name` binds once, and the runtime (`collectNamedParameters`) already honored that (dedup at `src/adapters/named-params.ts:27` via `!names.includes(name)`). The type-level inference in `src/params.ts` did not: `AddParam` unconditionally appended a new tuple slot for every occurrence of a non-indexed placeholder, since `PlaceholderPosition` only recognized `$N`-style numeric placeholders as "already has a slot."

This is a **data-corruption bug**, not just a type inconvenience. `mssql.ts`/`node-sqlite.ts` bind the *i*-th **distinct** name (from the already-deduped runtime scan) to `params[i]`, using positional indices from the caller's full args array:

```sql
UPDATE users SET last_login = @now, updated_at = @now WHERE id = @id
```

The old (buggy) type demanded 3 positional args (`@now` counted twice). A caller following it would call `query(sql, nowVal, nowVal, idVal)`. At runtime, the already-deduped names `['@now', '@id']` bind `@now -> params[0]` (correct) but `@id -> params[1]` - the caller's **second** `nowVal`, not `idVal`. The real `idVal` at `params[2]` is silently dropped and the wrong row gets updated. No error, no exception.

## Fix

- **`src/params.ts`**: Added `PlaceholderName`/`FindNameIndex` and threaded a `SequentialNames` array alongside the existing `Sequential`/`Indexed` state through `AddParam`, `ScanParamsRaw`, `MatchInsertValues`, and `ScanValuesGroups`. A repeated name intersects into its existing slot (`SetSlot`, mirroring how `$N` positions already merge); a bare `?` still gets its own slot every time, since each occurrence is genuinely distinct - it pushes a same-length filler (`'?'`) onto `SequentialNames` so a later named lookup's returned index still lines up with its real position in `Sequential`. (Caught this alignment requirement via manual verification with a forced-error scratch check, not the type checker itself, since a `?` before a repeated name silently broke the naive first version - see extra test coverage below for exactly that shape.)
- **`src/adapters/mssql.ts`**: No change needed. Once the type matches the runtime's dedup order, the existing index-based binding lines up correctly on its own - verified with a dedicated test.
- **`src/adapters/node-sqlite.ts`** + **`src/adapters/named-params.ts`**: A second, separate bug here - once *any* named parameter was present, the code took the bag-only `.all(bag)` path, silently dropping positional `?` values entirely. Fixed by adding `resolveMixedParameters` (a single ordered scan partitioning into a named bag + an ordered positional list), so `node-sqlite.ts` now calls `.all(bag, ...positional)` and binds both.

## Test plan

- `tests/params-index.test-d.ts`: the issue's exact repro (`@id` used twice → `[number]` not `[number, string]`), a `$name` variant, and a mixed `?` + repeated-`@id` case (the shape that exposed the `SequentialNames`/`Sequential` alignment bug during development).
- `tests/adapter-mssql.test.ts`: end-to-end repeated-`@name`-then-distinct-param binding, mirroring the issue's `UPDATE` repro.
- `tests/adapter-node-sqlite.test.ts`: mixing `?` with `@name` in one query (real in-memory DB, through the typed client), plus an end-to-end repeated-name test against two rows where a pre-fix misalignment would have left the target row unmodified.
- Reverted all three touched source files in isolation and confirmed the type-level and `?`-mixing regression tests fail exactly as expected; restored and re-verified. `npm run test:types` clean, full `vitest run` 205/205 green.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>