### PR TITLE
Add ts-plugin diagnostics for simple WHERE-clause column references

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,17 +715,21 @@ any `FROM` is typed at all, exactly what covers the example above. `WHERE`-
 position completions require a `FROM` to already be present (there's no
 table to scope to otherwise). It also reports unknown columns, unknown
 tables, unknown aliases, and ambiguous unqualified columns (present in more
-than one joined table) as live editor diagnostics in the `SELECT` list and
-`FROM`/`JOIN` clause — the same checks strict mode (`{ strict: true }`)
-applies at compile time, surfaced as a squiggle while you type instead of
-only once the query is finished.
+than one joined table) as live editor diagnostics in the `SELECT` list,
+`FROM`/`JOIN` clause, and simple `WHERE` comparisons (`where naem = 'x'`
+squiggles `naem` the moment you type it) — the same checks strict mode
+(`{ strict: true }`) applies at compile time, surfaced as a squiggle while
+you type instead of only once the query is finished.
 
 **What it does not do** (documented scope, not bugs):
 
-- No diagnostics for the `WHERE` clause or other expressions — only the
-  `SELECT` list and `FROM`/`JOIN` table names are checked, matching what the
-  type-level parser itself validates (`WHERE` is scanned only for
-  parameter placeholders, never typed).
+- **`WHERE`-clause diagnostics cover simple comparisons only.** A column
+  token immediately before `=`/`<>`/`<`/`>`/`<=`/`>=`/`LIKE`/`ILIKE`/`IN`/
+  `BETWEEN`/`IS`, or `AND`/`OR`, or the end of the clause, is checked exactly
+  like a `SELECT`-list column. The moment a `WHERE` clause contains any `(`
+  or `)` at all — a subquery, a function call, a parenthesized group — the
+  whole clause is skipped rather than risked: no diagnostics for it, never a
+  wrong one. `HAVING`/`ORDER BY`/`GROUP BY` aren't checked at all.
 - No table-name completions after `FROM`/`JOIN` — only column names, after
   `SELECT`/`WHERE`, are suggested.
 - The first `FROM <table>` is found with a regex, not a real SQL parser: a

--- a/src/ts-plugin/diagnostics.cts
+++ b/src/ts-plugin/diagnostics.cts
@@ -10,6 +10,36 @@ const DISTINCT_KEYWORD = /^\s*distinct\b/i;
 const LITERAL_TOKEN = /^(?:-?\d+(?:\.\d+)?|true|false|null)$/i;
 const QUOTE_CHAR = /['"`[\]]/;
 const AS_KEYWORD = /^as$/i;
+const WHERE_KEYWORD = /\bwhere\b/gi;
+const WHERE_CLAUSE_BOUNDARY_WORDS: ReadonlySet<string> = new Set([
+  'group',
+  'having',
+  'order',
+  'limit',
+  'offset',
+  'union',
+]);
+// Mirrors IsTriggerOperator/IsAndOr/IsTransparentToken in src/where.ts: the
+// type-level WHERE scanner validates whichever token sits immediately before
+// one of these, plus the clause's trailing token.
+const WHERE_TRIGGER_OPERATORS: ReadonlySet<string> = new Set([
+  '=',
+  '<>',
+  '!=',
+  '<',
+  '>',
+  '<=',
+  '>=',
+  'like',
+  'ilike',
+  'in',
+  'between',
+  'is',
+]);
+const WHERE_AND_OR: ReadonlySet<string> = new Set(['and', 'or']);
+const WHERE_TRANSPARENT_WORD = /^not$/i;
+const WHERE_IDENTIFIER_TOKEN = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/;
+const WHERE_PLACEHOLDER_TOKEN = /^(?:\$\d+|\?|@[A-Za-z_][A-Za-z0-9_]*)$/;
 
 interface ColumnEntry {
   text: string;
@@ -60,6 +90,164 @@ function splitTopLevelCommas(text: string): ColumnEntry[] {
 function skipLeadingKeyword(text: string, keyword: RegExp): string {
   const match = keyword.exec(text);
   return match ? text.slice(match[0].length) : text;
+}
+
+// Finds the top-level WHERE clause's body, bounded by the next top-level
+// GROUP BY/HAVING/ORDER BY/LIMIT/OFFSET/UNION keyword (or the end of the
+// text). Those clauses have their own, different column semantics (HAVING
+// sees aggregates, ORDER BY can reference a SELECT-list alias), so they're
+// excluded rather than treated as more WHERE text.
+function findWhereClauseText(text: string): { text: string; start: number } | null {
+  WHERE_KEYWORD.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = WHERE_KEYWORD.exec(text)) !== null) {
+    let depth = 0;
+    for (let i = 0; i < match.index; i += 1) {
+      if (text[i] === '(') depth += 1;
+      else if (text[i] === ')') depth -= 1;
+    }
+    if (depth !== 0) {
+      continue;
+    }
+
+    const clauseStart = match.index + match[0].length;
+    let end = text.length;
+    let wordStart = clauseStart;
+    let boundaryDepth = 0;
+    for (let i = clauseStart; i <= text.length; i += 1) {
+      const char = text[i];
+      if (char === '(') boundaryDepth += 1;
+      else if (char === ')') boundaryDepth -= 1;
+
+      if (char === undefined || char === ' ') {
+        const word = text.slice(wordStart, i).toLowerCase();
+        if (boundaryDepth === 0 && WHERE_CLAUSE_BOUNDARY_WORDS.has(word)) {
+          end = wordStart;
+          break;
+        }
+        wordStart = i + 1;
+      }
+    }
+
+    return { text: text.slice(clauseStart, end), start: clauseStart };
+  }
+  return null;
+}
+
+// Validates one WHERE-clause token the same way an unqualified/qualified
+// SELECT-list column already is. Only plain identifier-shaped tokens are
+// checked - literals, placeholders, quoted identifiers, and anything
+// operator-shaped are silently left alone, matching how src/where.ts's
+// ValidateWhereOperand already short-circuits on IsPlaceholder/LiteralType
+// before attempting a column lookup.
+function whereTokenDiagnostics(
+  checker: ts.TypeChecker,
+  dbType: ts.Type,
+  literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral,
+  sources: ReturnType<typeof findSources>,
+  token: { text: string; start: number },
+): DiagnosticSpan[] {
+  if (
+    !WHERE_IDENTIFIER_TOKEN.test(token.text) ||
+    LITERAL_TOKEN.test(token.text) ||
+    WHERE_PLACEHOLDER_TOKEN.test(token.text)
+  ) {
+    return [];
+  }
+
+  const dotIndex = token.text.indexOf('.');
+  const qualifier = dotIndex === -1 ? null : token.text.slice(0, dotIndex);
+  const columnName = dotIndex === -1 ? token.text : token.text.slice(dotIndex + 1);
+  const columnStart = token.start + (dotIndex === -1 ? 0 : dotIndex + 1);
+
+  if (qualifier) {
+    const matchedSource = findSourceByAlias(sources, qualifier);
+    if (!matchedSource) {
+      return [{ start: token.start, length: qualifier.length, message: `unknown alias: ${qualifier}` }];
+    }
+    if (!checker.getPropertyOfType(dbType, matchedSource.table)) {
+      return [];
+    }
+    const names = getColumnNames(checker, dbType, literal, matchedSource.table);
+    return names.includes(columnName)
+      ? []
+      : [{ start: columnStart, length: columnName.length, message: `unknown column: ${columnName}` }];
+  }
+
+  const knownTables = sources.filter((source) => checker.getPropertyOfType(dbType, source.table));
+  if (knownTables.length === 0) {
+    return [];
+  }
+
+  const containingTables = knownTables.filter((source) =>
+    getColumnNames(checker, dbType, literal, source.table).includes(columnName),
+  );
+
+  if (containingTables.length === 0) {
+    return [{ start: columnStart, length: columnName.length, message: `unknown column: ${columnName}` }];
+  }
+  if (containingTables.length > 1) {
+    return [{ start: columnStart, length: columnName.length, message: `ambiguous column: ${columnName}` }];
+  }
+  return [];
+}
+
+// Scans the WHERE clause the same way src/where.ts's type-level WhereScan
+// does: track the token immediately before it, and validate that token as a
+// column reference whenever a comparison operator, AND/OR, or the end of the
+// clause is reached. Deliberately skips anything containing a paren
+// (subqueries, function calls, grouped expressions) rather than tracking
+// depth through them - the common, parenthesis-free case is what this
+// recovers diagnostics for; a stray ( or ) just means no extra diagnostics,
+// never a wrong one.
+function findWhereDiagnostics(
+  checker: ts.TypeChecker,
+  dbType: ts.Type,
+  literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral,
+  sources: ReturnType<typeof findSources>,
+  stripped: string,
+  literalStart: number,
+): DiagnosticSpan[] {
+  const clause = findWhereClauseText(stripped);
+  if (!clause || clause.text.includes('(') || clause.text.includes(')')) {
+    return [];
+  }
+
+  const diagnostics: DiagnosticSpan[] = [];
+  let prevToken: { text: string; start: number } | null = null;
+  const wordPattern = /\S+/g;
+  let match: RegExpExecArray | null;
+
+  const flush = () => {
+    if (!prevToken) {
+      return;
+    }
+    diagnostics.push(
+      ...whereTokenDiagnostics(checker, dbType, literal, sources, {
+        text: prevToken.text,
+        start: literalStart + prevToken.start,
+      }),
+    );
+  };
+
+  while ((match = wordPattern.exec(clause.text)) !== null) {
+    const word = match[0];
+    const lower = word.toLowerCase();
+    const start = clause.start + match.index;
+
+    if (WHERE_TRIGGER_OPERATORS.has(lower) || WHERE_AND_OR.has(lower)) {
+      flush();
+      prevToken = null;
+      continue;
+    }
+    if (WHERE_TRANSPARENT_WORD.test(word)) {
+      continue;
+    }
+    prevToken = { text: word, start };
+  }
+  flush();
+
+  return diagnostics;
 }
 
 function columnTokenFromEntry(entry: ColumnEntry): { token: string; offset: number } | null {
@@ -181,6 +369,8 @@ function getQueryDiagnostics(
       diagnostics.push({ start: columnStart, length: columnName.length, message: `ambiguous column: ${columnName}` });
     }
   }
+
+  diagnostics.push(...findWhereDiagnostics(checker, dbType, literal, sources, stripped, literalStart));
 
   return diagnostics;
 }

--- a/tests/ts-plugin-diagnostics.test.ts
+++ b/tests/ts-plugin-diagnostics.test.ts
@@ -141,4 +141,60 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
       ),
     ).toEqual([]);
   });
+
+  it('reports an unknown column referenced in the WHERE clause (issue #174 repro)', () => {
+    expect(diagnosticsFor("select id from users where naem = 'x'")).toEqual([
+      { message: 'unknown column: naem', text: 'naem' },
+    ]);
+  });
+
+  it('reports an unknown alias qualifier in the WHERE clause', () => {
+    expect(diagnosticsFor('select id from users u where z.id = 1')).toEqual([
+      { message: 'unknown alias: z', text: 'z' },
+    ]);
+  });
+
+  it('reports an unknown column on a specific alias in the WHERE clause', () => {
+    expect(
+      diagnosticsFor('select u.id from users u join posts p on p.user_id = u.id where u.nope = 1'),
+    ).toEqual([{ message: 'unknown column: nope', text: 'nope' }]);
+  });
+
+  it('reports an ambiguous unqualified column in the WHERE clause', () => {
+    expect(
+      diagnosticsFor('select u.id from users u join posts p on p.user_id = u.id where id = 1'),
+    ).toEqual([{ message: 'ambiguous column: id', text: 'id' }]);
+  });
+
+  it('reports no diagnostics for a valid WHERE clause with AND/OR and a trailing operand', () => {
+    expect(
+      diagnosticsFor("select id from users where name = 'ada' and id = 1 or id = 2"),
+    ).toEqual([]);
+  });
+
+  it('does not flag literal or placeholder operands in the WHERE clause', () => {
+    expect(diagnosticsFor('select id from users where id = $1 and name is not null')).toEqual([]);
+  });
+
+  it('does not flag a valid BETWEEN clause', () => {
+    expect(diagnosticsFor('select id from users where id between 1 and 10')).toEqual([]);
+  });
+
+  it('skips WHERE diagnostics entirely once a paren appears, rather than risking a false positive', () => {
+    expect(
+      diagnosticsFor("select id from users where id in (1, 2, 3) and naem = 'x'"),
+    ).toEqual([]);
+  });
+
+  it('does not let an ORDER BY alias bleed into WHERE-clause validation', () => {
+    expect(
+      diagnosticsFor("select id from users where name = 'ada' order by id desc"),
+    ).toEqual([]);
+  });
+
+  it('reports a WHERE-clause typo alongside a genuinely unrelated ORDER BY clause', () => {
+    expect(
+      diagnosticsFor('select id from users where naem = 1 order by id desc'),
+    ).toEqual([{ message: 'unknown column: naem', text: 'naem' }]);
+  });
 });


### PR DESCRIPTION
## Summary
The editor plugin already reports unknown columns/tables/aliases and ambiguous columns live for the `SELECT` list and `FROM`/`JOIN` clause, but README explicitly called `WHERE` out as documented scope, not a bug - even though `src/where.ts`'s `WhereClauseError` already validates `WHERE`-clause column references in strict mode (`tests/where-strict.test-d.ts`). A typo like `where naem = 'x'` is at least as common as one in the `SELECT` list, and previously only got caught at compile time, never as a live squiggle.

## Approach
`diagnostics.cts` already reimplements `SELECT`-list scanning at runtime rather than calling into the compile-time types directly (`WhereScan` in `where.ts` is type-level only - there's nothing to call into), so the `WHERE` side gets the same treatment: a runtime scanner that mirrors `WhereScan`'s actual algorithm from `src/where.ts` - track the token immediately before it, and validate that token as a column reference whenever a comparison operator (`=`, `<>`, `<`, `>`, `<=`, `>=`, `LIKE`, `ILIKE`, `IN`, `BETWEEN`, `IS`), `AND`/`OR`, or the end of the clause is reached. The `WHERE` clause itself is bounded by the next top-level `GROUP BY`/`HAVING`/`ORDER BY`/`LIMIT`/`OFFSET`/`UNION` keyword, since those clauses have different column semantics (`HAVING` sees aggregates, `ORDER BY` can reference a `SELECT`-list alias) and aren't part of this.

## Scope
Deliberately bounded: the moment a `WHERE` clause contains any paren at all (a subquery, a function call, a grouped expression), the whole clause is skipped rather than attempting to track depth through it. This recovers diagnostics for the common, parenthesis-free case - not full parity with the type-level scanner. A stray paren means no extra diagnostics, never a wrong one.

## Test plan
- Added 10 tests to `tests/ts-plugin-diagnostics.test.ts` covering the issue's exact repro, an unqualified/qualified unknown column, an unknown alias, an ambiguous column, `AND`/`OR` chains with a trailing operand, literal/placeholder operands not being flagged, `BETWEEN`, the paren bail-out not producing a false negative, and a `WHERE` typo correctly surfacing alongside (not swallowed by) an unrelated `ORDER BY` clause.
- Ran the full existing `getQueryDiagnostics` suite before writing new tests to confirm no regressions from the new code path (all pre-existing tests still pass, including ones with `WHERE`-clause string literals containing `--`).
- Reverted `diagnostics.cts` to master in isolation with the new tests in place; all 5 new WHERE-specific tests failed with the exact expected mismatches, then restored the fix.
- `npm run test:types` passes.
- `npx vitest run` passes (242/242).
- Updated README's editor-autocomplete section: replaced the stale "`WHERE` is scanned only for parameter placeholders, never typed" claim (already inaccurate before this PR - `where.ts` does validate it in strict mode) with an accurate description of the new capability and its scope boundary.

Fixes #174