### PR TITLE
Add MSSQL MERGE statement support

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,7 @@ this.**
 | Backtick identifiers | `` select `id` from `users` `` (MySQL style) |
 | `TOP` clause | `select top 10 id from users`, `top (n)`, `top n percent`, `top n with ties` (SQL Server) |
 | `OUTPUT` clause | `insert ... output inserted.id values (...)` (SQL Server) |
+| `MERGE ... OUTPUT` | `merge into t as target using ... on ... when matched then ... output inserted.id, $action` (SQL Server) — see [Limitations](#limitations) |
 
 ## Limitations
 
@@ -887,6 +888,14 @@ This is a focused tool for the common read path, not a full SQL grammar:
   only recognizes the `inserted`/`deleted` pseudo-table prefixes (they
   resolve against the statement's single table); `OUTPUT ... INTO @table` is
   not supported.
+- **`MERGE` types the target table and `OUTPUT` clause, not the merge logic
+  itself.** The `USING`/`ON`/`WHEN MATCHED`/`WHEN NOT MATCHED` branches aren't
+  parsed or validated — only `MERGE INTO <target>` (an explicit `INTO` is
+  required; the rarely-used `MERGE <target> USING ...` form without it isn't
+  recognized) and the trailing `OUTPUT` clause, resolved against the target
+  table the same way `OUTPUT` already works for `INSERT`/`UPDATE`/`DELETE`.
+  `OUTPUT $action` is recognized and typed as `'INSERT' | 'UPDATE' |
+  'DELETE'`.
 - **Unknown columns, tables, or aliases resolve to `unknown`** by default — pass
   `{ strict: true }` to turn them into a `QueryTypeError` instead.
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -149,6 +149,16 @@ type OutputClauseColumns<S extends string, StopKeyword extends string> = AfterKe
     : ''
   : '';
 
+// MERGE's OUTPUT clause is always the last clause in the statement (nothing
+// meaningful follows it), so unlike INSERT/UPDATE/DELETE's OUTPUT it needs no
+// stop keyword to truncate at - it runs to the end of the (already
+// semicolon-stripped) string.
+type OutputClauseColumnsToEnd<S extends string> = AfterKeyword<S, 'output'> extends infer Rest
+  ? Rest extends string
+    ? Trim<Rest>
+    : ''
+  : '';
+
 type StripPseudoTableEntry<Entry extends string> = Lowercase<
   Qualifier<Trim<Entry>>
 > extends 'inserted' | 'deleted'
@@ -246,7 +256,18 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
               ];
               whereText: ExtractUpdateDeleteWhereText<S>;
             }
-          : never
+          : IsKeyword<Keyword, 'merge'> extends true
+            ? {
+                // The USING/WHEN branches aren't modeled - only the target
+                // table (for OUTPUT column resolution) and the trailing
+                // OUTPUT clause itself, mirroring how OUTPUT already works
+                // for INSERT/UPDATE/DELETE. Requires an explicit INTO; MERGE
+                // without it (legal but rare in practice) isn't recognized.
+                columns: StripPseudoTableQualifiers<OutputClauseColumnsToEnd<S>>;
+                sources: SingleSource<WordAfterKeyword<S, 'into'>>;
+                whereText: '';
+              }
+            : never
   : never;
 
 export type ParseStatement<S extends string> = ParseStatementNormalized<Normalize<S>>;
@@ -612,12 +633,21 @@ type StrictFunctionType<
     : Error
   : never;
 
+// MERGE's OUTPUT clause can select $action, a pseudo-column with no backing
+// table that reports which branch fired for each row - not a real column on
+// any source, so it's special-cased ahead of ordinary column resolution.
+type IsMergeActionPseudoColumn<Expression extends string> = Lowercase<Expression> extends '$action'
+  ? true
+  : false;
+
 export type ResolveColumnType<
   DB extends SchemaLike,
   Sources extends Source[],
   Expression extends string,
   Strict extends boolean,
-> = IsCaseExpression<Expression> extends true
+> = IsMergeActionPseudoColumn<Expression> extends true
+  ? 'INSERT' | 'UPDATE' | 'DELETE'
+  : IsCaseExpression<Expression> extends true
   ? SplitCaseExpression<Expression> extends { body: infer Body extends string }
     ? CaseExpressionType<DB, Sources, Body, Strict>
     : unknown

--- a/tests/dialect-mssql.test-d.ts
+++ b/tests/dialect-mssql.test-d.ts
@@ -1,4 +1,4 @@
-import type { Query, Params } from '../src/index.js';
+import type { Query, Params, StrictQuery, QueryTypeError } from '../src/index.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -88,6 +88,76 @@ type NoOutputClauseIsEmptyRow = Expect<
   Equal<Query<DB, 'insert into users (name) values (@name)'>, Record<string, never>[]>
 >;
 
+type MergeOutputClause = Expect<
+  Equal<
+    Query<
+      DB,
+      'merge into users as target using (values (@id, @name)) as source (id, name) on target.id = source.id when matched then update set target.name = source.name when not matched then insert (id, name) values (source.id, source.name) output inserted.id, inserted.name'
+    >,
+    { id: number; name: string }[]
+  >
+>;
+
+type MergeActionPseudoColumn = Expect<
+  Equal<
+    Query<
+      DB,
+      'merge into users as target using (values (@id, @name)) as source (id, name) on target.id = source.id when matched then update set target.name = source.name output $action, inserted.id'
+    >,
+    { $action: 'INSERT' | 'UPDATE' | 'DELETE'; id: number }[]
+  >
+>;
+
+type MergeWithoutTargetAlias = Expect<
+  Equal<
+    Query<
+      DB,
+      'merge into users using (values (@id)) as source (id) on users.id = source.id when not matched then insert (id) values (source.id) output inserted.id'
+    >,
+    { id: number }[]
+  >
+>;
+
+type MergeNoOutputClauseIsEmptyRow = Expect<
+  Equal<
+    Query<
+      DB,
+      'merge into users as target using (values (@id, @name)) as source (id, name) on target.id = source.id when matched then update set target.name = source.name'
+    >,
+    Record<string, never>[]
+  >
+>;
+
+type MergeStrictRejectsUnknownOutputColumn = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'merge into users as target using (values (@id)) as source (id) on target.id = source.id when not matched then insert (id) values (source.id) output inserted.bogus'
+    >,
+    QueryTypeError<'unknown column: bogus'>[]
+  >
+>;
+
+type MergeStrictRejectsUnknownTargetTable = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'merge into ghosts as target using (values (@id)) as source (id) on target.id = source.id when not matched then insert (id) values (source.id) output inserted.id'
+    >,
+    QueryTypeError<'unknown table: ghosts'>[]
+  >
+>;
+
+type MergeKeywordIsCaseInsensitive = Expect<
+  Equal<
+    Query<
+      DB,
+      'MERGE INTO users AS target USING (values (@id, @name)) AS source (id, name) ON target.id = source.id WHEN MATCHED THEN UPDATE SET target.name = source.name OUTPUT inserted.id'
+    >,
+    { id: number }[]
+  >
+>;
+
 export type MssqlLock = [
   NamedParamSingle,
   NamedParamMultiple,
@@ -103,4 +173,11 @@ export type MssqlLock = [
   UpdateOutputClause,
   DeleteOutputClause,
   NoOutputClauseIsEmptyRow,
+  MergeOutputClause,
+  MergeActionPseudoColumn,
+  MergeWithoutTargetAlias,
+  MergeNoOutputClauseIsEmptyRow,
+  MergeStrictRejectsUnknownOutputColumn,
+  MergeStrictRejectsUnknownTargetTable,
+  MergeKeywordIsCaseInsensitive,
 ];


### PR DESCRIPTION
## Summary
`ParseStatementNormalized` only recognized `SELECT`/`INSERT`/`UPDATE`/`DELETE`, so a `MERGE` statement fell straight through to `never` and resolved to a generic `Flatten<{ [x: string]: unknown }>[]` shape - no typing at all. SQL Server has no single-statement upsert other than `MERGE` (Postgres has `INSERT ... ON CONFLICT`, MySQL has `INSERT ... ON DUPLICATE KEY UPDATE`, both already typed correctly in this library), so this was a complete blank for a genuinely common pattern on the one dialect that actually needs it.

## Scope
Per the issue's own suggested shape, this types the target table and the trailing `OUTPUT` clause, not the merge logic itself:

```sql
merge into users as target
using (values (1, 'ada')) as source (id, name)
on target.id = source.id
when matched then update set name = source.name
when not matched then insert (id, name) values (source.id, source.name)
output inserted.id, inserted.name;
```

resolves to `{ id: number; name: string }[]`.

- `MERGE INTO <target>` resolves the target table (explicit `INTO` required - `MERGE <target> USING ...` without it is legal T-SQL but rare, and isn't recognized).
- The trailing `OUTPUT` clause resolves against that target table, reusing the exact same `OUTPUT`/`inserted.`/`deleted.` pseudo-table-qualifier machinery `INSERT`/`UPDATE`/`DELETE` already use.
- The `USING`/`ON`/`WHEN MATCHED`/`WHEN NOT MATCHED` branches aren't parsed or validated at all - modeling them for column resolution would be a materially bigger undertaking than typing the common `OUTPUT` case.
- `OUTPUT $action` (a pseudo-column with no backing table, reporting which `WHEN` branch fired) is recognized and typed as the literal union `'INSERT' | 'UPDATE' | 'DELETE'` - without this, `$action` would resolve to `unknown` in normal mode or a spurious `unknown column: $action` `QueryTypeError` in strict mode, for what's valid, extremely common `MERGE OUTPUT` syntax.

## Test plan
- Added 7 type-level tests to `tests/dialect-mssql.test-d.ts`: happy-path `OUTPUT`, `$action` typing, a target without an alias, no-`OUTPUT`-clause falling back to `EmptyRow` (matching `INSERT`/`UPDATE`/`DELETE`'s existing behavior), strict-mode rejection of an unknown `OUTPUT` column and an unknown target table, and case-insensitivity of the `MERGE` keyword.
- Verified the exact fallback behavior being fixed via a forced type error before writing the fix (`Flatten<{ [x: string]: unknown; }>[]`), and the corrected output after, for several MERGE shapes including the `$action` and no-`OUTPUT` cases, before committing to the tests above.
- Reverted `src/parse.ts` to master in isolation with the new tests in place; all 7 failed with the exact expected type errors, then restored the fix.
- `npm run test:types` passes.
- `npx vitest run` passes (232/232).
- Documented the feature and its scope boundary in README's Supported SQL subset table and Limitations section.

Fixes #172