### PR TITLE
Add a small transaction helper per adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,45 +483,74 @@ provides one), so an INSERT without `RETURNING` is no longer a black box.
 
 ### 11. Transactions
 
-There is no built-in transaction API yet — and there is a footgun to know
-about: **never run `BEGIN`/`COMMIT` through an executor bound to a pool.**
-Each `query()` may check out a *different* connection, so `BEGIN` runs on
-connection A and `COMMIT` on connection B, leaving an open transaction (and
-its locks) on a pooled connection that is later handed to another caller.
+There is a footgun to know about: **never run `BEGIN`/`COMMIT` through an
+executor bound to a pool.** Each `query()` may check out a *different*
+connection, so `BEGIN` runs on connection A and `COMMIT` on connection B,
+leaving an open transaction (and its locks) on a pooled connection that is
+later handed to another caller.
 
-The adapters accept anything with the right `query`/`execute` shape — a
-`pg.Pool`, `pg.Client` or `pg.PoolClient`; a mysql2 `Pool` or `Connection` —
-so pin one connection and scope a client to it:
+`pg`, `postgres.js`, `mysql2`, and `mssql` each ship a small transaction
+helper that pins one connection for the whole callback and handles
+begin/commit/rollback for you:
 
 ```ts
 import { Pool } from 'pg';
-import { createTypedDb } from '@owlsql/core';
-import { createPgExecutor } from '@owlsql/core/pg';
+import { createPgTransaction } from '@owlsql/core/pg';
 
 const pool = new Pool();
 
 async function transferFunds(from: number, to: number, amount: number) {
-  const client = await pool.connect();
-  const tx = createTypedDb<DB>(createPgExecutor(client));
-
-  try {
-    await client.query('begin');
+  await createPgTransaction<DB>(pool)(async (tx) => {
     await tx.query('update accounts set balance = balance - $1 where id = $2', amount, from);
     await tx.query('update accounts set balance = balance + $1 where id = $2', amount, to);
-    await client.query('commit');
-  } catch (error) {
-    await client.query('rollback');
-    throw error;
-  } finally {
-    client.release();
-  }
+  });
 }
 ```
 
-postgres.js has its own `sql.begin(...)` — build the executor from the
-transaction-scoped `sql` it hands you. Kysely users should use Kysely's
-`db.transaction()`. `node:sqlite` is a single connection, so plain
-`begin`/`commit` statements are safe there.
+`createPgTransaction<DB>(pool)` returns the function that actually runs the
+transaction — it's curried on `DB` because TypeScript can't partially infer
+type arguments; a single `createPgTransaction<DB>(pool, fn)` call would
+compile, but would silently stop inferring the callback's return type and
+type it `unknown` instead. Splitting `DB` into its own call keeps the second
+call (`(fn, options?)`) argument-only, so both the optional `options` and the
+callback's return type infer normally.
+
+The callback's `tx` is a full `TypedDb<DB>`, typed exactly like the one
+`createTypedDb` returns (pass `{ strict: true }` as the second argument to
+the inner call the same way: `createPgTransaction<DB>(pool)(fn, { strict:
+true })`). The transaction commits if the callback resolves and rolls back if
+it throws — a rejected `tx.query()` result (the normal `Result` error path)
+does *not* trigger a rollback by itself, only a thrown error does, same as
+everywhere else this library never throws on a query failure.
+
+`createMysql2Transaction<DB>(pool)(fn, options?)` and
+`createMssqlTransaction<DB>(pool)(fn, options?)` work the same way.
+`createPostgresJsTransaction<DB>(sql)(fn, options?)` wraps postgres.js's own
+`sql.begin(...)`, which already pins the connection and handles
+commit/rollback itself.
+
+Kysely users should use Kysely's own `db.transaction()`. `node:sqlite` is a
+single connection, so plain `begin`/`commit` statements are safe there and no
+helper is provided.
+
+Under the hood, each helper does exactly what you'd otherwise write by hand:
+
+```ts
+const client = await pool.connect();
+const tx = createTypedDb<DB>(createPgExecutor(client), { placeholders: 'dollar' });
+
+try {
+  await client.query('begin');
+  await tx.query('update accounts set balance = balance - $1 where id = $2', amount, from);
+  await tx.query('update accounts set balance = balance + $1 where id = $2', amount, to);
+  await client.query('commit');
+} catch (error) {
+  await client.query('rollback');
+  throw error;
+} finally {
+  client.release();
+}
+```
 
 ## Driver recipes
 
@@ -787,6 +816,10 @@ ever required):
 | `createNodeSqliteExecutor(db)` | `@owlsql/core/node-sqlite` | `node:sqlite` `DatabaseSync` → `Executor`. |
 | `createMssqlExecutor(pool)` | `@owlsql/core/mssql` | `mssql` `ConnectionPool` → `Executor`, binding `@name` params. |
 | `createKyselyExecutor(db)` | `@owlsql/core/kysely` | `Kysely<DB>` → `Executor`, via `CompiledQuery.raw`. |
+| `createPgTransaction<DB>(pool)(fn, options?)` | `@owlsql/core/pg` | Pins a `PoolClient`, runs `fn(tx)` inside `BEGIN`/`COMMIT`/`ROLLBACK`. Curried on `DB` - see [Transactions](#11-transactions). |
+| `createMysql2Transaction<DB>(pool)(fn, options?)` | `@owlsql/core/mysql2` | Same shape, over a pinned mysql2 `Connection`. |
+| `createPostgresJsTransaction<DB>(sql)(fn, options?)` | `@owlsql/core/postgres` | Same shape, wrapping postgres.js's own `sql.begin(...)`. |
+| `createMssqlTransaction<DB>(pool)(fn, options?)` | `@owlsql/core/mssql` | Same shape, over a pinned mssql `Transaction`. |
 
 **`query` return type.** `query` resolves to
 `Result<Query<DB, Q>, QueryError>`. On success, `result.value` holds the typed

--- a/src/adapters/mssql.ts
+++ b/src/adapters/mssql.ts
@@ -1,5 +1,6 @@
 import type { ConnectionPool, Transaction, Request } from 'mssql';
-import type { DialectExecutor, QueryMeta } from '../index.js';
+import type { DialectExecutor, QueryMeta, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
+import { createTypedDb } from '../index.js';
 import { collectNamedParameters } from './named-params.js';
 
 const MSSQL_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@']);
@@ -29,5 +30,42 @@ export function createMssqlExecutor(source: MssqlQueryable): DialectExecutor<'at
       meta.rowCount = result.rowsAffected[0];
     }
     return { rows: result.recordset ?? [], meta };
+  };
+}
+
+// A BEGIN TRAN/COMMIT run through an executor bound to the pool is a
+// footgun - each query() would implicitly open its own Request against a
+// fresh connection, never actually joining the transaction. pool.transaction()
+// pins one connection for the whole callback, exactly the pattern already
+// documented by hand in the README's transactions section; commit/rollback
+// already release that connection back to the pool, no separate release step
+// needed.
+//
+// Curried on DB, same as createPgTransaction - see the comment there for why
+// a single combined call would silently break inference of the callback's
+// return type.
+export function createMssqlTransaction<DB extends SchemaLike>(pool: ConnectionPool) {
+  return async function runMssqlTransaction<
+    const Options extends Omit<TypedDbOptions, 'placeholders'> = TypedDbOptions,
+    T = unknown,
+  >(
+    fn: (tx: TypedDb<DB, Options extends { strict: true } ? true : false, 'at'>) => Promise<T>,
+    options?: Options,
+  ): Promise<T> {
+    const transaction = pool.transaction();
+    const tx = createTypedDb<DB, Options & { placeholders: 'at' }>(
+      createMssqlExecutor(transaction),
+      { ...options, placeholders: 'at' } as Options & { placeholders: 'at' },
+    );
+
+    try {
+      await transaction.begin();
+      const result = await fn(tx);
+      await transaction.commit();
+      return result;
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
   };
 }

--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -1,6 +1,7 @@
 import type { Pool, Connection } from 'mysql2/promise';
 import type { ExecuteValues } from 'mysql2';
-import type { DialectExecutor, QueryMeta } from '../index.js';
+import type { DialectExecutor, QueryMeta, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
+import { createTypedDb } from '../index.js';
 
 export type Mysql2Queryable = Pool | Connection;
 
@@ -26,5 +27,44 @@ export function createMysql2Executor(connection: Mysql2Queryable): DialectExecut
       return rows;
     }
     return { rows: [], meta: writeMeta(rows as { affectedRows?: number; insertId?: number }) };
+  };
+}
+
+// A BEGIN/COMMIT run through an executor bound to the pool is a footgun -
+// each query() may check out a different pooled connection, leaving an open
+// transaction (and its locks) on a connection later handed to another
+// caller. This pins one PoolConnection for the whole callback, exactly the
+// pattern already documented by hand in the README's transactions section.
+//
+// Curried on DB, same as createPgTransaction - see the comment there for why
+// a single combined call would silently break inference of the callback's
+// return type.
+export function createMysql2Transaction<DB extends SchemaLike>(pool: Pool) {
+  return async function runMysql2Transaction<
+    const Options extends Omit<TypedDbOptions, 'placeholders'> = TypedDbOptions,
+    T = unknown,
+  >(
+    fn: (
+      tx: TypedDb<DB, Options extends { strict: true } ? true : false, 'question'>,
+    ) => Promise<T>,
+    options?: Options,
+  ): Promise<T> {
+    const connection = await pool.getConnection();
+    const tx = createTypedDb<DB, Options & { placeholders: 'question' }>(
+      createMysql2Executor(connection),
+      { ...options, placeholders: 'question' } as Options & { placeholders: 'question' },
+    );
+
+    try {
+      await connection.beginTransaction();
+      const result = await fn(tx);
+      await connection.commit();
+      return result;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
   };
 }

--- a/src/adapters/pg.ts
+++ b/src/adapters/pg.ts
@@ -1,5 +1,6 @@
 import type { Pool, Client, PoolClient } from 'pg';
-import type { DialectExecutor } from '../index.js';
+import type { DialectExecutor, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
+import { createTypedDb } from '../index.js';
 
 export type PgQueryable = Pool | Client | PoolClient;
 
@@ -19,5 +20,46 @@ export function createPgExecutor(client: PgQueryable): DialectExecutor<'dollar'>
       rows: result.rows,
       meta: result.rowCount === null ? {} : { rowCount: result.rowCount },
     };
+  };
+}
+
+// A BEGIN/COMMIT run through an executor bound to the pool is a footgun -
+// each query() may check out a different pooled connection, leaving an open
+// transaction (and its locks) on a connection later handed to another
+// caller. This pins one PoolClient for the whole callback, exactly the
+// pattern already documented by hand in the README's transactions section.
+//
+// Curried on DB: TypeScript can't partially infer type arguments, so once DB
+// is given explicitly (it always must be - nothing about `pool` carries
+// schema information), a single combined call would silently stop inferring
+// the callback's return type T too, defaulting it to unknown. Splitting DB
+// into its own call keeps the second call argument-only, so Options (via the
+// optional options object) and T (via the callback's return type) both infer
+// normally.
+export function createPgTransaction<DB extends SchemaLike>(pool: Pool) {
+  return async function runPgTransaction<
+    const Options extends Omit<TypedDbOptions, 'placeholders'> = TypedDbOptions,
+    T = unknown,
+  >(
+    fn: (tx: TypedDb<DB, Options extends { strict: true } ? true : false, 'dollar'>) => Promise<T>,
+    options?: Options,
+  ): Promise<T> {
+    const client = await pool.connect();
+    const tx = createTypedDb<DB, Options & { placeholders: 'dollar' }>(createPgExecutor(client), {
+      ...options,
+      placeholders: 'dollar',
+    } as Options & { placeholders: 'dollar' });
+
+    try {
+      await client.query('begin');
+      const result = await fn(tx);
+      await client.query('commit');
+      return result;
+    } catch (error) {
+      await client.query('rollback');
+      throw error;
+    } finally {
+      client.release();
+    }
   };
 }

--- a/src/adapters/postgres.ts
+++ b/src/adapters/postgres.ts
@@ -1,9 +1,12 @@
 import type postgres from 'postgres';
-import type { DialectExecutor } from '../index.js';
+import type { DialectExecutor, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
+import { createTypedDb } from '../index.js';
 
 type PostgresUnsafeParam = NonNullable<Parameters<postgres.Sql['unsafe']>[1]>[number];
 
-export function createPostgresJsExecutor(client: postgres.Sql): DialectExecutor<'dollar'> {
+export function createPostgresJsExecutor(
+  client: postgres.Sql | postgres.TransactionSql,
+): DialectExecutor<'dollar'> {
   return async (sql, params) => {
     // postgres.js throws on a raw undefined parameter ("Undefined values are
     // not allowed") - normalize to null, matching mssql.ts/node-sqlite.ts.
@@ -13,5 +16,33 @@ export function createPostgresJsExecutor(client: postgres.Sql): DialectExecutor<
       rows: [...result],
       meta: typeof result.count === 'number' ? { rowCount: result.count } : {},
     };
+  };
+}
+
+// postgres.js's own sql.begin(...) already pins a single connection and
+// handles commit/rollback (rolling back on a thrown error, committing
+// otherwise) - this just wraps the transaction-scoped sql it hands the
+// callback in a TypedDb, the same way createPostgresJsExecutor wraps the
+// top-level sql.
+//
+// Curried on DB, same as createPgTransaction - see the comment there for why
+// a single combined call would silently break inference of the callback's
+// return type.
+export function createPostgresJsTransaction<DB extends SchemaLike>(sql: postgres.Sql) {
+  return function runPostgresJsTransaction<
+    const Options extends Omit<TypedDbOptions, 'placeholders'> = TypedDbOptions,
+    T = unknown,
+  >(
+    fn: (tx: TypedDb<DB, Options extends { strict: true } ? true : false, 'dollar'>) => Promise<T>,
+    options?: Options,
+  ) {
+    return sql.begin((transactionSql) =>
+      fn(
+        createTypedDb<DB, Options & { placeholders: 'dollar' }>(
+          createPostgresJsExecutor(transactionSql),
+          { ...options, placeholders: 'dollar' } as Options & { placeholders: 'dollar' },
+        ),
+      ),
+    );
   };
 }

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { ConnectionPool, Request, Transaction } from 'mssql';
-import { createMssqlExecutor } from '../src/adapters/mssql.js';
+import { createMssqlExecutor, createMssqlTransaction } from '../src/adapters/mssql.js';
 
 interface FakeRequest {
   input: ReturnType<typeof vi.fn>;
@@ -24,6 +24,28 @@ function fakeTransaction(result: unknown): { transaction: Transaction; request: 
   const request = fakeRequest(result);
   const transaction = { request: () => request } as unknown as Transaction;
   return { transaction, request };
+}
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+function fakeTransactionalPool(): {
+  pool: ConnectionPool;
+  transactionFactory: ReturnType<typeof vi.fn>;
+  begin: ReturnType<typeof vi.fn>;
+  commit: ReturnType<typeof vi.fn>;
+  rollback: ReturnType<typeof vi.fn>;
+  request: FakeRequest;
+} {
+  const request = fakeRequest({ recordset: [] });
+  const begin = vi.fn().mockResolvedValue(undefined);
+  const commit = vi.fn().mockResolvedValue(undefined);
+  const rollback = vi.fn().mockResolvedValue(undefined);
+  const transaction = { begin, commit, rollback, request: () => request };
+  const transactionFactory = vi.fn().mockReturnValue(transaction);
+  const pool = { transaction: transactionFactory } as unknown as ConnectionPool;
+  return { pool, transactionFactory, begin, commit, rollback, request };
 }
 
 describe('createMssqlExecutor', () => {
@@ -107,5 +129,35 @@ describe('createMssqlExecutor', () => {
       ['now', 'now-value'],
       ['id', 7],
     ]);
+  });
+});
+
+describe('createMssqlTransaction', () => {
+  it('begins, runs the callback against the pinned transaction, and commits', async () => {
+    const { pool, transactionFactory, begin, commit, request } = fakeTransactionalPool();
+
+    const result = await createMssqlTransaction<DB>(pool)(async (tx) => {
+      await tx.query('select id from users');
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(transactionFactory).toHaveBeenCalledOnce();
+    expect(begin).toHaveBeenCalledOnce();
+    expect(request.query).toHaveBeenCalledWith('select id from users');
+    expect(commit).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back when the callback throws', async () => {
+    const { pool, rollback, commit } = fakeTransactionalPool();
+
+    await expect(
+      createMssqlTransaction<DB>(pool)(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(rollback).toHaveBeenCalledOnce();
+    expect(commit).not.toHaveBeenCalled();
   });
 });

--- a/tests/adapter-mysql2.test.ts
+++ b/tests/adapter-mysql2.test.ts
@@ -1,10 +1,41 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Pool } from 'mysql2/promise';
-import { createMysql2Executor } from '../src/adapters/mysql2.js';
+import { createMysql2Executor, createMysql2Transaction } from '../src/adapters/mysql2.js';
 
 function fakePool(result: unknown): { pool: Pool; execute: ReturnType<typeof vi.fn> } {
   const execute = vi.fn().mockResolvedValue([result, undefined]);
   return { pool: { execute } as unknown as Pool, execute };
+}
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+function fakeTransactionalPool(): {
+  pool: Pool;
+  getConnection: ReturnType<typeof vi.fn>;
+  execute: ReturnType<typeof vi.fn>;
+  beginTransaction: ReturnType<typeof vi.fn>;
+  commit: ReturnType<typeof vi.fn>;
+  rollback: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+} {
+  const execute = vi.fn().mockResolvedValue([[], undefined]);
+  const beginTransaction = vi.fn().mockResolvedValue(undefined);
+  const commit = vi.fn().mockResolvedValue(undefined);
+  const rollback = vi.fn().mockResolvedValue(undefined);
+  const release = vi.fn();
+  const connection = { execute, beginTransaction, commit, rollback, release };
+  const getConnection = vi.fn().mockResolvedValue(connection);
+  return {
+    pool: { getConnection } as unknown as Pool,
+    getConnection,
+    execute,
+    beginTransaction,
+    commit,
+    rollback,
+    release,
+  };
 }
 
 describe('createMysql2Executor', () => {
@@ -48,5 +79,38 @@ describe('createMysql2Executor', () => {
       7,
       null,
     ]);
+  });
+});
+
+describe('createMysql2Transaction', () => {
+  it('begins, runs the callback against the pinned connection, commits, and releases', async () => {
+    const { pool, getConnection, execute, beginTransaction, commit, release } =
+      fakeTransactionalPool();
+
+    const result = await createMysql2Transaction<DB>(pool)(async (tx) => {
+      await tx.query('select id from users');
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(getConnection).toHaveBeenCalledOnce();
+    expect(beginTransaction).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledWith('select id from users', []);
+    expect(commit).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back and still releases when the callback throws', async () => {
+    const { pool, rollback, commit, release } = fakeTransactionalPool();
+
+    await expect(
+      createMysql2Transaction<DB>(pool)(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(rollback).toHaveBeenCalledOnce();
+    expect(commit).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
   });
 });

--- a/tests/adapter-pg.test.ts
+++ b/tests/adapter-pg.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Pool } from 'pg';
-import { createPgExecutor } from '../src/adapters/pg.js';
+import { createPgExecutor, createPgTransaction } from '../src/adapters/pg.js';
 
 function fakePool(result: { rows: unknown[]; rowCount: number | null }): {
   pool: Pool;
@@ -8,6 +8,23 @@ function fakePool(result: { rows: unknown[]; rowCount: number | null }): {
 } {
   const query = vi.fn().mockResolvedValue(result);
   return { pool: { query } as unknown as Pool, query };
+}
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+function fakeTransactionalPool(): {
+  pool: Pool;
+  connect: ReturnType<typeof vi.fn>;
+  clientQuery: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+} {
+  const clientQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+  const release = vi.fn();
+  const client = { query: clientQuery, release };
+  const connect = vi.fn().mockResolvedValue(client);
+  return { pool: { connect } as unknown as Pool, connect, clientQuery, release };
 }
 
 describe('createPgExecutor', () => {
@@ -57,5 +74,60 @@ describe('createPgExecutor', () => {
       7,
       null,
     ]);
+  });
+});
+
+describe('createPgTransaction', () => {
+  it('begins, runs the callback against the pinned client, commits, and releases', async () => {
+    const { pool, connect, clientQuery, release } = fakeTransactionalPool();
+    const calls: string[] = [];
+    clientQuery.mockImplementation(async (sql: string) => {
+      calls.push(sql);
+      return { rows: [], rowCount: 0 };
+    });
+
+    const result = await createPgTransaction<DB>(pool)(async (tx) => {
+      await tx.query('select id from users');
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(connect).toHaveBeenCalledOnce();
+    expect(calls).toEqual(['begin', 'select id from users', 'commit']);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back and still releases when the callback throws', async () => {
+    const { pool, clientQuery, release } = fakeTransactionalPool();
+    const calls: string[] = [];
+    clientQuery.mockImplementation(async (sql: string) => {
+      calls.push(sql);
+      return { rows: [], rowCount: 0 };
+    });
+
+    await expect(
+      createPgTransaction<DB>(pool)(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(calls).toEqual(['begin', 'rollback']);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('releases even when commit itself throws', async () => {
+    const { pool, clientQuery, release } = fakeTransactionalPool();
+    clientQuery.mockImplementation(async (sql: string) => {
+      if (sql === 'commit') {
+        throw new Error('commit failed');
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    await expect(createPgTransaction<DB>(pool)(async () => 'done')).rejects.toThrow(
+      'commit failed',
+    );
+
+    expect(release).toHaveBeenCalledOnce();
   });
 });

--- a/tests/adapter-postgres.test.ts
+++ b/tests/adapter-postgres.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type postgres from 'postgres';
-import { createPostgresJsExecutor } from '../src/adapters/postgres.js';
+import { createPostgresJsExecutor, createPostgresJsTransaction } from '../src/adapters/postgres.js';
 
 function fakeClient(rows: unknown[], count: number | null): {
   client: postgres.Sql;
@@ -9,6 +9,27 @@ function fakeClient(rows: unknown[], count: number | null): {
   const result = Object.assign([...rows], { count });
   const unsafe = vi.fn().mockResolvedValue(result);
   return { client: { unsafe } as unknown as postgres.Sql, unsafe };
+}
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+function fakeTransactionalSql(): {
+  sql: postgres.Sql;
+  unsafe: ReturnType<typeof vi.fn>;
+  begin: ReturnType<typeof vi.fn>;
+} {
+  const result = Object.assign([], { count: 0 });
+  const unsafe = vi.fn().mockResolvedValue(result);
+  const transactionSql = { unsafe } as unknown as postgres.TransactionSql;
+  // Real sql.begin invokes the callback with a transaction-scoped sql,
+  // commits on a resolved callback, and rolls back (rejecting) on a thrown
+  // one - the fake only needs to reproduce that pass-through/reject shape.
+  const begin = vi.fn(async (cb: (transactionSql: postgres.TransactionSql) => unknown) =>
+    cb(transactionSql),
+  );
+  return { sql: { begin } as unknown as postgres.Sql, unsafe, begin };
 }
 
 describe('createPostgresJsExecutor', () => {
@@ -31,5 +52,30 @@ describe('createPostgresJsExecutor', () => {
       7,
       null,
     ]);
+  });
+});
+
+describe('createPostgresJsTransaction', () => {
+  it('runs the callback against the transaction-scoped sql via sql.begin', async () => {
+    const { sql, unsafe, begin } = fakeTransactionalSql();
+
+    const result = await createPostgresJsTransaction<DB>(sql)(async (tx) => {
+      await tx.query('select id from users');
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+    expect(begin).toHaveBeenCalledOnce();
+    expect(unsafe).toHaveBeenCalledWith('select id from users', []);
+  });
+
+  it('propagates a thrown error from the callback - sql.begin owns the rollback itself', async () => {
+    const { sql } = fakeTransactionalSql();
+
+    await expect(
+      createPostgresJsTransaction<DB>(sql)(async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
   });
 });

--- a/tests/adapter-transactions.test-d.ts
+++ b/tests/adapter-transactions.test-d.ts
@@ -1,0 +1,77 @@
+import type { Pool as PgPool } from 'pg';
+import type { Pool as Mysql2Pool } from 'mysql2/promise';
+import type postgres from 'postgres';
+import type { ConnectionPool } from 'mssql';
+import type { Result, QueryError, QueryTypeError } from '../src/index.js';
+import { createPgTransaction } from '../src/adapters/pg.js';
+import { createPostgresJsTransaction } from '../src/adapters/postgres.js';
+import { createMysql2Transaction } from '../src/adapters/mysql2.js';
+import { createMssqlTransaction } from '../src/adapters/mssql.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+declare const pgPool: PgPool;
+declare const mysqlPool: Mysql2Pool;
+declare const postgresJsSql: postgres.Sql;
+declare const mssqlPool: ConnectionPool;
+
+export async function transactionPlaceholderStyleCallSites() {
+  await createPgTransaction<DB>(pgPool)(async (tx) => {
+    await tx.query('select id from users where id = $1', 1);
+
+    // @ts-expect-error a pg transaction's tx rejects ? placeholders
+    await tx.query('select id from users where id = ?', 1);
+  });
+
+  await createPostgresJsTransaction<DB>(postgresJsSql)(async (tx) => {
+    await tx.query('select id from users where id = $1', 1);
+
+    // @ts-expect-error a postgres.js transaction's tx rejects ? placeholders
+    await tx.query('select id from users where id = ?', 1);
+  });
+
+  await createMysql2Transaction<DB>(mysqlPool)(async (tx) => {
+    await tx.query('select id from users where id = ?', 1);
+
+    // @ts-expect-error a mysql2 transaction's tx rejects $n placeholders
+    await tx.query('select id from users where id = $1', 1);
+  });
+
+  await createMssqlTransaction<DB>(mssqlPool)(async (tx) => {
+    await tx.query('select id from users where id = @id', 1);
+
+    // @ts-expect-error an mssql transaction's tx rejects $n placeholders
+    await tx.query('select id from users where id = $1', 1);
+  });
+}
+
+export async function transactionReturnValuePassesThrough() {
+  // DB has to be curried into its own call - TypeScript can't partially
+  // infer type arguments, so a single combined call (DB explicit, T left to
+  // infer) would silently default T to unknown instead of inferring it from
+  // the callback's return type.
+  const result = await createPgTransaction<DB>(pgPool)(async () => 42);
+  const check: number = result;
+  void check;
+}
+
+export async function strictOptionFlowsThroughToTheCallback() {
+  await createPgTransaction<DB>(pgPool)(
+    async (tx) => {
+      const result = await tx.query('select bogus from users');
+      type _StrictOptionProducesAQueryTypeError = Expect<
+        Equal<typeof result, Result<QueryTypeError<'unknown column: bogus'>[], QueryError>>
+      >;
+    },
+    { strict: true },
+  );
+}


### PR DESCRIPTION
## Summary
README's transactions section spelled out a real footgun by hand: never run `BEGIN`/`COMMIT` through an executor bound to a pool, since each `query()` may check out a *different* connection, leaving an open transaction (and its locks) on a connection later handed to another caller. The documented workaround was entirely manual - pin a connection, build a second `createTypedDb` scoped to it, wrap in try/catch/finally, every time, in every project that does more than single-statement writes.

## Changes
Added `createPgTransaction`, `createPostgresJsTransaction`, `createMysql2Transaction`, and `createMssqlTransaction` - one per adapter that supports transactions. Each pins the right connection type for its driver (a `pg` `PoolClient`, a mysql2 `Connection`, postgres.js's own `sql.begin()`-scoped client, an mssql `Transaction` via `pool.transaction()`) and does exactly what the README's manual example already did by hand: begin, run the callback, commit on success, roll back and rethrow on a thrown error, release the pinned connection.

Kysely already has its own `db.transaction()`, and `node:sqlite` is a single connection with no pooling footgun to guard against, so neither gets a helper - documented as such.

## A note on the API shape
Each helper is **curried on `DB`**: `createPgTransaction<DB>(pool)(fn, options?)`, not the single-call `createPgTransaction(pool, fn)` a first pass (and the issue's own rough sketch) suggested. TypeScript can't partially infer type arguments - once `DB` is explicit (it always must be; nothing about `pool` carries schema information), a single combined call would silently *stop* inferring the callback's return type too, defaulting it to `unknown` instead of the real type. I confirmed this with an isolated repro before settling on the curried shape: splitting `DB` into its own call keeps the second call argument-only, so both the optional `options` (for strict mode, via a `const` type parameter) and the callback's return type infer normally.

The callback's `tx` is a full `TypedDb<DB>`, dialect-branded the same way `createTypedDb` already supports via `options.placeholders` - a query using the wrong placeholder style inside the callback is a compile error, verified via `@ts-expect-error`.

## Test plan
- Added a `describe` block per adapter to its existing runtime test file (`tests/adapter-{pg,postgres,mysql2,mssql}.test.ts`) covering: begin → callback → commit → release on success, rollback + release on a thrown callback error, and (pg) that release still happens even when commit itself throws.
- Added `tests/adapter-transactions.test-d.ts`: placeholder-style rejection per adapter via `@ts-expect-error`, the callback's return value passing through correctly, and `{ strict: true }` flowing through to the callback's `tx` (verified by asserting the exact `QueryTypeError` shape an unknown column produces).
- Reverted all four adapter source files to master in isolation with every new test in place; all of them failed (missing exports, implicit-any callback params, an unsatisfied `Expect<true>` constraint), then restored the fix.
- `npm run test:types` passes.
- `npx vitest run` passes (241/241).
- Rewrote README's Transactions section (#11) to lead with the helpers, explain the curried shape and why, and keep the manual pattern as "what the helper does under the hood." Added the four new exports to the API reference table.

Fixes #173