### PR TITLE
Fix ts-plugin to detect TypedDb wrapped in an interface or generic parameter

### DIFF
--- a/src/ts-plugin/detect.cts
+++ b/src/ts-plugin/detect.cts
@@ -93,7 +93,18 @@ function findTypedDbTypeReference(
   checker: ts.TypeChecker,
   type: ts.Type,
 ): ts.TypeReference | null {
-  if (isTypeReference(typescript, type) && hasTypedDbBrand(checker, type)) {
+  // A type reference only carries the DB type argument when it's an actual
+  // instantiation of the generic TypedDb<DB> - `interface AppDb extends
+  // TypedDb<DB> {}` inherits the brand property onto AppDb's own type too
+  // (getPropertyOfType walks inherited members), but AppDb itself isn't
+  // generic, so checker.getTypeArguments(AppDb) is empty. Requiring a type
+  // argument here forces that case past this check and into the base-type
+  // walk below, where the real TypedDb<DB> reference is found instead.
+  if (
+    isTypeReference(typescript, type) &&
+    hasTypedDbBrand(checker, type) &&
+    checker.getTypeArguments(type).length > 0
+  ) {
     return type;
   }
 
@@ -103,6 +114,24 @@ function findTypedDbTypeReference(
       if (found) {
         return found;
       }
+    }
+  }
+
+  if (type.isClassOrInterface()) {
+    for (const baseType of type.getBaseTypes() ?? []) {
+      const found = findTypedDbTypeReference(typescript, checker, baseType);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  // `function run<T extends TypedDb<DB>>(db: T)` - the receiver is a bare
+  // type parameter, so the brand only shows up on its constraint.
+  if (type.isTypeParameter()) {
+    const constraint = type.getConstraint();
+    if (constraint) {
+      return findTypedDbTypeReference(typescript, checker, constraint);
     }
   }
 

--- a/tests/ts-plugin-detect.test.ts
+++ b/tests/ts-plugin-detect.test.ts
@@ -140,4 +140,40 @@ describe('matchQueryLiteral', () => {
 
     expect(match).not.toBeNull();
   });
+
+  it('activates through an interface that extends TypedDb (issue #166 repro)', () => {
+    const match = run(`
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      interface AppDb extends TypedDb<DB> {}
+      declare const db: AppDb;
+      db.query(\`select 1\`);
+    `);
+
+    expect(match).not.toBeNull();
+  });
+
+  it('activates through a generic type parameter constrained to TypedDb (issue #166 repro)', () => {
+    const match = run(`
+      import type { TypedDb } from '@owlsql/core';
+      interface DB { users: { id: number } }
+      function run<T extends TypedDb<DB>>(db: T) {
+        db.query(\`select 1\`);
+      }
+    `);
+
+    expect(match).not.toBeNull();
+  });
+
+  it('does not activate through an interface extending an unrelated base', () => {
+    const match = run(`
+      interface DB { users: { id: number } }
+      interface Logger { log(sql: string): void }
+      interface AppLogger extends Logger {}
+      declare const logger: AppLogger;
+      logger.query(\`select 1\`);
+    `);
+
+    expect(match).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
`findTypedDbTypeReference` in `src/ts-plugin/detect.cts` only matched a direct (or intersection-nested) type reference carrying the `__owlsqlTypedDb` brand. Two natural wrapping styles slipped past it:

- `interface AppDb extends TypedDb<DB> {}`, receiver typed `AppDb`
- `function run<T extends TypedDb<DB>>(db: T)`, receiver typed as the bare type parameter `T`

Both silently fell back to native completions/diagnostics with no error or warning.

## Root cause
It's subtler than "the brand isn't found." A receiver typed `AppDb` actually **does** pass the existing `isTypeReference(type) && hasTypedDbBrand(type)` check, because `checker.getPropertyOfType` walks inherited members - `AppDb` structurally carries `__owlsqlTypedDb` through its `extends TypedDb<DB>` clause. The real problem is one line further down: `AppDb` itself isn't generic, so `checker.getTypeArguments(typedDbRef)` comes back empty, and `matchQueryLiteralNode`'s `if (!dbType) return null` bails immediately after. Confirmed by tracing the actual checker output rather than trusting the issue's framing at face value.

The type-parameter case is more straightforward: a bare type parameter isn't an object type at all, so it never reached the brand check.

## Fix
`findTypedDbTypeReference` now requires a matching candidate to actually carry a type argument (`checker.getTypeArguments(type).length > 0`), which forces the `AppDb` case past the direct check and into a new base-type walk (`type.isClassOrInterface()` + `getBaseTypes()`) that finds the real `TypedDb<DB>` reference instead. A new type-parameter branch (`type.isTypeParameter()` + `getConstraint()`) resolves `T` to its constraint before recursing, covering the generic case. Both walks recurse through the same function, so combinations (a type parameter constrained to an interface that extends `TypedDb`, etc.) resolve too.

## Test plan
- Added regression tests to `tests/ts-plugin-detect.test.ts` for both repro cases from the issue, plus a guard test confirming an interface extending an unrelated base still correctly returns no match.
- Reverted the fix in isolation with the new tests in place; both failed with the exact expected mismatch, then restored the fix.
- `npm run test:types` passes.
- `npx vitest run` passes (221/221).

Fixes #166