### PR TITLE
fix(cli): stop mapping MySQL tinyint(1)/bit(1) to boolean

### DIFF
--- a/src/cli/dialects/mysql.ts
+++ b/src/cli/dialects/mysql.ts
@@ -34,18 +34,19 @@ const MYSQL_SCALAR_TYPES: Record<string, string> = {
   bit: 'Buffer',
 };
 
-export function mapMysqlType(dataType: string, columnType: string): string {
+export function mapMysqlType(dataType: string): string {
   const type = dataType.toLowerCase();
-  const fullType = columnType.toLowerCase();
 
-  if (type === 'tinyint' && fullType.startsWith('tinyint(1)')) {
-    return 'boolean';
-  }
-
-  if (type === 'bit' && fullType.startsWith('bit(1)')) {
-    return 'boolean';
-  }
-
+  // tinyint(1)/bit(1) were previously special-cased to `boolean` here, but
+  // mysql2's stock parsers (no custom typeCast, which this library has no
+  // way to force onto a connection it doesn't create) never actually
+  // produce a boolean for either: TINY decodes to a plain number regardless
+  // of display width, and BIT has no dedicated case so it falls through to
+  // a raw Buffer. Trusting a `boolean` type here silently mistyped the
+  // generated column - and for BIT, a non-empty Buffer is always truthy
+  // regardless of the underlying byte, so callers checking `if (row.flag)`
+  // treated every row as true. Falling through to the plain type-map
+  // entries below matches what the driver actually returns.
   return MYSQL_SCALAR_TYPES[type] ?? 'unknown';
 }
 
@@ -82,7 +83,7 @@ export async function introspectMysql(connection: ConnectionInfo): Promise<Table
 
     const [rows] = await connectionHandle.query(
       `select c.table_name as table_name, c.column_name as column_name, c.data_type as data_type,
-              c.column_type as column_type, c.is_nullable as is_nullable
+              c.is_nullable as is_nullable
        from information_schema.columns c
        join information_schema.tables t
          on t.table_schema = c.table_schema and t.table_name = c.table_name
@@ -112,7 +113,7 @@ export function groupMysqlColumns(rows: MysqlColumnRow[], tableNames: string[] =
     const table = tables.get(tableName) ?? { name: tableName, columns: [] };
     table.columns.push({
       name: readField(row, 'column_name'),
-      tsType: mapMysqlType(readField(row, 'data_type'), readField(row, 'column_type')),
+      tsType: mapMysqlType(readField(row, 'data_type')),
       nullable: readField(row, 'is_nullable') === 'YES',
     });
     tables.set(tableName, table);

--- a/tests/cli-mysql-introspect.test.ts
+++ b/tests/cli-mysql-introspect.test.ts
@@ -27,7 +27,7 @@ describe('groupMysqlColumns', () => {
         name: 'users',
         columns: [
           { name: 'id', tsType: 'number', nullable: false },
-          { name: 'active', tsType: 'boolean', nullable: true },
+          { name: 'active', tsType: 'number', nullable: true },
         ],
       },
     ]);
@@ -67,7 +67,7 @@ describe('introspectMysql', () => {
     const columnsSql = query.mock.calls[1]?.[0] as string;
     expect(tablesSql).toContain("table_type = 'BASE TABLE'");
     expect(columnsSql).toContain("table_type = 'BASE TABLE'");
-    for (const column of ['table_name', 'column_name', 'data_type', 'column_type', 'is_nullable']) {
+    for (const column of ['table_name', 'column_name', 'data_type', 'is_nullable']) {
       expect(columnsSql).toContain(`${column} as ${column}`);
     }
     expect(tables.map((table) => table.name)).toEqual(['users', 'empty_t']);

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -54,29 +54,34 @@ describe('mapPostgresType', () => {
 
 describe('mapMysqlType', () => {
   it('maps ordinary integers and floats to number', () => {
-    expect(mapMysqlType('int', 'int(11)')).toBe('number');
-    expect(mapMysqlType('smallint', 'smallint(6)')).toBe('number');
+    expect(mapMysqlType('int')).toBe('number');
+    expect(mapMysqlType('smallint')).toBe('number');
   });
 
   it('maps decimal to string but bigint to number, matching mysql2 defaults', () => {
-    expect(mapMysqlType('decimal', 'decimal(10,2)')).toBe('string');
-    expect(mapMysqlType('bigint', 'bigint(20)')).toBe('number');
+    expect(mapMysqlType('decimal')).toBe('string');
+    expect(mapMysqlType('bigint')).toBe('number');
   });
 
-  it('maps tinyint(1) to boolean but other tinyint widths to number', () => {
-    expect(mapMysqlType('tinyint', 'tinyint(1)')).toBe('boolean');
-    expect(mapMysqlType('tinyint', 'tinyint(4)')).toBe('number');
+  it('maps every tinyint width to number, matching mysql2 defaults', () => {
+    // mysql2's stock parsers decode TINY as a plain number regardless of
+    // display width - tinyint(1) is not special-cased to boolean, since
+    // nothing actually casts it to one at runtime (#135).
+    expect(mapMysqlType('tinyint')).toBe('number');
   });
 
-  it('maps bit(1) to boolean but wider bit fields to Buffer', () => {
-    expect(mapMysqlType('bit', 'bit(1)')).toBe('boolean');
-    expect(mapMysqlType('bit', 'bit(8)')).toBe('Buffer');
+  it('maps bit to Buffer at every width, matching mysql2 defaults', () => {
+    // BIT has no dedicated case in mysql2's parsers, so it falls through to
+    // a raw Buffer - bit(1) is not special-cased to boolean, since a
+    // non-empty Buffer is always truthy regardless of the underlying byte
+    // (#135).
+    expect(mapMysqlType('bit')).toBe('Buffer');
   });
 
   it('maps date/time types and binary types', () => {
-    expect(mapMysqlType('datetime', 'datetime')).toBe('Date');
-    expect(mapMysqlType('time', 'time')).toBe('string');
-    expect(mapMysqlType('blob', 'blob')).toBe('Buffer');
+    expect(mapMysqlType('datetime')).toBe('Date');
+    expect(mapMysqlType('time')).toBe('string');
+    expect(mapMysqlType('blob')).toBe('Buffer');
   });
 });
 


### PR DESCRIPTION
Fixes #135

## Summary

`mapMysqlType` special-cased `tinyint(1)` and `bit(1)` columns to `boolean`. But `introspectMysql` connects via plain `createConnection(connection.url)` with no custom `typeCast` - and this library has no way to force one onto a connection at runtime either, since the actual query executor (`src/adapters/mysql2.ts`) is handed an already-created connection/pool by the caller, not one OwlSQL owns. mysql2's stock parsers (checked `node_modules/mysql2/lib/parsers/{text_parser,binary_parser}.js`) never actually produce a boolean for either:

- `TINY` (any display width, including `(1)`) always decodes to a plain JS **number**.
- `BIT` has no dedicated case in either parser's switch; it falls to the default branch and, since BIT columns report a BINARY charset, resolves to a raw **Buffer**.

The `Buffer` case is the dangerous one: a non-empty `Buffer` is always truthy in JS regardless of whether the underlying byte is `0x00` or `0x01`. Code trusting the generated `flag: boolean` type (`if (row.flag) { ... }`) silently treated every row as true.

## Fix

Dropped the special-casing entirely. `tinyint`/`bit` already had correct entries in `MYSQL_SCALAR_TYPES` (`number`/`Buffer`), so `mapMysqlType`'s existing fallback (`MYSQL_SCALAR_TYPES[type] ?? 'unknown'`) now handles both correctly with zero width inspection needed. Removed the now-unused `columnType` parameter and the `column_type` introspection query column along with it.

## Compounding issue (per the report)

`tests/cli-type-mapping.test.ts:66-74` asserted the wrong mapping as correct - the test suite passed by encoding the bug as expected behavior rather than catching it. Updated it (and `tests/cli-mysql-introspect.test.ts`, which had the same wrong expectation baked into a fixture-based test) to assert the mapping that actually matches mysql2's runtime output.

## Test plan

- `tests/cli-type-mapping.test.ts`: `tinyint` → `number` at every width, `bit` → `Buffer` at every width.
- `tests/cli-mysql-introspect.test.ts`: fixed the `active tinyint(1)` fixture's expected `tsType` from `boolean` to `number`; removed `column_type` from the SQL-column-aliasing assertion since it's no longer selected.
- Reverted `src/cli/dialects/mysql.ts` in isolation: 6 tests fail (5 via a hard crash from the now-incompatible 2-arg signature, 1 via the exact wrong-`tsType` assertion this issue describes). Restored and re-verified. `npm run test:types` clean, full `vitest run` 202/202 green.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>