### PR TITLE
Fix ts-plugin to recognize CTE (WITH) queries

### DIFF
--- a/src/ts-plugin/diagnostics.cts
+++ b/src/ts-plugin/diagnostics.cts
@@ -2,7 +2,7 @@ import type * as ts from 'typescript';
 import sqlContext = require('./sql-context.cjs');
 import schemaModule = require('./schema.cjs');
 
-const { findSources, findSourceByAlias, stripStringLiterals } = sqlContext;
+const { findSources, findSourceByAlias, stripStringLiterals, stripWithClause } = sqlContext;
 const { getColumnNames } = schemaModule;
 
 const SELECT_KEYWORD = /^\s*select\b/i;
@@ -105,9 +105,14 @@ function getQueryDiagnostics(
   // file. Mirrors the same fix already applied to hover in index.cts.
   const text = sourceFile.text.slice(literalStart, literal.getEnd() - 1);
   const { stripped } = stripStringLiterals(text);
+  // A CTE query's outer statement doesn't start at offset 0 - skip the
+  // WITH-clause prefix (mirroring ParseWithClause in src/cte.ts) so the
+  // SELECT gate and the select-list slice below both operate on the outer
+  // statement rather than being fooled by the CTE body's own FROM/SELECT.
+  const { remainder, remainderStart } = stripWithClause(stripped);
 
   const fromIndex = findTopLevelFromIndex(stripped);
-  if (fromIndex === null || !SELECT_KEYWORD.test(stripped)) {
+  if (fromIndex === null || !SELECT_KEYWORD.test(remainder)) {
     return [];
   }
 
@@ -124,10 +129,10 @@ function getQueryDiagnostics(
     }
   }
 
-  const beforeFrom = stripped.slice(0, fromIndex);
+  const beforeFrom = stripped.slice(remainderStart, fromIndex);
   const afterSelect = skipLeadingKeyword(beforeFrom, SELECT_KEYWORD);
   const selectList = skipLeadingKeyword(afterSelect, DISTINCT_KEYWORD);
-  const selectListOffset = beforeFrom.length - selectList.length;
+  const selectListOffset = remainderStart + (beforeFrom.length - selectList.length);
 
   for (const entry of splitTopLevelCommas(selectList)) {
     const parsed = columnTokenFromEntry(entry);

--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -1,6 +1,11 @@
 const SELECT_START = /^select\b/i;
 const HAS_FROM = /\bfrom\b/i;
 const HAS_COLUMN_CLAUSE = /\b(where|having|on|order\s+by|group\s+by)\b/i;
+const WITH_START = /^\s*with\b/i;
+const RECURSIVE_KEYWORD = /^\s*recursive\b/i;
+const CTE_NAME = /^\s*([A-Za-z_][A-Za-z0-9_]*)/;
+const AS_KEYWORD_START = /^\s*as\b/i;
+const LEADING_COMMA = /^\s*,/;
 const QUALIFIED_TRAILING_TOKEN = /(?:([A-Za-z_][A-Za-z0-9_]*)\.)?([A-Za-z0-9_]*)$/;
 const FROM_TABLE = /\bfrom\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)/i;
 const FROM_OR_JOIN_SOURCE = /\b(from|join)\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)(?:\s+(as\s+)?([A-Za-z_][A-Za-z0-9_]*))?/gid;
@@ -117,6 +122,90 @@ function stripStringLiterals(text: string): StrippedText {
   return { stripped, insideLiteral };
 }
 
+interface WithClauseResult {
+  cteNames: string[];
+  remainder: string;
+  remainderStart: number;
+}
+
+function skipParenGroup(text: string, openIndex: number): number | null {
+  let depth = 0;
+  for (let i = openIndex; i < text.length; i += 1) {
+    if (text[i] === '(') {
+      depth += 1;
+    } else if (text[i] === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return i + 1;
+      }
+    }
+  }
+  return null;
+}
+
+// Skip a leading `WITH [RECURSIVE] name [(cols)] AS (query), ...` prefix so
+// the caller can test the statement that actually follows it, mirroring how
+// the type-level parser's ParseWithClause (src/cte.ts) strips CTEs before
+// parsing the rest of the statement. `text` is expected to already be
+// comment/literal-masked (see stripStringLiterals). When the cursor lands
+// inside a still-open CTE body, this recurses into that body directly, since
+// completions there should be resolved against the CTE's own inner query.
+function stripWithClause(text: string): WithClauseResult {
+  const fallback: WithClauseResult = { cteNames: [], remainder: text, remainderStart: 0 };
+  if (!WITH_START.test(text)) {
+    return fallback;
+  }
+
+  const cteNames: string[] = [];
+  let rest = text.replace(WITH_START, '').replace(RECURSIVE_KEYWORD, '');
+
+  while (true) {
+    const nameMatch = CTE_NAME.exec(rest);
+    if (!nameMatch?.[1]) {
+      return fallback;
+    }
+    const name = nameMatch[1];
+    let afterName = rest.slice(nameMatch[0].length);
+
+    if (/^\s*\(/.test(afterName)) {
+      const openIndex = afterName.indexOf('(');
+      const closeIndex = skipParenGroup(afterName, openIndex);
+      if (closeIndex === null) {
+        return fallback;
+      }
+      afterName = afterName.slice(closeIndex);
+    }
+
+    if (!AS_KEYWORD_START.test(afterName)) {
+      return fallback;
+    }
+    const afterAs = afterName.replace(AS_KEYWORD_START, '');
+
+    const openIndex = afterAs.indexOf('(');
+    if (openIndex === -1 || afterAs.slice(0, openIndex).trim() !== '') {
+      return fallback;
+    }
+
+    const closeIndex = skipParenGroup(afterAs, openIndex);
+    if (closeIndex === null) {
+      const body = afterAs.slice(openIndex + 1);
+      const inner = stripWithClause(body);
+      const remainderStart = text.length - body.length + inner.remainderStart;
+      return { cteNames: [...cteNames, name, ...inner.cteNames], remainder: inner.remainder, remainderStart };
+    }
+
+    cteNames.push(name);
+    rest = afterAs.slice(closeIndex);
+
+    if (LEADING_COMMA.test(rest)) {
+      rest = rest.replace(LEADING_COMMA, '');
+      continue;
+    }
+
+    return { cteNames, remainder: rest, remainderStart: text.length - rest.length };
+  }
+}
+
 function prefixFrom(textBeforeCursor: string): SelectListContext | null {
   const match = QUALIFIED_TRAILING_TOKEN.exec(textBeforeCursor);
   const qualifier = match?.[1] ?? null;
@@ -133,11 +222,13 @@ function getSelectListContext(textBeforeCursor: string): SelectListContext | nul
     return null;
   }
 
-  if (!SELECT_START.test(stripped.trimStart())) {
+  const { remainder } = stripWithClause(stripped);
+
+  if (!SELECT_START.test(remainder.trimStart())) {
     return null;
   }
 
-  if (HAS_FROM.test(stripped)) {
+  if (HAS_FROM.test(remainder)) {
     return null;
   }
 
@@ -150,11 +241,13 @@ function getWhereClauseContext(textBeforeCursor: string): SelectListContext | nu
     return null;
   }
 
-  if (!HAS_FROM.test(stripped)) {
+  const { remainder } = stripWithClause(stripped);
+
+  if (!HAS_FROM.test(remainder)) {
     return null;
   }
 
-  if (!HAS_COLUMN_CLAUSE.test(stripped)) {
+  if (!HAS_COLUMN_CLAUSE.test(remainder)) {
     return null;
   }
 
@@ -169,19 +262,32 @@ function findFromTable(fullLiteralText: string): string | null {
 
 function findSources(fullLiteralText: string): QuerySource[] {
   const { stripped } = stripStringLiterals(fullLiteralText);
+  // A CTE's inner query is its own private scope: its FROM/JOIN sources
+  // belong to it, not to the outer statement, so scan only what follows the
+  // WITH-clause. That also keeps a CTE's own name from being surfaced as a
+  // FROM/JOIN source when the outer statement selects from it - it isn't a
+  // real schema table, and its projected columns aren't something this
+  // heuristic scanner can compute anyway.
+  const { remainder, remainderStart, cteNames } = stripWithClause(stripped);
+  const cteNameSet = new Set(cteNames.map((name) => name.toLowerCase()));
   const sources: QuerySource[] = [];
 
   FROM_OR_JOIN_SOURCE.lastIndex = 0;
   let match: RegExpExecArray | null;
-  while ((match = FROM_OR_JOIN_SOURCE.exec(stripped)) !== null) {
+  while ((match = FROM_OR_JOIN_SOURCE.exec(remainder)) !== null) {
     const table = match[2];
     const tableSpan = (match as unknown as { indices?: Array<[number, number] | undefined> }).indices?.[2];
-    if (!table || !tableSpan) {
+    if (!table || !tableSpan || cteNameSet.has(table.toLowerCase())) {
       continue;
     }
     const rawAlias = match[4] ?? null;
     const alias = rawAlias && !RESERVED_AFTER_SOURCE.has(rawAlias.toLowerCase()) ? rawAlias : table;
-    sources.push({ table, alias, tableStart: tableSpan[0], tableEnd: tableSpan[1] });
+    sources.push({
+      table,
+      alias,
+      tableStart: remainderStart + tableSpan[0],
+      tableEnd: remainderStart + tableSpan[1],
+    });
   }
 
   return sources;
@@ -242,4 +348,5 @@ export = {
   getQualifierBefore,
   getWordAtOffset,
   stripStringLiterals,
+  stripWithClause,
 };

--- a/tests/ts-plugin-diagnostics.test.ts
+++ b/tests/ts-plugin-diagnostics.test.ts
@@ -115,4 +115,30 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
       diagnosticsFor('select id,\r\n  name,\r\n  nope\r\nfrom users\r\nwhere id = 1'),
     ).toEqual([{ message: 'unknown column: nope', text: 'nope' }]);
   });
+
+  it('does not flag a CTE name as an unknown table (issue #165 repro)', () => {
+    expect(
+      diagnosticsFor('with recent_users as (select id from users) select id, name from recent_users'),
+    ).toEqual([]);
+  });
+
+  it('reports an unknown table in the outer FROM clause of a CTE query', () => {
+    expect(
+      diagnosticsFor('with recent_users as (select id from users) select id from ghosts'),
+    ).toEqual([{ message: 'unknown table: ghosts', text: 'ghosts' }]);
+  });
+
+  it('reports an unknown column in the outer SELECT list of a CTE query', () => {
+    expect(
+      diagnosticsFor('with recent_users as (select id from users) select id, nope from users'),
+    ).toEqual([{ message: 'unknown column: nope', text: 'nope' }]);
+  });
+
+  it('does not flag any of several comma-separated CTE names as unknown tables', () => {
+    expect(
+      diagnosticsFor(
+        'with a as (select id from users), b as (select id from posts) select id from a join b on a.id = b.id',
+      ),
+    ).toEqual([]);
+  });
 });

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -33,6 +33,33 @@ describe('getSelectListContext', () => {
     expect(getSelectListContext('SELECT id, na')).toEqual({ prefix: 'na', qualifier: null });
   });
 
+  it('offers completions in the outer SELECT list of a CTE query (issue #165 repro)', () => {
+    expect(
+      getSelectListContext('with recent_users as (select id from users) select id, na'),
+    ).toEqual({ prefix: 'na', qualifier: null });
+  });
+
+  it('offers completions inside a still-open CTE body', () => {
+    expect(getSelectListContext('with recent_users as (select id, na')).toEqual({
+      prefix: 'na',
+      qualifier: null,
+    });
+  });
+
+  it('offers completions past a WITH RECURSIVE clause', () => {
+    expect(
+      getSelectListContext('with recursive nums as (select id from users) select id, na'),
+    ).toEqual({ prefix: 'na', qualifier: null });
+  });
+
+  it('offers completions past multiple comma-separated CTEs', () => {
+    expect(
+      getSelectListContext(
+        'with a as (select id from users), b as (select id from posts) select id, na',
+      ),
+    ).toEqual({ prefix: 'na', qualifier: null });
+  });
+
   it('captures an alias qualifier in front of the partial word', () => {
     expect(getSelectListContext('select u.na')).toEqual({ prefix: 'na', qualifier: 'u' });
   });
@@ -70,6 +97,14 @@ describe('getWhereClauseContext', () => {
       prefix: 'na',
       qualifier: null,
     });
+  });
+
+  it('offers completions in the outer WHERE clause of a CTE query', () => {
+    expect(
+      getWhereClauseContext(
+        'with recent_users as (select id from users) select id from recent_users where na',
+      ),
+    ).toEqual({ prefix: 'na', qualifier: null });
   });
 });
 
@@ -208,6 +243,29 @@ describe('findSources', () => {
     expect(users).toBeDefined();
     if (!users) return;
     expect(text.slice(users.tableStart, users.tableEnd)).toBe('users');
+  });
+
+  it('does not surface a CTE name as if it were a real schema table (issue #165 repro)', () => {
+    const sources = findSources(
+      'with recent_users as (select id from users) select id from recent_users where active',
+    );
+    expect(sources).toEqual([]);
+  });
+
+  it('scopes sources to the outer statement, not a CTE body real table it wraps', () => {
+    const sources = findSources(
+      'with recent_users as (select id from users) select id, name from users',
+    );
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('excludes every comma-separated CTE name, keeping only real sources', () => {
+    const sources = findSources(
+      'with a as (select id from users), b as (select id from posts) select id from a join b on a.id = b.id',
+    );
+    expect(sources).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- `SELECT_START` in `src/ts-plugin/sql-context.cts` and `SELECT_KEYWORD` in `src/ts-plugin/diagnostics.cts` both required the text before the cursor to literally start with `select`. Any query starting with `WITH` failed that check immediately, so `getSelectListContext` returned `null` for the entire outer query of a CTE (zero completions ever offered), and `getQueryDiagnostics` returned no diagnostics at all for a CTE query.
- Separately, `findSources` had no concept of CTEs: it picked up a CTE's own name as if it were a real schema table, so a CTE reference in the outer FROM looked like an unknown table.

## Fix
Added `stripWithClause` to `sql-context.cts` - a small recursive-descent scanner that walks past a `WITH [RECURSIVE] name [(cols)] AS (query), ...` prefix (mirroring `ParseWithClause` in `src/cte.ts`) and returns the outer statement text plus the declared CTE names. If the cursor is still inside an unclosed CTE body, it recurses into that body directly, since completions there should resolve against the CTE's own inner query.

- `getSelectListContext` / `getWhereClauseContext` now test the outer statement (or the open CTE body) instead of the raw text.
- `findSources` now scans only the outer statement for FROM/JOIN sources, since a CTE's inner query is its own scope, and excludes any match whose name is a declared CTE. This also fixes a false "ambiguous column" diagnostic that a real table used only inside a CTE body would otherwise cause once the SELECT gate was fixed.
- `diagnostics.cts` reuses the same helper so unknown-table/unknown-column checks now run for CTE queries too.

## Scope
A CTE's own projected columns still aren't resolvable by this heuristic scanner (it doesn't infer the CTE body's result shape), so qualified completion against a CTE's own alias, and diagnostics for typos strictly inside a CTE's body, remain out of scope - the same category of accepted gap as the LATERAL correlation caveat from #170.

## Test plan
- Added regression tests to `tests/ts-plugin-sql-context.test.ts` covering the issue's exact repro, `WITH RECURSIVE`, multiple comma-separated CTEs, and completions while still typing inside an open CTE body.
- Added regression tests to `tests/ts-plugin-diagnostics.test.ts` covering unknown-table/unknown-column diagnostics on the outer statement of a CTE query, and no false positive on the CTE name itself.
- Reverted both source files in isolation with the new tests in place; all 9 new tests failed with the exact expected mismatches, then restored the fix.
- `npm run test:types` passes.
- `npx vitest run` passes (230/230).

Fixes #165