### PR TITLE
fix(cli): match Postgres array/numeric[]/interval type mapping to pg's actual decode

### DIFF
--- a/src/cli/dialects/postgres.ts
+++ b/src/cli/dialects/postgres.ts
@@ -25,7 +25,9 @@ const POSTGRES_SCALAR_TYPES: Record<string, string> = {
   date: 'Date',
   time: 'string',
   timetz: 'string',
-  interval: 'string',
+  // interval decodes to a structured { years, months, days, ... } object at
+  // both scalar and array positions (the `postgres-interval` package), not a
+  // string - see POSTGRES_SCALAR_TYPES lookup below, which special-cases it.
   inet: 'string',
   cidr: 'string',
   macaddr: 'string',
@@ -37,8 +39,55 @@ const POSTGRES_SCALAR_TYPES: Record<string, string> = {
   oid: 'number',
 };
 
+// pg only decodes an array column into a real JS array for the base types
+// pg-types has a static OID registered for (verified against every
+// register(...) call in pg-types/lib/textParsers.js). Everything else -
+// including enum arrays, whose OIDs are assigned per-database at CREATE TYPE
+// time and can never be statically registered - falls through to pg-types'
+// unregistered-OID fallback, which hands back the raw wire-format string
+// ("{happy,sad}"), not an array.
+const POSTGRES_ARRAY_SAFE_TYPES: ReadonlySet<string> = new Set([
+  'int2',
+  'int4',
+  'int8',
+  'oid',
+  'float4',
+  'float8',
+  'bool',
+  'text',
+  'varchar',
+  'bpchar',
+  'uuid',
+  'money',
+  'bytea',
+  'timestamp',
+  'timestamptz',
+  'date',
+  'time',
+  'timetz',
+  'inet',
+  'cidr',
+  'macaddr',
+  'json',
+  'jsonb',
+  'interval',
+]);
+
+// numeric[] decodes element-wise with parseFloat (real numbers), unlike the
+// scalar numeric mapping ('string', to avoid precision loss).
+const POSTGRES_ARRAY_TYPE_OVERRIDES: Record<string, string> = {
+  numeric: 'number',
+};
+
 function renderEnumUnion(labels: string[]): string {
   return labels.map((label) => `'${label.replace(/'/g, "\\'")}'`).join(' | ');
+}
+
+function scalarType(base: string): string {
+  if (base === 'interval') {
+    return 'unknown';
+  }
+  return POSTGRES_SCALAR_TYPES[base] ?? 'unknown';
 }
 
 export function mapPostgresType(udtName: string, enums?: Map<string, string[]>): string {
@@ -48,11 +97,19 @@ export function mapPostgresType(udtName: string, enums?: Map<string, string[]>):
   const labels = enums?.get(base);
   if (labels && labels.length > 0) {
     const union = renderEnumUnion(labels);
-    return isArray ? `(${union})[]` : union;
+    return isArray ? 'string' : union;
   }
 
-  const scalar = POSTGRES_SCALAR_TYPES[base] ?? 'unknown';
-  return isArray ? `${scalar}[]` : scalar;
+  if (!isArray) {
+    return scalarType(base);
+  }
+
+  const override = POSTGRES_ARRAY_TYPE_OVERRIDES[base];
+  if (override) {
+    return `${override}[]`;
+  }
+
+  return POSTGRES_ARRAY_SAFE_TYPES.has(base) ? `${scalarType(base)}[]` : 'string';
 }
 
 interface PgColumnRow {

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -29,26 +29,54 @@ describe('mapPostgresType', () => {
     expect(mapPostgresType('timetz')).toBe('string');
   });
 
-  it('maps array udt names (leading underscore) to T[]', () => {
+  it('maps array udt names (leading underscore) to T[] when pg actually decodes them as arrays', () => {
     expect(mapPostgresType('_int4')).toBe('number[]');
     expect(mapPostgresType('_text')).toBe('string[]');
+    expect(mapPostgresType('_bool')).toBe('boolean[]');
+    expect(mapPostgresType('_timestamptz')).toBe('Date[]');
   });
 
   it('falls back to unknown for unrecognized types', () => {
     expect(mapPostgresType('some_custom_domain')).toBe('unknown');
   });
 
-  it('maps network, interval, bit and text-search types to string', () => {
+  it('maps network, bit and text-search types to string', () => {
     expect(mapPostgresType('inet')).toBe('string');
-    expect(mapPostgresType('interval')).toBe('string');
     expect(mapPostgresType('tsvector')).toBe('string');
     expect(mapPostgresType('oid')).toBe('number');
+  });
+
+  it('maps interval to unknown, not string - pg decodes it to a structured object', () => {
+    expect(mapPostgresType('interval')).toBe('unknown');
+    expect(mapPostgresType('_interval')).toBe('unknown[]');
+  });
+
+  it('maps numeric[] to number[], unlike the scalar numeric mapping to string', () => {
+    expect(mapPostgresType('numeric')).toBe('string');
+    expect(mapPostgresType('_numeric')).toBe('number[]');
+  });
+
+  it('maps an array type with no registered pg-types array parser to the raw string pg returns, not T[]', () => {
+    // bit/varbit/macaddr8/name/xml/tsvector/tsquery/citext/single-char "char"
+    // have no array OID registered in pg-types - pg hands back the raw
+    // wire-format string ("{a,b}"), never an actual array.
+    expect(mapPostgresType('_bit')).toBe('string');
+    expect(mapPostgresType('_varbit')).toBe('string');
+    expect(mapPostgresType('_macaddr8')).toBe('string');
+    expect(mapPostgresType('_name')).toBe('string');
+    expect(mapPostgresType('_xml')).toBe('string');
+    expect(mapPostgresType('_tsvector')).toBe('string');
+    expect(mapPostgresType('_char')).toBe('string');
   });
 
   it('maps enums to a label union when the enum map is provided', () => {
     const enums = new Map([['mood', ['happy', 'sad']]]);
     expect(mapPostgresType('mood', enums)).toBe("'happy' | 'sad'");
-    expect(mapPostgresType('_mood', enums)).toBe("('happy' | 'sad')[]");
+  });
+
+  it('maps an enum array to the raw string pg returns - enum OIDs are dynamic and never registered as arrays', () => {
+    const enums = new Map([['mood', ['happy', 'sad']]]);
+    expect(mapPostgresType('_mood', enums)).toBe('string');
   });
 });
 


### PR DESCRIPTION
Fixes #159

## Summary

`mapPostgresType` generically appended `[]` to the scalar type mapping for any array column (a leading-underscore `udt_name`), and mapped `interval` to `string`. Both claim types `pg` doesn't actually produce by default. Checked against every `register(...)` call in `pg-types/lib/textParsers.js` and verified the resulting element types at runtime (`pg-types` is a direct dependency of `pg`, so this is exactly what a real `pg` client returns with no custom `typeCast`):

**Most array types decode as a raw wire-format string, not an array.** `pg` resolves a column's parser by static OID lookup, and only ~25 array OIDs are registered. Enum array OIDs are assigned per-database at `CREATE TYPE` time and can never be in that static list:

```sql
create type mood as enum ('happy','sad');
create table t (moods mood[]);
```
Generated: `moods: ('happy' | 'sad')[]`. Actual runtime value: `"{happy,sad}"` (a string). `row.moods.map(...)` throws. Same problem for `bit[]`, `varbit[]`, `macaddr8[]`, `name[]`, `xml[]`, `tsvector[]`, `tsquery[]`, and single-char `"char"[]`.

**`numeric[]` decodes to `number[]`, not `string[]`.** The scalar `numeric` mapping to `'string'` is correct (kept as a string specifically to avoid precision loss). But OID 1231 (`_numeric`) is registered to `parseFloatArray`, so the array form was silently producing the wrong element type in the *other* direction.

**`interval` decodes to a structured object, not a string** - `{ years, months, days, hours, minutes, seconds }` via the `postgres-interval` package - at both scalar and array positions.

## Fix

Replaced the blanket "any array → `T[]`" assumption with `POSTGRES_ARRAY_SAFE_TYPES`, an explicit allowlist of base types whose array form is registered and decodes to the naive `T[]` shape, plus a small override table for the `numeric[]` divergence. Anything not on the allowlist (enums included) now maps to `'string'`, matching `pg-types`' actual `noParse` fallback.

## Test plan

`tests/cli-type-mapping.test.ts` previously asserted the wrong mappings as correct for `interval` and enum arrays - the same "test encodes the bug as expected behavior" pattern already fixed once for MySQL's tinyint/bit (#135). Corrected both, and added coverage for: `numeric[]` → `number[]`, the unregistered-array fallback across `bit`/`varbit`/`macaddr8`/`name`/`xml`/`tsvector`/single-char `char`, and confirmed the still-correct cases (`bool[]`, `timestamptz[]`) stay right.

Reverted `src/cli/dialects/postgres.ts` in isolation: exactly the 4 new tests fail, matching the 4 distinct bug categories. Restored and re-verified. `npm run test:types` clean, full `vitest run` 213/213 green.