### PR TITLE
fix(parse): register UPDATE ... FROM / DELETE ... USING's extra table as a source

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -169,6 +169,33 @@ type SingleSource<Table extends string> = [
   { table: CleanTargetIdentifier<Table>; alias: CleanTargetIdentifier<Table>; nullable: false },
 ];
 
+// Postgres/SQLite's `UPDATE t SET ... FROM other WHERE ...` and Postgres's
+// `DELETE FROM t USING other WHERE ...` both introduce an extra table that
+// isn't the statement's own single target. Depth-tracked (unlike
+// AfterKeyword) so a "from"/"using" inside a subquery in the SET list isn't
+// mistaken for the clause introducer.
+type SplitAtTopLevelKeyword<
+  S extends string,
+  Keyword extends string,
+  Depth extends unknown[] = [],
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? IsKeyword<Head, Keyword> extends true
+      ? { before: Trim<Accumulated>; after: Tail }
+      : SplitAtTopLevelKeyword<Tail, Keyword, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+    : SplitAtTopLevelKeyword<Tail, Keyword, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+  : Depth extends []
+    ? IsKeyword<S, Keyword> extends true
+      ? { before: Trim<Accumulated>; after: '' }
+      : never
+    : never;
+
+type ExtraSourcesAfterKeyword<S extends string, Keyword extends string> =
+  SplitAtTopLevelKeyword<S, Keyword> extends { after: infer AfterClause extends string }
+    ? ParseFromClause<AfterClause>
+    : [];
+
 export interface ParsedStatement {
   columns: string;
   sources: Source[];
@@ -204,13 +231,19 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
       : IsKeyword<Keyword, 'update'> extends true
         ? {
             columns: ReturningOrOutputColumns<S, 'where'>;
-            sources: SingleSource<WordAfterKeyword<S, 'update'>>;
+            sources: [
+              ...SingleSource<WordAfterKeyword<S, 'update'>>,
+              ...ExtraSourcesAfterKeyword<S, 'from'>,
+            ];
             whereText: ExtractUpdateDeleteWhereText<S>;
           }
         : IsKeyword<Keyword, 'delete'> extends true
           ? {
               columns: ReturningOrOutputColumns<S, 'where'>;
-              sources: SingleSource<WordAfterKeyword<S, 'from'>>;
+              sources: [
+                ...SingleSource<WordAfterKeyword<S, 'from'>>,
+                ...ExtraSourcesAfterKeyword<S, 'using'>,
+              ];
               whereText: ExtractUpdateDeleteWhereText<S>;
             }
           : never

--- a/tests/dml-target.test-d.ts
+++ b/tests/dml-target.test-d.ts
@@ -1,4 +1,4 @@
-import type { Query, Params } from '../src/index.js';
+import type { Query, Params, StrictQuery, QueryTypeError } from '../src/index.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -11,6 +11,11 @@ interface DB {
   users: {
     id: number;
     name: string;
+  };
+  accounts: {
+    id: number;
+    user_id: number;
+    balance: number;
   };
 }
 
@@ -60,6 +65,40 @@ type UnquotedInsertStillWorks = Expect<
   >
 >;
 
+type UpdateFromRegistersTheExtraTableAsASource = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'update users set name = name from accounts where accounts.user_id = users.id and accounts.balance > 100 returning users.id'
+    >,
+    { id: number }[]
+  >
+>;
+
+type DeleteUsingRegistersTheExtraTableAsASource = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'delete from users using accounts where accounts.user_id = users.id and accounts.balance < 0 returning users.id'
+    >,
+    { id: number }[]
+  >
+>;
+
+type UpdateFromStillRejectsATrulyUnknownAlias = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'update users set name = name from accounts where ghosts.id = users.id returning users.id'
+    >,
+    QueryTypeError<'unknown alias: ghosts'>[]
+  >
+>;
+
+type UpdateWithoutFromIsUnaffected = Expect<
+  Equal<Query<DB, 'update users set name = $1 where id = $2'>, Record<string, never>[]>
+>;
+
 export type Assertions = [
   SchemaQualifiedInsertResolvesReturning,
   QuotedInsertTargetResolvesReturning,
@@ -68,4 +107,8 @@ export type Assertions = [
   SchemaQualifiedDeleteResolvesReturning,
   SchemaQualifiedInsertParamsResolve,
   UnquotedInsertStillWorks,
+  UpdateFromRegistersTheExtraTableAsASource,
+  DeleteUsingRegistersTheExtraTableAsASource,
+  UpdateFromStillRejectsATrulyUnknownAlias,
+  UpdateWithoutFromIsUnaffected,
 ];


### PR DESCRIPTION
Fixes #158

## Summary

`ParseStatementNormalized`'s UPDATE and DELETE branches only ever recorded a single source - the statement's own target table. Postgres and SQLite both support `UPDATE t SET ... FROM other WHERE t.id = other.id` and `DELETE FROM t USING other WHERE t.id = other.id` - the extra table introduced by `FROM`/`USING` never got added to `sources`, so nothing downstream knew it existed.

```ts
StrictQuery<DB, "update users set balance = 0 from accounts where accounts.user_id = 1 returning users.id">
// QueryTypeError<'unknown alias: accounts'>[]
```

`accounts` is a real, legitimately joined table - this is valid SQL in both engines. Same result for `DELETE ... USING`.

## Fix

Added `SplitAtTopLevelKeyword`, a depth-tracked scan (same `ApplyParenDelta` pattern `ColumnsBeforeFrom` already uses for `SELECT`'s `FROM` detection) that finds the first `FROM`/`USING` at paren-depth 0 - so one appearing inside a subquery in the `SET` list or `WHERE` clause is correctly skipped rather than mistaken for the clause introducer. When found, the remaining text is handed to the existing `ParseFromClause`, which already knows how to parse a comma-list or `JOIN` chain and self-terminates at the next clause boundary (`WHERE`, `GROUP BY`, ...) - no new boundary-detection logic needed.

## Test plan

- `UpdateFromRegistersTheExtraTableAsASource` / `DeleteUsingRegistersTheExtraTableAsASource` - the issue's repro for both statement types, in strict mode with `RETURNING`.
- `UpdateFromStillRejectsATrulyUnknownAlias` - a genuinely unknown alias in the same shape still correctly errors (confirms the fix isn't overly permissive).
- `UpdateWithoutFromIsUnaffected` - a plain `UPDATE` with no `FROM` clause is untouched.
- Reverted `src/parse.ts` in isolation: the two regression tests fail exactly as expected; the two guard tests pass on both old and new code. Restored and re-verified. `npm run test:types` clean, full `vitest run` 209/209 green.