### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owlsql/core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owlsql/core",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "bin": {
         "owlsql": "dist/cli/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owlsql/core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Parse SQL in TypeScript template literal types and infer the result shape from your schema — no codegen, no ORM.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- Bump `version` in `package.json` and `package-lock.json` from 0.1.6 to 0.1.7.

No other version references in the repo.