### PR TITLE
fix(ts-plugin): anchor diagnostic offsets to raw source text, not cooked

### DIFF
--- a/src/ts-plugin/diagnostics.cts
+++ b/src/ts-plugin/diagnostics.cts
@@ -95,9 +95,15 @@ function getQueryDiagnostics(
   checker: ts.TypeChecker,
   dbType: ts.Type,
   literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral,
+  sourceFile: ts.SourceFile,
 ): DiagnosticSpan[] {
-  const literalStart = literal.getStart() + 1;
-  const text = literal.text;
+  const literalStart = literal.getStart(sourceFile) + 1;
+  // Read the raw source slice, not the node's cooked `.text` - `.text`
+  // normalizes CRLF line endings to LF and resolves escapes, so offsets
+  // computed against it drift out of alignment with literalStart (a raw
+  // source position) by one character per preceding line break on a CRLF
+  // file. Mirrors the same fix already applied to hover in index.cts.
+  const text = sourceFile.text.slice(literalStart, literal.getEnd() - 1);
   const { stripped } = stripStringLiterals(text);
 
   const fromIndex = findTopLevelFromIndex(stripped);

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -220,7 +220,7 @@ function init(modules: { typescript: typeof ts }) {
         const extra: ts.Diagnostic[] = [];
 
         for (const match of matches) {
-          for (const span of getQueryDiagnostics(checker, match.dbType, match.literal)) {
+          for (const span of getQueryDiagnostics(checker, match.dbType, match.literal, sourceFile)) {
             extra.push({
               file: sourceFile,
               start: span.start,

--- a/tests/ts-plugin-diagnostics.test.ts
+++ b/tests/ts-plugin-diagnostics.test.ts
@@ -32,7 +32,7 @@ function diagnosticsFor(query: string): { message: string; text: string }[] {
     expect(matches).toHaveLength(1);
     const [match] = matches;
     if (!match) return [];
-    return getQueryDiagnostics(checker, match.dbType, match.literal).map((span) => ({
+    return getQueryDiagnostics(checker, match.dbType, match.literal, sourceFile).map((span) => ({
       message: span.message,
       text: sourceFile.text.slice(span.start, span.start + span.length),
     }));
@@ -102,5 +102,17 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
 
   it('does not treat a -- inside a string literal as a comment', () => {
     expect(diagnosticsFor("select name from users where name = 'a -- not a comment'")).toEqual([]);
+  });
+
+  it('anchors the diagnostic span correctly across CRLF line breaks (issue #137 repro)', () => {
+    expect(diagnosticsFor('select id,\r\n  bogus_col\r\nfrom users')).toEqual([
+      { message: 'unknown column: bogus_col', text: 'bogus_col' },
+    ]);
+  });
+
+  it('anchors a second diagnostic after multiple preceding CRLF line breaks', () => {
+    expect(
+      diagnosticsFor('select id,\r\n  name,\r\n  nope\r\nfrom users\r\nwhere id = 1'),
+    ).toEqual([{ message: 'unknown column: nope', text: 'nope' }]);
   });
 });


### PR DESCRIPTION
Fixes #137

## Summary

`getQueryDiagnostics` (`src/ts-plugin/diagnostics.cts`) computed diagnostic spans from the template literal's **cooked** text (`literal.text`, which normalizes CRLF line endings to LF and resolves escapes) but anchored those offsets to a **raw** source position (`literal.getStart() + 1`). On a CRLF file, the cooked text is one character shorter than the raw source per preceding line break, so offsets computed against it drift out of alignment with `literalStart` - growing by one per line break before the offending token.

```ts
db.query(`select id,
  bogus_col
from users`);
```

On a CRLF file, the reported span for `bogus_col` doesn't line up with the raw source - slicing that exact range out of the actual file text yields a truncated/shifted substring instead of `bogus_col`.

This is exactly the raw-vs-cooked confusion `getQuickInfoAtPosition` already had to fix in `index.cts` (it slices `sourceFile.text` directly instead of using the cooked `.text`).

## Fix

Applied the identical fix: `getQueryDiagnostics` now also takes `sourceFile` and slices `sourceFile.text.slice(literalStart, literal.getEnd() - 1)` for all downstream offset math, instead of reading `literal.text`. Updated the one call site in `index.cts`'s `getSemanticDiagnostics` (which already has `sourceFile` in scope) to pass it through.

## Test plan

Added two CRLF regression tests to `tests/ts-plugin-diagnostics.test.ts`, using explicit `\r\n` in the query text so the repro doesn't depend on how the test file itself happens to be checked out:
- The issue's own repro shape (unknown column two lines into a CRLF query).
- A second diagnostic after multiple preceding CRLF line breaks, to make sure the drift (which grows per line break) doesn't just happen to cancel out for a single-break case.

Both assert on `text: sourceFile.text.slice(span.start, span.start + span.length)`, so a misaligned span shows up directly as the wrong substring rather than needing a separate offset assertion.

Reverted `src/ts-plugin/diagnostics.cts` + `src/ts-plugin/index.cts` in isolation (kept the updated test file) and confirmed both new tests fail exactly as expected. Restored and re-verified. `npm run test:types` clean, full `vitest run` 204/204 green.

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>