### PR TITLE
Fix ts-plugin string masking to honor backslash-escaped quotes

### DIFF
--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -59,18 +59,25 @@ interface StrippedText {
 function stripStringLiterals(text: string): StrippedText {
   let stripped = '';
   let insideLiteral = false;
+  // Count of consecutive backslash characters immediately preceding the
+  // current position, so a quote closing a literal can be told apart from
+  // one escaped by MySQL's default \' - mirrors EndsWithOddBackslashes in
+  // src/string.ts, which the type-level parser already relies on for the
+  // same reason. Only meaningful while insideLiteral is true.
+  let precedingBackslashes = 0;
   let i = 0;
 
   while (i < text.length) {
     const char = text[i];
 
     if (insideLiteral) {
-      if (char === "'") {
+      if (char === "'" && precedingBackslashes % 2 === 0) {
         insideLiteral = false;
         stripped += char;
       } else {
         stripped += ' ';
       }
+      precedingBackslashes = char === '\\' ? precedingBackslashes + 1 : 0;
       i += 1;
       continue;
     }
@@ -78,6 +85,7 @@ function stripStringLiterals(text: string): StrippedText {
     if (char === "'") {
       insideLiteral = true;
       stripped += char;
+      precedingBackslashes = 0;
       i += 1;
       continue;
     }
@@ -111,6 +119,7 @@ function stripStringLiterals(text: string): StrippedText {
     }
 
     stripped += char;
+    precedingBackslashes = char === '\\' ? precedingBackslashes + 1 : 0;
     i += 1;
   }
 

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -87,6 +87,10 @@ describe('context misfire guards', () => {
     expect(getWhereClauseContext('select id from users where id = 12')).toBeNull();
   });
 
+  it('stays inside the literal after a backslash-escaped quote', () => {
+    expect(getWhereClauseContext("select id from users where bio = 'it\\'s ")).toBeNull();
+  });
+
   it('offers columns after ORDER BY and GROUP BY without a WHERE clause', () => {
     expect(getWhereClauseContext('select id from users order by na')).toEqual({
       prefix: 'na',
@@ -196,6 +200,13 @@ describe('findSources', () => {
 
   it('does not treat a -- inside a string literal as a comment', () => {
     const sources = findSources("select id from users where note = 'a -- from ghosts'");
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('does not treat a backslash-escaped quote as closing the string literal', () => {
+    const sources = findSources("select * from users where bio = 'it\\'s from secrets_table'");
     expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
       { table: 'users', alias: 'users' },
     ]);


### PR DESCRIPTION
## Summary
- `stripStringLiterals` in `src/ts-plugin/sql-context.cts` masks string-literal bodies before FROM/JOIN/column detection runs, but closed the literal on any `'`, ignoring MySQL's `\'` escape.
- A query like `select * from users where bio = 'it\'s from secrets_table'` closed the literal early on the escaped quote, so `from secrets_table` inside the string got parsed as a real second source.

## Fix
Track the run of consecutive backslashes immediately preceding each quote while scanning inside a literal, and only treat the quote as closing when that run is even (not an escape). This mirrors `EndsWithOddBackslashes` in `src/string.ts`, which the type-level parser already uses for the same reason. Character offsets stay 1:1 since the function still emits exactly one output character per input character.

## Test plan
- Added `findSources` regression test using the issue's exact repro, confirming `secrets_table` is no longer picked up as a source.
- Added a `getWhereClauseContext` test confirming the cursor is still reported as inside the literal right after an escaped quote.
- Reverted the source fix in isolation with the new tests in place and confirmed both fail with the exact expected mismatch, then restored the fix.
- `npm run test:types` passes.
- `npx vitest run` passes (216/216).

Fixes #163