### PR TITLE
fix(functions): preserve the caller's casing in a function call's output name

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -49,7 +49,7 @@ export type FunctionName<Expr extends string> = Expr extends `${infer Name}(${st
   ? Trim<Name>
   : Expr;
 
-export type FunctionOutputName<Expr extends string> = Lowercase<FunctionName<Expr>>;
+export type FunctionOutputName<Expr extends string> = FunctionName<Expr>;
 
 export type FunctionReturnType<Expr extends string> =
   Lowercase<FunctionName<Expr>> extends keyof FunctionReturnTypes

--- a/tests/case-insensitive.test-d.ts
+++ b/tests/case-insensitive.test-d.ts
@@ -53,6 +53,14 @@ type UppercaseInsertParamsResolve = Expect<
   Equal<Params<DB, 'INSERT INTO USERS (NAME) VALUES ($1)'>, [string]>
 >;
 
+type UppercaseFunctionCallPreservesOutputCasing = Expect<
+  Equal<Query<DB, 'SELECT COUNT(*) FROM USERS'>, { COUNT: number }[]>
+>;
+
+type MixedCaseFunctionCallPreservesOutputCasing = Expect<
+  Equal<Query<DB, 'select Count(*) from users'>, { Count: number }[]>
+>;
+
 export type Assertions = [
   UppercaseTableAndColumnResolve,
   MixedCaseTableResolves,
@@ -63,4 +71,6 @@ export type Assertions = [
   StrictStillRejectsTrulyUnknownColumn,
   UppercaseParamColumnResolves,
   UppercaseInsertParamsResolve,
+  UppercaseFunctionCallPreservesOutputCasing,
+  MixedCaseFunctionCallPreservesOutputCasing,
 ];


### PR DESCRIPTION
Fixes #168

## Summary

`FunctionOutputName` (`src/functions.ts`) force-lowercased the synthesized output key for a function call, unlike every other unaliased identifier in this codebase - columns, tables, CTE names all preserve the exact casing the user typed, only doing case-insensitive *lookup* against the schema (`ResolveKey`/`CaseInsensitiveKey` in `src/parse.ts` explicitly return the original name on a case-insensitive match, never the schema's own casing).

```ts
Query<DB, 'SELECT ID FROM USERS'>        // keyof result: "ID" (case preserved)
Query<DB, 'SELECT COUNT(*) FROM USERS'>  // keyof result: "count" (force-lowercased!)
```

Both verified against the real `Query` type. There was no test anywhere in `tests/` for a function call written in anything but lowercase, so this asymmetry had never been caught either way.

## Fix

`FunctionOutputName` now returns `FunctionName<Expr>` as-is instead of `Lowercase<FunctionName<Expr>>`. `FunctionReturnType` (right below it) already looks up the lowercased form as the `FunctionReturnTypes` key separately and correctly - that part is untouched.

## Test plan

Added to `tests/case-insensitive.test-d.ts` (the existing home for this exact class of casing test): `SELECT COUNT(*) FROM USERS` → `{ COUNT: number }[]`, and a mixed-case `Count(*)` → `{ Count: number }[]`.

Reverted `src/functions.ts` in isolation: both new tests fail exactly as expected. Restored and re-verified. `npm run test:types` clean, full `vitest run` 209/209 green.