### PR TITLE
fix(from): strip a leading LATERAL keyword before parsing a derived table

### DIFF
--- a/src/from.ts
+++ b/src/from.ts
@@ -146,8 +146,18 @@ type DerivedSegmentToSource<Segment extends string, Nullable extends boolean> = 
     : never
   : never;
 
-type SegmentToSource<Segment extends string, Nullable extends boolean> = Trim<Segment> extends `(${string}`
-  ? DerivedSegmentToSource<Segment, Nullable>
+// `LATERAL` attaches directly to a derived-table subquery ("join lateral
+// (select ...) alias on ..."), so it has to be stripped before the "does
+// this segment start with a paren" check below - otherwise the keyword
+// itself gets read as the table name and the real alias is lost.
+type StripLateral<Segment extends string> = Trim<Segment> extends `${infer Head} ${infer Rest}`
+  ? IsKeyword<Head, 'lateral'> extends true
+    ? Trim<Rest>
+    : Trim<Segment>
+  : Trim<Segment>;
+
+type SegmentToSource<Segment extends string, Nullable extends boolean> = StripLateral<Segment> extends `(${string}`
+  ? DerivedSegmentToSource<StripLateral<Segment>, Nullable>
   : CleanIdentifier<FirstWord<Segment>> extends infer Table extends string
     ? {
         table: Table;

--- a/tests/derived-table.test-d.ts
+++ b/tests/derived-table.test-d.ts
@@ -1,4 +1,4 @@
-import type { Query } from '../src/index.js';
+import type { Query, StrictQuery } from '../src/index.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -44,9 +44,31 @@ type DerivedTableContainingItsOwnJoin = Expect<
   >
 >;
 
+type LateralJoinResolvesLikeAnyDerivedTable = Expect<
+  Equal<
+    Query<
+      DB,
+      'select u.name, p.top_views from users u join lateral (select max(views) as top_views from posts where posts.user_id = u.id) p on true'
+    >,
+    { name: string; top_views: number }[]
+  >
+>;
+
+type LateralJoinResolvesInStrictModeWithoutCorrelation = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select u.name, p.top_views from users u join lateral (select max(views) as top_views from posts) p on true'
+    >,
+    { name: string; top_views: number }[]
+  >
+>;
+
 export type DerivedTableLock = [
   SimpleDerivedTable,
   DerivedTableWithWhereClauseInside,
   DerivedTableJoinedWithRealTable,
   DerivedTableContainingItsOwnJoin,
+  LateralJoinResolvesLikeAnyDerivedTable,
+  LateralJoinResolvesInStrictModeWithoutCorrelation,
 ];


### PR DESCRIPTION
Fixes #170

## Summary

`SegmentToSource` decided whether a FROM-clause segment was a derived table purely by checking whether the trimmed text started with `(`. `join lateral (select ...) alias on ...` glues `LATERAL` onto the subquery with no space-separated marker that check could see, so the segment fell into the plain-table branch: `FirstWord` read `"lateral"` as the table name, and alias detection grabbed the first fragment of the subquery text (`"(select"`) as the alias. The real alias and the subquery text were both lost - no `derivedQuery` was ever produced, so the alias could never be resolved again downstream.

```ts
Query<DB, 'select u.name, o.total from users u join lateral (select sum(amount) as total from orders where orders.user_id = u.id) o on true'>
// { name: string; total: unknown }[] - `o` was never registered as a real alias
```

In strict mode this became `QueryTypeError<'unknown alias: o'>` - a false positive on valid, dialect-supported SQL (Postgres and MySQL 8+ both support `LATERAL`).

## Fix

Strips a leading case-insensitive `LATERAL` token before the paren check, so the segment parses exactly like a plain (non-lateral) derived table from that point on - which already works correctly and is tested.

## One caveat (documented, not silently swept under)

`LATERAL`'s whole point is letting the subquery reference a preceding FROM item's columns, and this codebase doesn't thread outer sources into a derived table's own WHERE validation at all today (lateral or not). So a *correlated* LATERAL subquery still fails strict-mode validation - with a confusing `"unknown column: total"` on the *outer* query rather than pointing at the real `"unknown alias: u"` cause (traced it: the subquery's own `QueryTypeError` leaks into the derived alias's pseudo-schema entry via `Flatten<...>`, and the outer column lookup against that broken entry produces the wrong-looking error). That's the same class of gap as the already-tracked "scalar subqueries in `WHERE` aren't typed" limitation - not something a parsing fix alone closes, and out of scope here.

## Test plan

- `LateralJoinResolvesLikeAnyDerivedTable` - loose mode, with the correlated repro from the issue (confirms the parsing fix: `top_views: number` resolves correctly).
- `LateralJoinResolvesInStrictModeWithoutCorrelation` - strict mode, with a LATERAL subquery that doesn't reference the outer alias (confirms strict mode works cleanly once nothing needs the outer-scope resolution this PR doesn't attempt).
- Reverted `src/from.ts` in isolation: both new tests fail exactly as expected. Restored and re-verified. `npm run test:types` clean, full `vitest run` 209/209 green.