### PR TITLE
fix(case): recognize a CASE wrapped in parens as a case expression

### DIFF
--- a/src/case.ts
+++ b/src/case.ts
@@ -1,21 +1,33 @@
 import type { Trim, FirstWord, DropFirstWord, IsKeyword, Unquote } from './string.js';
 import type { SchemaLike, Source, ResolveColumnType } from './parse.js';
 
-export type IsCaseExpression<Expr extends string> = IsKeyword<FirstWord<Trim<Expr>>, 'case'>;
+// A nested CASE is often written wrapped in parens (`(case ... end)`), which
+// glues the paren onto the adjacent keyword token ("(case", "end)") since
+// there's no space between them. Stripping the attached paren before the
+// keyword comparison - without touching what gets accumulated into the body
+// text - lets `case`/`end` depth-tracking see through the wrapping the same
+// way it already does for a bare nested `case ... end`.
+type StripLeadingParens<S extends string> = S extends `(${infer Rest}` ? StripLeadingParens<Rest> : S;
+type StripTrailingParens<S extends string> = S extends `${infer Rest})` ? StripTrailingParens<Rest> : S;
+
+type IsCaseToken<Token extends string> = IsKeyword<StripLeadingParens<Token>, 'case'>;
+type IsEndToken<Token extends string> = IsKeyword<StripTrailingParens<Token>, 'end'>;
+
+export type IsCaseExpression<Expr extends string> = IsCaseToken<FirstWord<Trim<Expr>>>;
 
 type FindEnd<
   S extends string,
   Depth extends unknown[] = [],
   Accumulated extends string = '',
 > = S extends `${infer Head} ${infer Tail}`
-  ? IsKeyword<Head, 'case'> extends true
+  ? IsCaseToken<Head> extends true
     ? FindEnd<Tail, [...Depth, unknown], Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
-    : IsKeyword<Head, 'end'> extends true
+    : IsEndToken<Head> extends true
       ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
         ? FindEnd<Tail, DepthRest, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
         : { body: Trim<Accumulated>; rest: Trim<Tail> }
       : FindEnd<Tail, Depth, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
-  : IsKeyword<S, 'end'> extends true
+  : IsEndToken<S> extends true
     ? Depth extends []
       ? { body: Trim<Accumulated>; rest: '' }
       : never
@@ -43,9 +55,9 @@ type ScanCaseSegments<
   Accumulated extends CaseSegment[],
   Depth extends unknown[] = [],
 > = S extends `${infer Head} ${infer Tail}`
-  ? IsKeyword<Head, 'case'> extends true
+  ? IsCaseToken<Head> extends true
     ? ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated, [...Depth, unknown]>
-    : IsKeyword<Head, 'end'> extends true
+    : IsEndToken<Head> extends true
       ? Depth extends [unknown, ...infer DepthRest extends unknown[]]
         ? ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated, DepthRest>
         : ScanCaseSegments<Tail, CurrentKind, CurrentText extends '' ? Head : `${CurrentText} ${Head}`, Accumulated, Depth>

--- a/tests/case.test-d.ts
+++ b/tests/case.test-d.ts
@@ -76,6 +76,23 @@ type NestedCaseFollowedByOuterElse = Expect<
   >
 >;
 
+type NestedCaseWrappedInParens = Expect<
+  Equal<
+    Query<
+      DB,
+      "select case when active then (case when age < 18 then 'minor' else 'adult' end) else 'unknown' end as status from users"
+    >,
+    { status: string }[]
+  >
+>;
+
+type OuterCaseWrappedInParens = Expect<
+  Equal<
+    Query<DB, "select (case when active then 'yes' else 'no' end) as status from users">,
+    { status: string }[]
+  >
+>;
+
 export type CaseLock = [
   CaseWithLiterals,
   CaseWithoutElseIsNullable,
@@ -85,4 +102,6 @@ export type CaseLock = [
   CaseWithUnknownColumnFallsBackToUnknown,
   NestedCase,
   NestedCaseFollowedByOuterElse,
+  NestedCaseWrappedInParens,
+  OuterCaseWrappedInParens,
 ];


### PR DESCRIPTION
Fixes #167

## Summary

`IsCaseExpression`, `FindEnd`, and `ScanCaseSegments` (`src/case.ts`) all detected `case`/`end` boundaries with an exact-token match (`IsKeyword<Head, 'case'|'end'>`). A CASE wrapped in parens - a natural way to write one, and effectively required to nest a CASE inside a THEN/ELSE branch under some formatting styles - glues the paren onto the adjacent keyword (`"(case"`, `"end)"`), so none of the three recognized it:

- The nested-case depth counter never incremented, so the inner `WHEN`/`THEN` tokens got read as the *outer* CASE's own segment boundaries, shredding its branch text into garbage.
- A parenthesized CASE used as a whole SELECT-list entry (`select (case ... end) as status`) never got recognized as a case expression at all.

Both resolved to `unknown` instead of the real branch type.

## Fix

Strips a leading/trailing attached paren, but only for the keyword *comparison* - the text that gets accumulated into the body keeps its original parens, since `DropFirstWord`/token-consumption already discards them naturally once the matching `case`/`end` pair is found. No separate unwrap step needed.

## Test plan

- `NestedCaseWrappedInParens` - the issue's exact repro (CASE inside a THEN branch, wrapped in parens).
- `OuterCaseWrappedInParens` - a whole parenthesized CASE as a SELECT-list entry, which turned out to *also* be broken on old code (resolved to `unknown`) even though I expected the generic parenthesized-entry path to handle it - reverting confirmed both are real regressions, not one real + one redundant.
- Reverted `src/case.ts` in isolation: both new tests fail exactly as expected. Restored and re-verified. `npm run test:types` clean, full `vitest run` 209/209 green.