### PR TITLE
fix(parse): a CTE reusing a real table's name now shadows it

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -712,6 +712,22 @@ type IsSelectAll<Columns extends string> = Trim<Columns> extends '*' ? true : fa
 
 type EmptyRow = Record<string, never>;
 
+// A CTE shadows a real table of the same name for the rest of the query -
+// only its own projected columns stay visible. Merging the CTE map into DB
+// with a plain intersection doesn't do that: object intersection is
+// additive, so DB['users'] & CteRow<...> still exposes every field of the
+// *original* users table, including ones the CTE's own query never
+// selected. Omitting the shadowed keys first (case-insensitively, matching
+// how every other name lookup in this codebase already resolves) before
+// intersecting closes that gap.
+type OmitShadowedTables<DB, ShadowedNames extends string> = {
+  [Key in keyof DB as Key extends string
+    ? Lowercase<Key> extends Lowercase<ShadowedNames>
+      ? never
+      : Key
+    : Key]: DB[Key];
+};
+
 export type ResolveCteContext<
   DB extends SchemaLike,
   Q extends string,
@@ -722,7 +738,10 @@ export type ResolveCteContext<
         ctes: infer Ctes extends [string, string, string[] | null][];
         rest: infer Rest extends string;
       }
-    ? { db: DB & BuildCteMap<DB, Ctes, Strict>; query: Rest }
+    ? {
+        db: OmitShadowedTables<DB, Ctes[number][0]> & BuildCteMap<DB, Ctes, Strict>;
+        query: Rest;
+      }
     : { db: DB; query: Normalize<Q> };
 
 type BuildDerivedSourceMap<

--- a/tests/cte.test-d.ts
+++ b/tests/cte.test-d.ts
@@ -108,6 +108,34 @@ type ParamsInsideAndAfterCteBodyBothTypeInTextualOrder = Expect<
   >
 >;
 
+type CteReusingARealTableNameShadowsIt = Expect<
+  Equal<
+    StrictQuery<DB, 'with users as (select id from posts) select name from users'>,
+    QueryTypeError<'unknown column: name'>[]
+  >
+>;
+
+type CteReusingARealTableNameStillExposesItsOwnColumns = Expect<
+  Equal<
+    StrictQuery<DB, 'with users as (select id from posts) select id from users'>,
+    { id: number }[]
+  >
+>;
+
+type CteShadowingIsCaseInsensitive = Expect<
+  Equal<
+    StrictQuery<DB, 'with Users as (select id from posts) select name from Users'>,
+    QueryTypeError<'unknown column: name'>[]
+  >
+>;
+
+type UnrelatedCteNameLeavesRealTablesAlone = Expect<
+  Equal<
+    StrictQuery<DB, 'with totals as (select id from posts) select name from users'>,
+    { name: string }[]
+  >
+>;
+
 export type CteLock = [
   SimpleCte,
   CteWithJoinAgainstRealTable,
@@ -121,4 +149,8 @@ export type CteLock = [
   ParamAfterMultipleCtesStillResolves,
   ParamInsideCteBodyIsTypedAgainstItsOwnSource,
   ParamsInsideAndAfterCteBodyBothTypeInTextualOrder,
+  CteReusingARealTableNameShadowsIt,
+  CteReusingARealTableNameStillExposesItsOwnColumns,
+  CteShadowingIsCaseInsensitive,
+  UnrelatedCteNameLeavesRealTablesAlone,
 ];


### PR DESCRIPTION
Fixes #171

## Summary

Per the SQL standard, a CTE named the same as an existing table completely shadows that table for the rest of the query - only the CTE's own projected columns stay visible. `ResolveCteContext` merged the CTE map into the schema via a plain intersection (`DB & BuildCteMap<...>`), and object intersection in TypeScript is additive: `DB['users'] & CteRow<...>` still exposed every field of the *original* `users` table, including fields the CTE's own query never selected.

```ts
StrictQuery<DB, 'with users as (select id from orders) select name from users'>
// { name: string }[] - no error, in either mode
```

The CTE named `users` only ever selects `id` from `orders`. Real Postgres/MySQL/SQLite/SQL Server would all reject `select name from users` here with "column name does not exist" - `name` resolved against the leftover field of the real `users` table because `{ id: number; name: string; email: string } & { id: number }` simplifies right back to the full original shape.

This is worse than the library's more common "falls back to `unknown`" failure mode - it's not vague, it's confidently and specifically wrong, and it survived strict mode, whose entire purpose is catching exactly this class of reference error.

## Fix

Added `OmitShadowedTables`, which drops a CTE's shadowed key from `DB` before intersecting with `BuildCteMap`'s result - case-insensitively, matching how every other name lookup in this codebase already resolves (`ResolveKey`/`CaseInsensitiveKey`). A CTE name that doesn't collide with anything is a no-op (`Omit` against a non-existent key changes nothing), so this only takes effect for the actual shadowing case.

## Test plan

- `CteReusingARealTableNameShadowsIt` - the issue's exact repro, now correctly a `QueryTypeError`.
- `CteReusingARealTableNameStillExposesItsOwnColumns` - the CTE's own selected column (`id`) still resolves fine.
- `CteShadowingIsCaseInsensitive` - a case-different collision (`Users` CTE vs. `users` table) is caught too.
- `UnrelatedCteNameLeavesRealTablesAlone` - a non-colliding CTE name doesn't touch real tables at all.
- Reverted `src/parse.ts` in isolation: the primary regression test fails exactly as expected; the other three (guard tests for the still-correct paths) pass on both old and new code. Restored and re-verified. `npm run test:types` clean, full `vitest run` 209/209 green.