### PR TITLE
fix(adapters): normalize an undefined parameter to null consistently

### DIFF
--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -17,7 +17,11 @@ function writeMeta(header: { affectedRows?: number; insertId?: number }): QueryM
 
 export function createMysql2Executor(connection: Mysql2Queryable): DialectExecutor<'question'> {
   return async (sql, params) => {
-    const [rows] = await connection.execute(sql, params as ExecuteValues);
+    // mysql2 throws on a raw undefined parameter ("Bind parameters must not
+    // contain undefined") - normalize to null, matching
+    // mssql.ts/node-sqlite.ts.
+    const values = params.map((value) => value ?? null);
+    const [rows] = await connection.execute(sql, values as ExecuteValues);
     if (Array.isArray(rows)) {
       return rows;
     }

--- a/src/adapters/pg.ts
+++ b/src/adapters/pg.ts
@@ -6,7 +6,14 @@ export type PgQueryable = Pool | Client | PoolClient;
 export function createPgExecutor(client: PgQueryable): DialectExecutor<'dollar'> {
   return async (sql, params) => {
     const result =
-      params.length === 0 ? await client.query(sql) : await client.query(sql, params as unknown[]);
+      params.length === 0
+        ? await client.query(sql)
+        : // pg already treats undefined the same as null on its own, so this
+          // is a no-op for pg specifically - normalized anyway for
+          // consistency with every other adapter (mssql.ts and
+          // node-sqlite.ts already do this explicitly; postgres.js and
+          // mysql2 throw on a raw undefined without it).
+          await client.query(sql, params.map((value) => value ?? null) as unknown[]);
 
     return {
       rows: result.rows,

--- a/src/adapters/postgres.ts
+++ b/src/adapters/postgres.ts
@@ -5,7 +5,10 @@ type PostgresUnsafeParam = NonNullable<Parameters<postgres.Sql['unsafe']>[1]>[nu
 
 export function createPostgresJsExecutor(client: postgres.Sql): DialectExecutor<'dollar'> {
   return async (sql, params) => {
-    const result = await client.unsafe(sql, params as unknown as PostgresUnsafeParam[]);
+    // postgres.js throws on a raw undefined parameter ("Undefined values are
+    // not allowed") - normalize to null, matching mssql.ts/node-sqlite.ts.
+    const values = params.map((value) => value ?? null);
+    const result = await client.unsafe(sql, values as unknown as PostgresUnsafeParam[]);
     return {
       rows: [...result],
       meta: typeof result.count === 'number' ? { rowCount: result.count } : {},

--- a/tests/adapter-mysql2.test.ts
+++ b/tests/adapter-mysql2.test.ts
@@ -37,4 +37,16 @@ describe('createMysql2Executor', () => {
 
     expect(execute).toHaveBeenCalledWith('select id from users where id = ?', [7]);
   });
+
+  it('normalizes an undefined param to null - mysql2 throws on a raw undefined', async () => {
+    const { pool, execute } = fakePool([]);
+
+    const executor = createMysql2Executor(pool);
+    await executor('select id from users where id = ? and name = ?', [7, undefined]);
+
+    expect(execute).toHaveBeenCalledWith('select id from users where id = ? and name = ?', [
+      7,
+      null,
+    ]);
+  });
 });

--- a/tests/adapter-pg.test.ts
+++ b/tests/adapter-pg.test.ts
@@ -46,4 +46,16 @@ describe('createPgExecutor', () => {
 
     expect(query).toHaveBeenCalledWith('select id from users where id = $1', [7]);
   });
+
+  it('normalizes an undefined param to null, matching mssql/node-sqlite', async () => {
+    const { pool, query } = fakePool({ rows: [], rowCount: 0 });
+    const executor = createPgExecutor(pool);
+
+    await executor('select id from users where id = $1 and name = $2', [7, undefined]);
+
+    expect(query).toHaveBeenCalledWith('select id from users where id = $1 and name = $2', [
+      7,
+      null,
+    ]);
+  });
 });

--- a/tests/adapter-postgres.test.ts
+++ b/tests/adapter-postgres.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import type postgres from 'postgres';
+import { createPostgresJsExecutor } from '../src/adapters/postgres.js';
+
+function fakeClient(rows: unknown[], count: number | null): {
+  client: postgres.Sql;
+  unsafe: ReturnType<typeof vi.fn>;
+} {
+  const result = Object.assign([...rows], { count });
+  const unsafe = vi.fn().mockResolvedValue(result);
+  return { client: { unsafe } as unknown as postgres.Sql, unsafe };
+}
+
+describe('createPostgresJsExecutor', () => {
+  it('passes rows and rowCount metadata through', async () => {
+    const { client } = fakeClient([{ id: 1 }], 1);
+    const executor = createPostgresJsExecutor(client);
+
+    const result = await executor('select id from users where id = $1', [1]);
+
+    expect(result).toEqual({ rows: [{ id: 1 }], meta: { rowCount: 1 } });
+  });
+
+  it('normalizes an undefined param to null - postgres.js throws on a raw undefined', async () => {
+    const { client, unsafe } = fakeClient([], 0);
+    const executor = createPostgresJsExecutor(client);
+
+    await executor('select id from users where id = $1 and name = $2', [7, undefined]);
+
+    expect(unsafe).toHaveBeenCalledWith('select id from users where id = $1 and name = $2', [
+      7,
+      null,
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #162

## Summary

`mssql.ts` and `node-sqlite.ts` both explicitly normalize a missing/`undefined` parameter to `null` before handing it to the driver. `pg.ts`, `postgres.ts`, and `mysql2.ts` didn't, and the underlying drivers disagree on what a raw `undefined` does:

- `pg` treats `null` and `undefined` as equivalent (`pg/lib/utils.js`) - this was already a no-op there.
- `postgres.js` throws `UNDEFINED_VALUE` ("Undefined values are not allowed").
- `mysql2` throws synchronously ("Bind parameters must not contain undefined").

Both throws get caught by `createTypedDb`'s try/catch and surfaced as a normal `EXECUTOR_FAILED` result - nothing crashes or silently corrupts data - but the actual behavior of passing `undefined` for a parameter depended entirely on which adapter was in use, and that wasn't documented anywhere.

## Fix

Normalized all three the same way (`value ?? null`), matching the pattern `mssql.ts`/`node-sqlite.ts` already established.

## Test plan

- New tests in `tests/adapter-pg.test.ts` and `tests/adapter-mysql2.test.ts` confirming an `undefined` param is sent to the driver as `null`.
- `tests/adapter-postgres.test.ts` - this adapter had zero direct unit test coverage before, so I added a small file (basic pass-through + the undefined-normalization case) since I needed it to verify this specific change.
- Reverted all three adapter files in isolation: all three new tests fail exactly as expected (the driver mock receives `undefined` instead of `null`). Restored and re-verified. `npm run test:types` clean, full `vitest run` 213/213 green.