### PR TITLE
fix(docs): correct the Kysely adapter's dialect-independence claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,9 +587,22 @@ const kysely = new Kysely<KyselySchema>({ dialect: new PostgresDialect({ /* ... 
 const db = createTypedDb<DB>(createKyselyExecutor(kysely));
 ```
 
-The adapter runs your query through `CompiledQuery.raw`, so it works
-regardless of which Kysely dialect (`PostgresDialect`, `MysqlDialect`,
-`SqliteDialect`, ...) you configured.
+The adapter runs your query through `CompiledQuery.raw`, which forwards the
+SQL text and parameters straight to the underlying driver with **no
+placeholder translation** — the SQL you write still has to use whichever
+placeholder syntax your configured dialect's own driver expects (`$1` for
+`PostgresDialect`, `?` for `MysqlDialect`/`SqliteDialect`). What the adapter
+does *not* care about is which Kysely dialect object you passed in; it just
+relays whatever string you give it.
+
+If you want the same compile-time protection against using the wrong
+placeholder style that the other adapters get, pass `placeholders` to
+`createTypedDb` the same way you would for any of them — it's driven by
+that option, not by which adapter produced the executor:
+
+```ts
+const db = createTypedDb<DB, { placeholders: 'question' }>(createKyselyExecutor(kysely));
+```
 
 **Drizzle (raw SQL)**
 

--- a/tests/dialect-brand.test-d.ts
+++ b/tests/dialect-brand.test-d.ts
@@ -1,10 +1,13 @@
 import { createTypedDb, type Executor } from '../src/index.js';
+import { createKyselyExecutor } from '../src/adapters/kysely.js';
+import type { Kysely } from 'kysely';
 
 interface DB {
   users: { id: number; name: string };
 }
 
 declare const executor: Executor;
+declare const kysely: Kysely<{ users: { id: number; name: string } }>;
 
 export async function placeholderStyleCallSites() {
   const pgDb = createTypedDb<DB, { placeholders: 'dollar' }>(executor);
@@ -30,4 +33,18 @@ export async function placeholderStyleCallSites() {
   await pgDb.query('select id, name from users');
 
   await pgDb.query("select id from users where name = 'why?'");
+
+  // Placeholder-style checking is driven entirely by the `placeholders`
+  // option passed to createTypedDb, not by anything the adapter itself
+  // declares - so it already applies to Kysely (or any adapter) the same
+  // way, with no special-casing needed (#161).
+  const kyselyMysqlDb = createTypedDb<DB, { placeholders: 'question' }>(
+    createKyselyExecutor(kysely),
+  );
+
+  await kyselyMysqlDb.query('select id from users where id = ?', 1);
+
+  // @ts-expect-error a question-style client rejects $n placeholders, even
+  // through the Kysely adapter
+  await kyselyMysqlDb.query('select id from users where id = $1', 1);
 }


### PR DESCRIPTION
Fixes #161

## Summary

README claimed the Kysely adapter "works regardless of which Kysely dialect you configured" because it runs queries through `CompiledQuery.raw`. Traced `CompiledQuery.raw` through Kysely's own postgres/mysql/sqlite drivers (`kysely/dist/dialect/{postgres,mysql,sqlite}/*-driver.js`): the SQL text and parameters are forwarded verbatim to the underlying driver (`pg.query`, mysql2 `execute`, `better-sqlite3`'s `stmt.all`) with **no placeholder translation**. The SQL you write still has to use whichever placeholder syntax the *configured dialect's own driver* expects (`$1` for Postgres, `?` for MySQL/SQLite) - a MySQL-backed Kysely instance queried with `$1`-style SQL through this adapter compiles fine and fails at runtime.

What `CompiledQuery.raw` actually buys you is that the adapter doesn't care *which dialect object* you passed in - it just relays whatever string you give it, regardless of dialect. That's a narrower (and different) guarantee than "works regardless of dialect."

## Fix

Corrected the README wording, and documented that `createTypedDb`'s `placeholders` option already protects Kysely users the same way it protects every other adapter - added a Kysely-specific `@ts-expect-error` case to `tests/dialect-brand.test-d.ts` proving it.

## A correction to my own original issue

I'd originally assumed `createKyselyExecutor` returning a plain `Executor` (not `DialectExecutor<Style>`, unlike the other adapters) meant placeholder-style checking couldn't apply to Kysely at all, and planned to widen its return type to match the others. Tracing `createTypedDb`'s actual signature shows that's wrong: its `executor` parameter is typed as plain `Executor` (not generic), and the `Style` used for checking comes entirely from the `placeholders` option the *caller* passes to `createTypedDb` - never from inspecting the executor argument's own type. None of the `DialectExecutor<Style>` brands any adapter returns are ever actually read by `createTypedDb`; they're documentation-by-type for whoever's writing the adapter call site, not a functional gate.

So there was no real code gap here beyond the README's wording - verified this by testing `createTypedDb<DB, { placeholders: 'question' }>(createKyselyExecutor(kysely))` against the *current, unmodified* adapter and confirming the `@ts-expect-error` on a `$1`-style query already fires correctly. No source change needed; this PR is docs + a test proving the existing behavior.

## Test plan

`npm run test:types` clean, full `vitest run` 209/209 green.