### PR TITLE
Fix ts-plugin schema introspection for optional tables and Record schemas

### DIFF
--- a/src/ts-plugin/diagnostics.cts
+++ b/src/ts-plugin/diagnostics.cts
@@ -3,7 +3,7 @@ import sqlContext = require('./sql-context.cjs');
 import schemaModule = require('./schema.cjs');
 
 const { findSources, findSourceByAlias, stripStringLiterals } = sqlContext;
-const { getColumnNames } = schemaModule;
+const { tableExists, columnExists } = schemaModule;
 
 const SELECT_KEYWORD = /^\s*select\b/i;
 const DISTINCT_KEYWORD = /^\s*distinct\b/i;
@@ -92,6 +92,7 @@ function columnTokenFromEntry(entry: ColumnEntry): { token: string; offset: numb
 }
 
 function getQueryDiagnostics(
+  typescript: typeof ts,
   checker: ts.TypeChecker,
   dbType: ts.Type,
   literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral,
@@ -115,7 +116,7 @@ function getQueryDiagnostics(
   const diagnostics: DiagnosticSpan[] = [];
 
   for (const source of sources) {
-    if (!checker.getPropertyOfType(dbType, source.table)) {
+    if (!tableExists(typescript, checker, dbType, source.table)) {
       diagnostics.push({
         start: literalStart + source.tableStart,
         length: source.tableEnd - source.tableStart,
@@ -151,23 +152,22 @@ function getQueryDiagnostics(
         diagnostics.push({ start: tokenStart, length: qualifier.length, message: `unknown alias: ${qualifier}` });
         continue;
       }
-      if (!checker.getPropertyOfType(dbType, matchedSource.table)) {
+      if (!tableExists(typescript, checker, dbType, matchedSource.table)) {
         continue;
       }
-      const names = getColumnNames(checker, dbType, literal, matchedSource.table);
-      if (!names.includes(columnName)) {
+      if (!columnExists(typescript, checker, dbType, literal, matchedSource.table, columnName)) {
         diagnostics.push({ start: columnStart, length: columnName.length, message: `unknown column: ${columnName}` });
       }
       continue;
     }
 
-    const knownTables = sources.filter((source) => checker.getPropertyOfType(dbType, source.table));
+    const knownTables = sources.filter((source) => tableExists(typescript, checker, dbType, source.table));
     if (knownTables.length === 0) {
       continue;
     }
 
     const containingTables = knownTables.filter((source) =>
-      getColumnNames(checker, dbType, literal, source.table).includes(columnName),
+      columnExists(typescript, checker, dbType, literal, source.table, columnName),
     );
 
     if (containingTables.length === 0) {

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -75,7 +75,7 @@ function init(modules: { typescript: typeof ts }) {
         const fullLiteralText = match.literal.text;
         const sources = findSources(fullLiteralText);
         const table = resolveTableScope(sources, context.qualifier);
-        const columns = getColumnNames(checker, match.dbType, match.literal, table);
+        const columns = getColumnNames(typescript, checker, match.dbType, match.literal, table);
         const prefix = context.prefix.toLowerCase();
         const filtered = columns.filter((name) => name.toLowerCase().startsWith(prefix));
 
@@ -140,7 +140,7 @@ function init(modules: { typescript: typeof ts }) {
         }
 
         const table = resolveTableScope(findSources(match.literal.text), null);
-        const columnType = getColumnType(checker, match.dbType, match.literal, table, entryName);
+        const columnType = getColumnType(typescript, checker, match.dbType, match.literal, table, entryName);
         if (!columnType) {
           return native();
         }
@@ -185,7 +185,7 @@ function init(modules: { typescript: typeof ts }) {
 
         const qualifier = getQualifierBefore(rawLiteralText, word.start);
         const table = resolveTableScope(findSources(rawLiteralText), qualifier);
-        const columnType = getColumnType(checker, match.dbType, match.literal, table, word.word);
+        const columnType = getColumnType(typescript, checker, match.dbType, match.literal, table, word.word);
         if (!columnType) {
           return native();
         }
@@ -220,7 +220,7 @@ function init(modules: { typescript: typeof ts }) {
         const extra: ts.Diagnostic[] = [];
 
         for (const match of matches) {
-          for (const span of getQueryDiagnostics(checker, match.dbType, match.literal, sourceFile)) {
+          for (const span of getQueryDiagnostics(typescript, checker, match.dbType, match.literal, sourceFile)) {
             extra.push({
               file: sourceFile,
               start: span.start,

--- a/src/ts-plugin/schema.cts
+++ b/src/ts-plugin/schema.cts
@@ -12,19 +12,106 @@ function scopeToTable(
   return tableSymbols.filter((symbol) => wanted.has(symbol.getName()));
 }
 
+function tableExists(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  dbType: ts.Type,
+  tableName: string,
+): boolean {
+  if (checker.getPropertyOfType(dbType, tableName)) {
+    return true;
+  }
+  // A Record<string, ...>-shaped schema (this library's own documented
+  // Schema type, src/parse.ts) has no per-table property to look up - every
+  // string key is a valid table, resolved through the index signature
+  // instead, the same way the type-level parser indexes DB[Table] directly.
+  return checker.getIndexInfoOfType(dbType, typescript.IndexKind.String) !== undefined;
+}
+
+// Resolve the row type(s) a table scope points at, tolerating the two DB
+// shapes getProperties() alone can't see through: an optional table key
+// (`users?: {...}` types the property as `{...} | undefined`, so its
+// properties are stripped to non-nullable) and a Record<string, ...> schema
+// with no per-table property to enumerate at all, in which case every
+// requested name falls back to the schema's string index type.
+function resolveTableRowTypes(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  dbType: ts.Type,
+  node: ts.Node,
+  onlyTable: string | string[] | null,
+): ts.Type[] {
+  const tableSymbols = scopeToTable(dbType.getProperties(), onlyTable);
+  const resolvedNames = new Set(tableSymbols.map((symbol) => symbol.getName()));
+  const rowTypes = tableSymbols.map((symbol) =>
+    checker.getNonNullableType(checker.getTypeOfSymbolAtLocation(symbol, node)),
+  );
+
+  if (!onlyTable) {
+    return rowTypes;
+  }
+
+  const indexType = checker.getIndexInfoOfType(dbType, typescript.IndexKind.String)?.type;
+  if (!indexType) {
+    return rowTypes;
+  }
+
+  const requestedNames = Array.isArray(onlyTable) ? onlyTable : [onlyTable];
+  for (const name of requestedNames) {
+    if (!resolvedNames.has(name)) {
+      rowTypes.push(indexType);
+    }
+  }
+
+  return rowTypes;
+}
+
+function resolveColumnType(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  rowType: ts.Type,
+  node: ts.Node,
+  columnName: string,
+): ts.Type | null {
+  const columnSymbol = checker.getPropertyOfType(rowType, columnName);
+  if (columnSymbol) {
+    return checker.getTypeOfSymbolAtLocation(columnSymbol, node);
+  }
+
+  return checker.getIndexInfoOfType(rowType, typescript.IndexKind.String)?.type ?? null;
+}
+
+// Whether a column reference is valid for a table, independent of whether
+// getColumnNames can actually enumerate it: a Record<string, ...> row type
+// has no named properties to list (there's no fixed name list to offer as
+// completions), but any string key still resolves through its index
+// signature, so it must not be flagged as an unknown column.
+function columnExists(
+  typescript: typeof ts,
+  checker: ts.TypeChecker,
+  dbType: ts.Type,
+  node: ts.Node,
+  table: string,
+  columnName: string,
+): boolean {
+  const rowTypes = resolveTableRowTypes(typescript, checker, dbType, node, table);
+  return rowTypes.some(
+    (rowType) => resolveColumnType(typescript, checker, rowType, node, columnName) !== null,
+  );
+}
+
 function getColumnNames(
+  typescript: typeof ts,
   checker: ts.TypeChecker,
   dbType: ts.Type,
   node: ts.Node,
   onlyTable: string | string[] | null,
 ): string[] {
-  const tables = scopeToTable(dbType.getProperties(), onlyTable);
-
+  const rowTypes = resolveTableRowTypes(typescript, checker, dbType, node, onlyTable);
   const columnNames = new Set<string>();
 
-  for (const tableSymbol of tables) {
-    const tableType = checker.getTypeOfSymbolAtLocation(tableSymbol, node);
-    for (const columnSymbol of tableType.getProperties()) {
+  for (const rowType of rowTypes) {
+    for (const columnSymbol of rowType.getProperties()) {
       columnNames.add(columnSymbol.getName());
     }
   }
@@ -33,24 +120,17 @@ function getColumnNames(
 }
 
 function getColumnType(
+  typescript: typeof ts,
   checker: ts.TypeChecker,
   dbType: ts.Type,
   node: ts.Node,
   onlyTable: string | string[] | null,
   columnName: string,
 ): ts.Type | null {
-  const tables = scopeToTable(dbType.getProperties(), onlyTable);
-
-  const matches: ts.Type[] = [];
-
-  for (const tableSymbol of tables) {
-    const tableType = checker.getTypeOfSymbolAtLocation(tableSymbol, node);
-    for (const columnSymbol of tableType.getProperties()) {
-      if (columnSymbol.getName() === columnName) {
-        matches.push(checker.getTypeOfSymbolAtLocation(columnSymbol, node));
-      }
-    }
-  }
+  const rowTypes = resolveTableRowTypes(typescript, checker, dbType, node, onlyTable);
+  const matches = rowTypes
+    .map((rowType) => resolveColumnType(typescript, checker, rowType, node, columnName))
+    .filter((type): type is ts.Type => type !== null);
 
   if (matches.length === 0) {
     return null;
@@ -63,4 +143,4 @@ function getColumnType(
   return isUnambiguous ? (first as ts.Type) : null;
 }
 
-export = { getColumnNames, getColumnType };
+export = { getColumnNames, getColumnType, tableExists, columnExists };

--- a/tests/ts-plugin-completions.test.ts
+++ b/tests/ts-plugin-completions.test.ts
@@ -65,7 +65,7 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
     const table = findFromTable(match.literal.text);
     expect(table).toBeNull();
 
-    const columns = getColumnNames(checker, match.dbType, match.literal, table);
+    const columns = getColumnNames(ts, checker, match.dbType, match.literal, table);
     const filtered = columns.filter((name) => name.startsWith(context.prefix));
 
     expect(filtered).toEqual(['name']);
@@ -85,7 +85,7 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
     const table = findFromTable(match.literal.text);
     expect(table).toBe('posts');
 
-    const columns = getColumnNames(checker, match.dbType, match.literal, table);
+    const columns = getColumnNames(ts, checker, match.dbType, match.literal, table);
 
     expect(columns.sort()).toEqual(['id', 'title']);
     expect(columns).not.toContain('name');
@@ -112,7 +112,7 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
     const table = findFromTable(match.literal.text);
     expect(table).toBe('users');
 
-    const columns = getColumnNames(checker, match.dbType, match.literal, table);
+    const columns = getColumnNames(ts, checker, match.dbType, match.literal, table);
     const filtered = columns.filter((name) => name.startsWith(context.prefix));
 
     expect(filtered).toEqual(['name']);

--- a/tests/ts-plugin-diagnostics.test.ts
+++ b/tests/ts-plugin-diagnostics.test.ts
@@ -23,8 +23,8 @@ interface DB {
 declare const db: TypedDb<DB>;
 `;
 
-function diagnosticsFor(query: string): { message: string; text: string }[] {
-  const source = `${FIXTURE}\ndb.query(\`${query}\`);\n`;
+function diagnosticsFor(query: string, fixture: string = FIXTURE): { message: string; text: string }[] {
+  const source = `${fixture}\ndb.query(\`${query}\`);\n`;
   const { program, sourceFile, dir } = buildProgram(source, 'owlsql-ts-plugin-diagnostics-');
   try {
     const checker = program.getTypeChecker();
@@ -32,7 +32,7 @@ function diagnosticsFor(query: string): { message: string; text: string }[] {
     expect(matches).toHaveLength(1);
     const [match] = matches;
     if (!match) return [];
-    return getQueryDiagnostics(checker, match.dbType, match.literal, sourceFile).map((span) => ({
+    return getQueryDiagnostics(ts, checker, match.dbType, match.literal, sourceFile).map((span) => ({
       message: span.message,
       text: sourceFile.text.slice(span.start, span.start + span.length),
     }));
@@ -114,5 +114,44 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
     expect(
       diagnosticsFor('select id,\r\n  name,\r\n  nope\r\nfrom users\r\nwhere id = 1'),
     ).toEqual([{ message: 'unknown column: nope', text: 'nope' }]);
+  });
+
+  it('does not flag valid columns on an optional table key (issue #164 repro)', () => {
+    const fixture = `
+      import type { TypedDb } from '@owlsql/core';
+
+      interface DB {
+        users?: { id: number; name: string };
+      }
+
+      declare const db: TypedDb<DB>;
+    `;
+    expect(diagnosticsFor('select id, name from users', fixture)).toEqual([]);
+  });
+
+  it('still reports an unknown column on an optional table key', () => {
+    const fixture = `
+      import type { TypedDb } from '@owlsql/core';
+
+      interface DB {
+        users?: { id: number; name: string };
+      }
+
+      declare const db: TypedDb<DB>;
+    `;
+    expect(diagnosticsFor('select id, nope from users', fixture)).toEqual([
+      { message: 'unknown column: nope', text: 'nope' },
+    ]);
+  });
+
+  it('does not flag any table as unknown against a Record<string, ...> schema (issue #164 repro)', () => {
+    const fixture = `
+      import type { TypedDb } from '@owlsql/core';
+
+      type DB = Record<string, Record<string, unknown>>;
+
+      declare const db: TypedDb<DB>;
+    `;
+    expect(diagnosticsFor('select id, name from users', fixture)).toEqual([]);
   });
 });

--- a/tests/ts-plugin-hover.test.ts
+++ b/tests/ts-plugin-hover.test.ts
@@ -72,7 +72,7 @@ describe('ts-plugin hover: getColumnType against a real ts.Program', () => {
     const table = findFromTable(match.literal.text);
     expect(table).toBe('users');
 
-    const columnType = getColumnType(checker, match.dbType, match.literal, table, word.word);
+    const columnType = getColumnType(ts, checker, match.dbType, match.literal, table, word.word);
     expect(columnType && checker.typeToString(columnType)).toBe('string');
   });
 
@@ -89,7 +89,7 @@ describe('ts-plugin hover: getColumnType against a real ts.Program', () => {
     if (!match) return;
 
     const table = findFromTable(match.literal.text);
-    const columnType = getColumnType(checker, match.dbType, match.literal, table, 'email');
+    const columnType = getColumnType(ts, checker, match.dbType, match.literal, table, 'email');
     expect(columnType && checker.typeToString(columnType)).toBe('string | null');
   });
 
@@ -106,7 +106,7 @@ describe('ts-plugin hover: getColumnType against a real ts.Program', () => {
     if (!match) return;
 
     const table = findFromTable(match.literal.text);
-    const columnType = getColumnType(checker, match.dbType, match.literal, table, 'nope');
+    const columnType = getColumnType(ts, checker, match.dbType, match.literal, table, 'nope');
     expect(columnType).toBeNull();
   });
 });

--- a/tests/ts-plugin-schema.test.ts
+++ b/tests/ts-plugin-schema.test.ts
@@ -36,7 +36,7 @@ describe('getColumnNames / getColumnType scoping', () => {
       declare const dbValue: DB;
     `);
 
-    expect(getColumnNames(checker, dbType, node, 'users').sort()).toEqual(['id', 'name']);
+    expect(getColumnNames(ts, checker, dbType, node, 'users').sort()).toEqual(['id', 'name']);
   });
 
   it('returns no columns for a FROM table that does not exist in the schema, instead of falling back to all tables', () => {
@@ -45,8 +45,8 @@ describe('getColumnNames / getColumnType scoping', () => {
       declare const dbValue: DB;
     `);
 
-    expect(getColumnNames(checker, dbType, node, 'userz')).toEqual([]);
-    expect(getColumnType(checker, dbType, node, 'userz', 'title')).toBeNull();
+    expect(getColumnNames(ts, checker, dbType, node, 'userz')).toEqual([]);
+    expect(getColumnType(ts, checker, dbType, node, 'userz', 'title')).toBeNull();
   });
 
   it('unions columns across all tables when no FROM table is given', () => {
@@ -55,7 +55,7 @@ describe('getColumnNames / getColumnType scoping', () => {
       declare const dbValue: DB;
     `);
 
-    expect(getColumnNames(checker, dbType, node, null).sort()).toEqual(['id', 'name', 'title']);
+    expect(getColumnNames(ts, checker, dbType, node, null).sort()).toEqual(['id', 'name', 'title']);
   });
 
   it('resolves a column type unambiguously when every table agrees on it, even with no FROM scoping', () => {
@@ -64,7 +64,7 @@ describe('getColumnNames / getColumnType scoping', () => {
       declare const dbValue: DB;
     `);
 
-    const columnType = getColumnType(checker, dbType, node, null, 'id');
+    const columnType = getColumnType(ts, checker, dbType, node, null, 'id');
     expect(columnType && checker.typeToString(columnType)).toBe('number');
   });
 
@@ -74,7 +74,7 @@ describe('getColumnNames / getColumnType scoping', () => {
       declare const dbValue: DB;
     `);
 
-    expect(getColumnType(checker, dbType, node, null, 'id')).toBeNull();
+    expect(getColumnType(ts, checker, dbType, node, null, 'id')).toBeNull();
   });
 
   it('unions columns across an explicit array of tables, for JOIN scoping', () => {
@@ -87,12 +87,12 @@ describe('getColumnNames / getColumnType scoping', () => {
       declare const dbValue: DB;
     `);
 
-    expect(getColumnNames(checker, dbType, node, ['users', 'posts']).sort()).toEqual([
+    expect(getColumnNames(ts, checker, dbType, node, ['users', 'posts']).sort()).toEqual([
       'id',
       'name',
       'title',
     ]);
-    expect(getColumnNames(checker, dbType, node, ['users', 'posts'])).not.toContain('body');
+    expect(getColumnNames(ts, checker, dbType, node, ['users', 'posts'])).not.toContain('body');
   });
 
   it('resolves a column type unambiguously across a joined table array', () => {
@@ -101,7 +101,7 @@ describe('getColumnNames / getColumnType scoping', () => {
       declare const dbValue: DB;
     `);
 
-    const columnType = getColumnType(checker, dbType, node, ['users', 'posts'], 'name');
+    const columnType = getColumnType(ts, checker, dbType, node, ['users', 'posts'], 'name');
     expect(columnType && checker.typeToString(columnType)).toBe('string');
   });
 
@@ -111,6 +111,42 @@ describe('getColumnNames / getColumnType scoping', () => {
       declare const dbValue: DB;
     `);
 
-    expect(getColumnType(checker, dbType, node, ['users', 'accounts'], 'id')).toBeNull();
+    expect(getColumnType(ts, checker, dbType, node, ['users', 'accounts'], 'id')).toBeNull();
+  });
+
+  it('resolves an optional table key by stripping undefined (issue #164 repro)', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB { users?: { id: number; name: string } }
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnNames(ts, checker, dbType, node, 'users').sort()).toEqual(['id', 'name']);
+    const columnType = getColumnType(ts, checker, dbType, node, 'users', 'id');
+    expect(columnType && checker.typeToString(columnType)).toBe('number');
+  });
+
+  it('resolves any table name against a Record<string, ...> schema (issue #164 repro)', () => {
+    const { checker, dbType, node } = buildDbType(`
+      type DB = Record<string, Record<string, unknown>>;
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnNames(ts, checker, dbType, node, 'users')).toEqual([]);
+    const columnType = getColumnType(ts, checker, dbType, node, 'users', 'id');
+    expect(columnType && checker.typeToString(columnType)).toBe('unknown');
+  });
+
+  it('resolves a named table alongside a Record<string, ...> catch-all', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB {
+        users: { id: number; name: string };
+        [table: string]: Record<string, unknown>;
+      }
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnNames(ts, checker, dbType, node, 'users').sort()).toEqual(['id', 'name']);
+    const columnType = getColumnType(ts, checker, dbType, node, 'ghost_table', 'anything');
+    expect(columnType && checker.typeToString(columnType)).toBe('unknown');
   });
 });


### PR DESCRIPTION
## Summary
`getColumnNames`/`getColumnType` (`src/ts-plugin/schema.cts`) and the diagnostics table-existence check both started from `dbType.getProperties()` and, per table, `tableType.getProperties()`. Two legal `DB` shapes broke on that:

1. **An optional table key.** For `interface DB { users?: { id: number; name: string } }`, `checker.getTypeOfSymbolAtLocation` returns `{...} | undefined`. `.getProperties()` on a union only returns properties common to every member, and `undefined` has none, so the result was `[]`. Completions went dead for that table, while `diagnostics.cts`'s own `checker.getPropertyOfType(dbType, table)` check still found the table (optionality doesn't remove it from lookup), so every real column got flagged `unknown column: <name>`.
2. **A `Record<string, ...>` schema** - this library's own documented `Schema` type (`src/parse.ts`). `dbType.getProperties()` returns nothing for an index-signature type, and `checker.getPropertyOfType(dbType, 'users')` returns `undefined` regardless of the table name, so every table reference got flagged `unknown table: X`, even though the type-level parser resolves the same query correctly by indexing `DB[Table]` directly instead of walking properties.

## Fix
`schema.cts` now resolves table row types through a shared `resolveTableRowTypes` helper that strips `undefined` via `checker.getNonNullableType` before reading properties, and falls back to the schema's string index type (`checker.getIndexInfoOfType`) for any requested table name `getProperties()` didn't already resolve. The same fallback applies one level down for columns, via a new `columnExists` check used by diagnostics instead of `getColumnNames(...).includes(name)` - an index-signature row type has no fixed name list to enumerate for completions, but any string key still resolves through it, so it must not be flagged as unknown. `diagnostics.cts`'s table-existence check gets the same fallback through a new `tableExists` helper.

Reading the index signature needs the real `IndexKind` enum value at runtime, so `getColumnNames`, `getColumnType`, and `getQueryDiagnostics` now take the host's `typescript` module as an explicit first parameter - the same way this ts-plugin already avoids importing the `typescript` package directly anywhere else, instead always going through the language-service host's own instance.

## Test plan
- Added regression tests to `tests/ts-plugin-schema.test.ts` for an optional table key, a pure `Record<string, ...>` schema, and a named table alongside a `Record`-typed catch-all index signature.
- Added regression tests to `tests/ts-plugin-diagnostics.test.ts` confirming no false `unknown table`/`unknown column` diagnostics for both shapes, and that a genuinely unknown column on an optional table is still caught.
- Reverted the fix logic in isolation (kept the new signatures so the test call sites stayed valid, dropped only the `getNonNullableType`/index-signature fallback behavior) with the new tests in place; all 6 new tests failed with the exact expected mismatches, then restored the fix.
- `npm run test:types` passes.
- `npx vitest run` passes (224/224).

Fixes #164