### PR TITLE
Add ts-plugin table-name completion after FROM/JOIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,21 +704,24 @@ that talk to `tsserver` (Cursor, some Neovim/Sublime LSP setups) generally
 pick up `tsconfig.json` plugins automatically.
 
 **What it does:** suggests column names right after `SELECT`/a comma in the
-column list or after `WHERE`/`AND`/`OR`, and shows a column's resolved type
-on hover, for `db.query(...)` calls made through a client built with
-`createTypedDb<DB>`. It is `JOIN`/alias-aware: every table introduced by a
-`FROM` or `JOIN` in the same string is in scope, and typing an alias
-qualifier (`u.` in `... from users u`) narrows completions and hover to that
-one source. With no qualifier, completions/hover union columns across all
-sources present so far — the deduplicated union of every table in `DB` before
-any `FROM` is typed at all, exactly what covers the example above. `WHERE`-
-position completions require a `FROM` to already be present (there's no
-table to scope to otherwise). It also reports unknown columns, unknown
-tables, unknown aliases, and ambiguous unqualified columns (present in more
-than one joined table) as live editor diagnostics in the `SELECT` list and
-`FROM`/`JOIN` clause — the same checks strict mode (`{ strict: true }`)
-applies at compile time, surfaced as a squiggle while you type instead of
-only once the query is finished.
+column list or after `WHERE`/`AND`/`OR`, suggests table names right after
+`FROM`/`JOIN` (or a comma in an old-style comma-joined `FROM` list), and
+shows a column's resolved type on hover, for `db.query(...)` calls made
+through a client built with `createTypedDb<DB>`. It is `JOIN`/alias-aware:
+every table introduced by a `FROM` or `JOIN` in the same string is in scope,
+and typing an alias qualifier (`u.` in `... from users u`) narrows
+completions and hover to that one source. With no qualifier, completions/hover
+union columns across all sources present so far — the deduplicated union of
+every table in `DB` before any `FROM` is typed at all, exactly what covers
+the example above. `WHERE`-position completions require a `FROM` to already
+be present (there's no table to scope to otherwise); table-name completions
+after `FROM`/`JOIN` suggest every table in `DB`, filtered by whatever prefix
+you've typed. It also reports unknown columns, unknown tables, unknown
+aliases, and ambiguous unqualified columns (present in more than one joined
+table) as live editor diagnostics in the `SELECT` list and `FROM`/`JOIN`
+clause — the same checks strict mode (`{ strict: true }`) applies at compile
+time, surfaced as a squiggle while you type instead of only once the query
+is finished.
 
 **What it does not do** (documented scope, not bugs):
 
@@ -726,8 +729,6 @@ only once the query is finished.
   `SELECT` list and `FROM`/`JOIN` table names are checked, matching what the
   type-level parser itself validates (`WHERE` is scanned only for
   parameter placeholders, never typed).
-- No table-name completions after `FROM`/`JOIN` — only column names, after
-  `SELECT`/`WHERE`, are suggested.
 - The first `FROM <table>` is found with a regex, not a real SQL parser: a
   `FROM (subquery)` can make it lock onto a table name from inside the
   subquery instead of recognizing there's no real outer table yet.
@@ -738,7 +739,8 @@ only once the query is finished.
   (`` db.query(`select ... ${x}`) ``) silently turns completions/hover off
   for that call — there's no squiggle or warning telling you why.
 - Completions after `ORDER BY`/`GROUP BY`/`HAVING`/etc. aren't offered yet —
-  only the `SELECT` column list and `WHERE` clause.
+  only the `SELECT` column list, `WHERE` clause, and `FROM`/`JOIN` table
+  names.
 - **Requires TypeScript < 7.** TypeScript 7's native (Go-based) compiler
   removed the classic JS Compiler API (`ts.Node`, `ts.forEachChild`,
   `ts.createProgram`, ...) that this plugin — and, as of this writing, every

--- a/src/ts-plugin/index.cts
+++ b/src/ts-plugin/index.cts
@@ -7,6 +7,7 @@ import diagnosticsModule = require('./diagnostics.cjs');
 const {
   getSelectListContext,
   getWhereClauseContext,
+  getFromClauseContext,
   findSources,
   findSourceByAlias,
   getQualifierBefore,
@@ -29,6 +30,33 @@ function resolveTableScope(
   }
 
   return sources.length > 0 ? sources.map((source) => source.table) : null;
+}
+
+function completionsFromNames(
+  names: string[],
+  prefix: string,
+  position: number,
+  kind: ts.ScriptElementKind,
+): ts.WithMetadata<ts.CompletionInfo> | null {
+  const lowerPrefix = prefix.toLowerCase();
+  const filtered = names.filter((name) => name.toLowerCase().startsWith(lowerPrefix));
+  if (filtered.length === 0) {
+    return null;
+  }
+
+  const replacementSpan = { start: position - prefix.length, length: prefix.length };
+
+  return {
+    isGlobalCompletion: false,
+    isMemberCompletion: false,
+    isNewIdentifierLocation: false,
+    entries: filtered.map((name) => ({
+      name,
+      kind,
+      sortText: '0',
+      replacementSpan,
+    })),
+  };
 }
 
 function init(modules: { typescript: typeof ts }) {
@@ -68,37 +96,33 @@ function init(modules: { typescript: typeof ts }) {
         const literalStart = match.literal.getStart(sourceFile) + 1;
         const textBeforeCursor = sourceFile.text.slice(literalStart, position);
         const context = getSelectListContext(textBeforeCursor) ?? getWhereClauseContext(textBeforeCursor);
-        if (!context) {
-          return native();
+        if (context) {
+          const fullLiteralText = match.literal.text;
+          const sources = findSources(fullLiteralText);
+          const table = resolveTableScope(sources, context.qualifier);
+          const columns = getColumnNames(checker, match.dbType, match.literal, table);
+          const response = completionsFromNames(
+            columns,
+            context.prefix,
+            position,
+            typescript.ScriptElementKind.memberVariableElement,
+          );
+          return response ?? native();
         }
 
-        const fullLiteralText = match.literal.text;
-        const sources = findSources(fullLiteralText);
-        const table = resolveTableScope(sources, context.qualifier);
-        const columns = getColumnNames(checker, match.dbType, match.literal, table);
-        const prefix = context.prefix.toLowerCase();
-        const filtered = columns.filter((name) => name.toLowerCase().startsWith(prefix));
-
-        if (filtered.length === 0) {
-          return native();
+        const tableContext = getFromClauseContext(textBeforeCursor);
+        if (tableContext) {
+          const tableNames = match.dbType.getProperties().map((symbol) => symbol.getName());
+          const response = completionsFromNames(
+            tableNames,
+            tableContext.prefix,
+            position,
+            typescript.ScriptElementKind.classElement,
+          );
+          return response ?? native();
         }
 
-        const replacementSpan = {
-          start: position - context.prefix.length,
-          length: context.prefix.length,
-        };
-
-        return {
-          isGlobalCompletion: false,
-          isMemberCompletion: false,
-          isNewIdentifierLocation: false,
-          entries: filtered.map((name) => ({
-            name,
-            kind: typescript.ScriptElementKind.memberVariableElement,
-            sortText: '0',
-            replacementSpan,
-          })),
-        };
+        return native();
       } catch {
         return native();
       }

--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -7,6 +7,8 @@ const CTE_NAME = /^\s*([A-Za-z_][A-Za-z0-9_]*)/;
 const AS_KEYWORD_START = /^\s*as\b/i;
 const LEADING_COMMA = /^\s*,/;
 const QUALIFIED_TRAILING_TOKEN = /(?:([A-Za-z_][A-Za-z0-9_]*)\.)?([A-Za-z0-9_]*)$/;
+const FROM_JOIN_TABLE_START = /(?:\bfrom|\bjoin)\s+([A-Za-z0-9_]*)$/i;
+const FROM_LIST_COMMA_START = /,\s*([A-Za-z0-9_]*)$/;
 const FROM_TABLE = /\bfrom\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)/i;
 const FROM_OR_JOIN_SOURCE = /\b(from|join)\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)(?:\s+(as\s+)?([A-Za-z_][A-Za-z0-9_]*))?/gid;
 const WORD_CHAR = /[A-Za-z0-9_]/;
@@ -263,6 +265,36 @@ function getWhereClauseContext(textBeforeCursor: string): SelectListContext | nu
   return prefixFrom(textBeforeCursor);
 }
 
+// Table-name completion triggers right after FROM/JOIN (any INNER/LEFT/
+// RIGHT/FULL/CROSS modifier before JOIN doesn't matter, only the JOIN
+// keyword itself does), or after a comma in an old-style comma-joined FROM
+// list. The comma case only fires once a FROM has been seen and no later
+// clause keyword (WHERE/HAVING/ON/GROUP BY/ORDER BY) has started yet -
+// otherwise a plain SELECT-list comma, or a comma inside a WHERE/ON
+// expression, would be misread as a table position too.
+function getFromClauseContext(textBeforeCursor: string): SelectListContext | null {
+  const { stripped, insideLiteral } = stripStringLiterals(textBeforeCursor);
+  if (insideLiteral) {
+    return null;
+  }
+
+  const { remainder } = stripWithClause(stripped);
+
+  const directMatch = FROM_JOIN_TABLE_START.exec(remainder);
+  if (directMatch) {
+    return { prefix: directMatch[1] ?? '', qualifier: null };
+  }
+
+  if (HAS_FROM.test(remainder) && !HAS_COLUMN_CLAUSE.test(remainder)) {
+    const commaMatch = FROM_LIST_COMMA_START.exec(remainder);
+    if (commaMatch) {
+      return { prefix: commaMatch[1] ?? '', qualifier: null };
+    }
+  }
+
+  return null;
+}
+
 function findFromTable(fullLiteralText: string): string | null {
   const { stripped } = stripStringLiterals(fullLiteralText);
   const match = FROM_TABLE.exec(stripped);
@@ -351,6 +383,7 @@ function getWordAtOffset(text: string, offset: number): WordAtOffset | null {
 export = {
   getSelectListContext,
   getWhereClauseContext,
+  getFromClauseContext,
   findFromTable,
   findSources,
   findSourceByAlias,

--- a/tests/ts-plugin-completions.test.ts
+++ b/tests/ts-plugin-completions.test.ts
@@ -8,7 +8,8 @@ import { buildProgram } from './ts-plugin-test-helpers.js';
 
 const { matchQueryLiteral } = detectModule;
 const { getColumnNames } = schemaModule;
-const { getSelectListContext, getWhereClauseContext, findFromTable } = sqlContext;
+const { getSelectListContext, getWhereClauseContext, getFromClauseContext, findFromTable } =
+  sqlContext;
 
 const FIXTURE = `
 import type { TypedDb } from '@owlsql/core';
@@ -23,6 +24,7 @@ declare const db: TypedDb<DB>;
 db.query(\`select id, na\`);
 db.query(\`select id, na from posts\`);
 db.query(\`select id from users where na\`);
+db.query(\`select id from po\`);
 `;
 
 describe('ts-plugin: detect + schema against a real ts.Program', () => {
@@ -116,5 +118,30 @@ describe('ts-plugin: detect + schema against a real ts.Program', () => {
     const filtered = columns.filter((name) => name.startsWith(context.prefix));
 
     expect(filtered).toEqual(['name']);
+  });
+
+  it('suggests table names right after FROM (issue #175 repro)', () => {
+    const { program, sourceFile, dir } = buildProgram(FIXTURE, 'owlsql-ts-plugin-completions-');
+    cleanupDir = dir;
+    const checker = program.getTypeChecker();
+
+    const queryText = 'select id from po';
+    const literalStart = sourceFile.text.indexOf(`\`${queryText}\``) + 1;
+    const cursor = sourceFile.text.indexOf(queryText) + queryText.length;
+    const match = matchQueryLiteral(ts, checker, sourceFile, cursor);
+    expect(match).not.toBeNull();
+    if (!match) return;
+
+    const textBeforeCursor = sourceFile.text.slice(literalStart, cursor);
+    expect(getSelectListContext(textBeforeCursor) ?? getWhereClauseContext(textBeforeCursor)).toBeNull();
+
+    const context = getFromClauseContext(textBeforeCursor);
+    expect(context).toEqual({ prefix: 'po', qualifier: null });
+    if (!context) return;
+
+    const tableNames = match.dbType.getProperties().map((symbol) => symbol.getName());
+    const filtered = tableNames.filter((name) => name.startsWith(context.prefix));
+
+    expect(filtered).toEqual(['posts']);
   });
 });

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -4,6 +4,7 @@ import sqlContext from '../src/ts-plugin/sql-context.cts';
 const {
   getSelectListContext,
   getWhereClauseContext,
+  getFromClauseContext,
   findFromTable,
   findSources,
   findSourceByAlias,
@@ -105,6 +106,65 @@ describe('getWhereClauseContext', () => {
         'with recent_users as (select id from users) select id from recent_users where na',
       ),
     ).toEqual({ prefix: 'na', qualifier: null });
+  });
+});
+
+describe('getFromClauseContext', () => {
+  it('offers table completions right after FROM', () => {
+    expect(getFromClauseContext('select id from us')).toEqual({ prefix: 'us', qualifier: null });
+  });
+
+  it('offers an empty-prefix table completion right after FROM with nothing typed yet', () => {
+    expect(getFromClauseContext('select id from ')).toEqual({ prefix: '', qualifier: null });
+  });
+
+  it('offers table completions right after JOIN', () => {
+    expect(getFromClauseContext('select id from users u join po')).toEqual({
+      prefix: 'po',
+      qualifier: null,
+    });
+  });
+
+  it('ignores an INNER/LEFT/RIGHT/FULL/CROSS modifier before JOIN', () => {
+    expect(getFromClauseContext('select id from users u left join po')).toEqual({
+      prefix: 'po',
+      qualifier: null,
+    });
+    expect(getFromClauseContext('select id from users u cross join po')).toEqual({
+      prefix: 'po',
+      qualifier: null,
+    });
+  });
+
+  it('offers a table completion after a comma in an old-style comma-joined FROM list', () => {
+    expect(getFromClauseContext('select id from users u, po')).toEqual({
+      prefix: 'po',
+      qualifier: null,
+    });
+  });
+
+  it('returns null before any FROM has been typed, including for a SELECT-list comma', () => {
+    expect(getFromClauseContext('select id, na')).toBeNull();
+  });
+
+  it('does not offer a table completion for a comma inside a WHERE clause', () => {
+    expect(getFromClauseContext('select id from users where id in (1, 2')).toBeNull();
+  });
+
+  it('does not offer a table completion for a comma after ON/WHERE/GROUP BY/ORDER BY has started', () => {
+    expect(
+      getFromClauseContext('select id from users u join posts p on p.user_id = u.id, po'),
+    ).toBeNull();
+  });
+
+  it('does not misfire inside a string literal', () => {
+    expect(getFromClauseContext("select id from users where name = 'from ")).toBeNull();
+  });
+
+  it('offers completions past the WITH-clause of a CTE query', () => {
+    expect(
+      getFromClauseContext('with recent_users as (select id from users) select id from re'),
+    ).toEqual({ prefix: 're', qualifier: null });
   });
 });
 


### PR DESCRIPTION
## Summary
README listed this explicitly as out of scope: "No table-name completions after `FROM`/`JOIN` - only column names, after `SELECT`/`WHERE`, are suggested." The plugin already had everything it needed at that position - the bound `DB` schema type is right there via the checker, the same way column names are already resolved for the `SELECT`-list/`WHERE` completions.

## Changes
- Added `getFromClauseContext` to `sql-context.cts`, mirroring the existing `getSelectListContext`/`getWhereClauseContext` detectors: it fires right after `FROM` or `JOIN` (any `INNER`/`LEFT`/`RIGHT`/`FULL`/`CROSS` modifier before `JOIN` doesn't matter, only the `JOIN` keyword itself does), or after a comma in an old-style comma-joined `FROM` list. The comma case is gated on having already seen a `FROM` but no later clause keyword (`WHERE`/`HAVING`/`ON`/`GROUP BY`/`ORDER BY`) yet, so a plain `SELECT`-list comma or a comma inside a `WHERE`/`ON` expression isn't misread as a table position.
- `index.cts`'s `getCompletionsAtPosition` gets a new branch that lists `Object.keys(DB)` (via `dbType.getProperties()`) filtered by whatever prefix has been typed, using a small `completionsFromNames` helper factored out of the existing column-completion path so both branches build the same completion-list/replacement-span shape. Table entries use `ScriptElementKind.classElement` so they render with a distinct icon from column completions (`memberVariableElement`).

## Test plan
- Added 11 unit tests to `tests/ts-plugin-sql-context.test.ts` for `getFromClauseContext`: direct `FROM`/`JOIN` triggers (with and without a typed prefix), `JOIN` modifiers, comma-joined `FROM` lists, correctly declining on a `SELECT`-list comma / a `WHERE`-clause comma / a comma after `ON` has started, string-literal misfire safety, and CTE-awareness.
- Added an integration test to `tests/ts-plugin-completions.test.ts` exercising the full path against a real `ts.Program` (the issue's own repro).
- Reverted both source files to master in isolation with the new tests in place; all 11 failed with `getFromClauseContext is not a function`, then restored the fix.
- `npm run test:types` passes.
- `npx vitest run` passes (243/243).
- Updated README's editor-autocomplete section: moved the table-completion capability from "what it does not do" into "what it does," and updated the `ORDER BY`/`GROUP BY`/`HAVING` limitation bullet to reflect the new scope.

Fixes #175