### PR TITLE
Document count/sum/avg vs pg's default string decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,9 @@ Recognized: `count`, `sum`, `avg`, `min`, `max`, `length`, `char_length`,
 `cume_dist` → `number`; `lower`, `upper`, `trim`, `ltrim`, `rtrim`, `concat` →
 `string`; `coalesce`, `nullif`, `lag`, `lead`, `first_value`, `last_value`,
 `nth_value` → `unknown`; `now`, `current_timestamp`, `current_date` → `Date`.
-Anything else resolves to `unknown`.
+Anything else resolves to `unknown`. This return-type table is
+dialect-agnostic, which isn't always what the driver actually hands back for
+`count`/`sum`/`avg` — see [Limitations](#limitations).
 
 ### 7. INSERT / UPDATE / DELETE with RETURNING
 
@@ -858,10 +860,19 @@ This is a focused tool for the common read path, not a full SQL grammar:
 - **Window `OVER (...)` clauses are only used as a boundary**, not parsed for
   their own typing — `PARTITION BY`/`ORDER BY` content inside `OVER (...)` is
   discarded, not validated.
-- **Aggregates assume numeric output.** `min`/`max` resolve to `number` even
-  over a text column; unrecognized functions resolve to `unknown`. `lag`,
-  `lead`, `first_value`, `last_value`, `nth_value` resolve to `unknown` (their
-  real type depends on the argument, which isn't inspected).
+- **Aggregates assume numeric output, dialect-agnostically.** `min`/`max`
+  resolve to `number` even over a text column; unrecognized functions resolve
+  to `unknown`. `count`, `sum`, and `avg` also resolve to `number`, but that's
+  not always what comes back at runtime: with `pg`'s default config (no
+  custom `types` parser), `count(*)`/`count(col)` is `bigint` and
+  `sum(int_col)`/`avg(...)` is `numeric` at the SQL level, and `pg` decodes
+  both as JS strings to avoid precision loss — the same reason plain
+  `bigint`/`numeric` *columns* map to `string` (see [Type mapping follows
+  each driver's defaults](#1-describe-your-schema)). Cast at the call site
+  (`Number(rows[0].count)`, or a BigInt-aware conversion) if you need to do
+  arithmetic on it. `lag`, `lead`, `first_value`, `last_value`, `nth_value`
+  resolve to `unknown` (their real type depends on the argument, which isn't
+  inspected).
 - **`select *` across a join merges columns by name.** When two tables share a
   column name (e.g. both have `id`), the types are intersected rather than kept
   separate. Alias the columns to keep them distinct.


### PR DESCRIPTION
## Summary
`FunctionReturnTypes` (`src/functions.ts`) declares `count`, `sum`, and `avg` as `number`, with no dialect awareness. At the SQL level in Postgres, `count(*)`/`count(col)` and `sum(int_col)` are `bigint`, and `avg(...)` is `numeric`. With `pg`'s default config (no custom `types` parser), both decode as JS strings, not numbers - verified directly against `pg-types`: the `int8` (oid 20) parser returns `String(value)` for the digit case, and `numeric` (oid 1700) is unregistered and falls through to the `noParse = String(val)` default.

```ts
type A = Query<DB, 'select count(*) from users'>;
// { count: number }[]
```

Run through `createPgExecutor`, `rows[0].count` is actually `"42"` at runtime. Arithmetic on it (`stats.count + 1`) silently does string concatenation instead of addition.

README already documents this exact class of mismatch for plain `bigint`/`numeric` *columns*, and separately caveats `min`/`max` as "assume numeric output" - `count`/`sum`/`avg` had no caveat at all, presented as unconditionally `number`.

## Why this is a docs fix, not a type-level one
A real fix means threading dialect awareness into `FunctionReturnType`, the same way the CLI's schema type mapper already has it for plain columns. But the type-level `Query<DB, SQL>` engine has no concept of "which driver/dialect" anywhere in its inference path today - it only sees the SQL string and your declared `DB` type. Adding that would mean a new type parameter flowing through `Query`/`StrictQuery`/`InferRowWith` and friends, which is a materially bigger, likely API-shape-changing design change than this issue's scope. Documenting the caveat, matching the existing `min`/`max` treatment, is the right-sized fix here.

## Changes
- Extended the `min`/`max` caveat in the Limitations section to cover `count`/`sum`/`avg`, cross-referencing the existing driver type-mapping note and suggesting `Number(...)`/BigInt-aware casting at the call site.
- Added a one-line pointer to Limitations right where the tutorial first shows `count(*)` resolving to `number`, so a first-time reader hits the caveat at the point of confusion, not just at the bottom of the doc.

No source or test changes - the type-level behavior itself isn't changing, only the documentation around it.

Fixes #169