### PR TITLE
fix(cli): map SQLite BLOB to Uint8Array, not Buffer

### DIFF
--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -21,7 +21,10 @@ export function mapSqliteType(declaredType: string): string {
   }
 
   if (type.includes('BLOB') || type === '') {
-    return 'Buffer';
+    // node:sqlite has no typeCast hook (same constraint as mysql2, #135) -
+    // its documented output type for a blob column is a plain Uint8Array,
+    // never a Buffer instance (@types/node/sqlite.d.ts's SQLOutputValue).
+    return 'Uint8Array';
   }
 
   if (type.includes('REAL') || type.includes('FLOA') || type.includes('DOUB')) {

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -91,8 +91,15 @@ describe('mapSqliteType', () => {
     expect(mapSqliteType('VARCHAR(255)')).toBe('string');
     expect(mapSqliteType('TEXT')).toBe('string');
     expect(mapSqliteType('REAL')).toBe('number');
-    expect(mapSqliteType('BLOB')).toBe('Buffer');
-    expect(mapSqliteType('')).toBe('Buffer');
+  });
+
+  it('maps BLOB and untyped columns to Uint8Array, matching node:sqlite output', () => {
+    // node:sqlite returns a plain Uint8Array for a blob column, not a
+    // Buffer instance - Buffer extends Uint8Array, not the other way
+    // around, so `instanceof Buffer` is false and Buffer-only methods
+    // (.toString('hex'), etc.) aren't there (#160).
+    expect(mapSqliteType('BLOB')).toBe('Uint8Array');
+    expect(mapSqliteType('')).toBe('Uint8Array');
   });
 
   it('special-cases BOOLEAN and DATE-like declared types', () => {


### PR DESCRIPTION
Fixes #160

## Summary

`mapSqliteType` mapped `BLOB` (and an untyped/empty declared column) to `'Buffer'`. `node:sqlite` has no `typeCast` hook - the same constraint as the mysql2 case in #135 - and its documented output type for a blob column is a plain `Uint8Array` (`@types/node/sqlite.d.ts`'s `SQLOutputValue = null | number | bigint | string | NodeJS.NonSharedUint8Array`), never a `Buffer` instance.

`Buffer` extends `Uint8Array`, not the other way around, so `row.data instanceof Buffer` is `false` and `Buffer`-only methods aren't there - `row.data.toString('hex')` doesn't hex-encode, it silently falls back to `Array.prototype.toString`, producing `"0,1,2,255"` instead of a hex string.

```sql
create table files (data BLOB);
```
Generated: `data: Buffer`. Actual: `db.prepare('select data from files').get().data` is a `Uint8Array`.

## Fix

Map to `Uint8Array` instead.

## Test plan

`tests/cli-type-mapping.test.ts` asserted the wrong mapping as correct - same "test encodes the bug as expected behavior" pattern already fixed for MySQL's tinyint/bit and Postgres's array/interval mappings. Corrected it.

Reverted `src/cli/dialects/sqlite.ts` in isolation: the new test fails exactly as expected. Restored and re-verified. `npm run test:types` clean, full `vitest run` 210/210 green.