### PR TITLE
Add CHANGELOG.md, rewrite CONTRIBUTING.md, bump to 0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+Notable changes to this project, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This log starts at 0.1.8; earlier history lives in git and the GitHub releases page.
+
+## [0.1.8] - 2026-07-24
+
+### Added
+
+- `MERGE` statement support for SQL Server: types the target table and the `OUTPUT` clause, including the `$action` pseudo-column.
+- Per-adapter transaction helpers (`createPgTransaction`, `createMysql2Transaction`, `createPostgresJsTransaction`, `createMssqlTransaction`) that pin a single connection and handle begin/commit/rollback for you.
+- Editor diagnostics for simple `WHERE`-clause column references: unknown column, unknown table, unknown alias, ambiguous column.
+- Table-name completions after `FROM`/`JOIN` in the editor plugin.
+- `owlsql generate --check` for catching schema drift in CI without writing the file.
+
+### Fixed
+
+- `UPDATE ... FROM` and `DELETE ... USING` now register the extra table as a source instead of ignoring it.
+- Postgres array columns map to more accurate JS types instead of assuming every array becomes `T[]`.
+- SQLite `BLOB` columns map to `Uint8Array`, matching what `node:sqlite` actually returns.
+- The `pg`, `postgres.js`, and `mysql2` adapters all normalize `undefined` parameters to `null` the same way.
+- Corrected the Kysely adapter docs: placeholder-style checking already works there, it just needs `{ placeholders: ... }` passed explicitly.
+- Editor plugin no longer treats a backslash-escaped quote (`\'`) as the end of a string literal.
+- Editor plugin schema lookups now handle optional table keys and `Record<string, ...>` schemas.
+- Editor plugin detects `TypedDb` even when it's wrapped in an interface or a generic type parameter.
+- Nested `CASE` expressions wrapped in parentheses parse correctly.
+- Function call output columns keep the casing you wrote instead of being lowercased.
+- `JOIN LATERAL` subqueries resolve correctly instead of being misread.
+- A CTE that reuses a real table's name now shadows it instead of leaking the original table's columns.
+- Editor plugin recognizes `WITH` queries instead of losing completions for the whole statement.
+- Documented that `count`/`sum`/`avg` come back as strings from `pg` by default, the same caveat already noted for `min`/`max`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,41 +1,76 @@
 # Contributing
 
-Maintainer notes for developing and releasing `@owlsql/core` (OwlSQL).
+Thanks for looking into this. OwlSQL is a small, opinionated library, so contributions of any size are welcome, from a typo fix to a new dialect feature. Please be kind in issues and reviews 🦉
 
-## Development
+## AI and open source
+
+Using an LLM to write code or draft a PR description is fine. Treat it as a pair programmer, not a replacement for understanding the change you're proposing.
+
+A few things that matter here specifically:
+
+- Don't paste raw LLM output into an issue or PR description. Summarize the problem or the change in your own words; link to logs or a repro instead of pasting walls of generated text.
+- Commits and PRs should read like a person wrote them. No `Co-Authored-By` trailers for AI tools, no "Generated with [assistant]" lines.
+- If a bot helped you find a bug, say so briefly. Don't dress up an AI-generated bug report as your own detailed investigation if it isn't.
+
+None of this is about gatekeeping tools. It's about keeping the history readable for the next person who has to `git blame` a line at 2am.
+
+## Issues
+
+A good bug report has three things: what you ran, what you expected, and what happened instead. A minimal repro (a schema + a query string) is worth more than a paragraph of description.
+
+For feature requests, explain the use case before the API. "I need X because Y" is more useful than a fully-formed proposal, since the shape of the fix often changes once the actual constraint is clear.
+
+## Pull requests
+
+Keep a PR to one fix or one feature. A PR that touches three unrelated things is harder to review and harder to revert if something breaks. Reference the issue it closes in the description.
+
+Every behavior change needs a test that would fail without the fix. If you're touching `src/parse.ts`, `src/where.ts`, or another type-level file, that usually means a `.test-d.ts` case with `@ts-expect-error` or an `Equal<>` assertion; runtime behavior (adapters, the CLI, the ts-plugin) gets a `.test.ts` case instead. A PR without a regression test is a PR someone else will eventually re-break by accident.
+
+## Developing
+
+### Environment
+
+You'll need Node 20 or later. The `node:sqlite` adapter and the CLI's SQLite introspection need Node 22.5+, since `node:sqlite` is newer than the rest of the runtime surface this library targets. TypeScript 5.4 through 7 is accepted as a peer dependency; the ts-plugin currently only loads on the classic (pre-7) compiler API.
 
 ```bash
 npm install
 npm test              # types + runtime
-npm run test:types    # tsc --noEmit over src + tests — type assertions
-npm run test:runtime  # vitest — exercises the client, Result, and error paths
+npm run test:types    # tsc --noEmit over src + tests
+npm run test:runtime  # vitest
 npm run build         # emit dist/ with .d.ts
 ```
 
-Two layers of tests:
+### Fixing a bug
 
-- **Type tests** (`tests/*.test-d.ts`) are pure type assertions — if they
-  compile, the inference is correct. They cover projection/aliases
-  (`types.test-d.ts`), failing-query expectations via `@ts-expect-error`
-  (`negative.test-d.ts`), permissive-inference behavior locks
-  (`inference-edge.test-d.ts`), and deep-recursion stress (`depth.test-d.ts`).
-- **Runtime tests** (`tests/runtime.test.ts`) run under vitest and cover the
-  success path, param forwarding, the empty-query guard, and executor failure.
+Start from a failing case, not from the code. Write the query string and the schema that trigger the bug as a test first, confirm it fails for the reason you think it fails, then fix it. If you can, revert your own fix locally with the new test still in place and check that the test actually goes red. A test that passes either way isn't testing your fix.
 
-CI (`.github/workflows/ci.yml`) runs the type tests against a matrix of
-TypeScript versions (5.0, 5.3, 5.6, 6.0) plus the runtime tests, so a
-template-literal behavior change in a new TypeScript release is caught early.
+### Adding a feature
+
+Open an issue before writing the implementation if the feature touches the public API or the SQL subset the parser accepts. The type-level parser is recursive template literal types; a change that looks small in the type signature can be a large change in how deeply TypeScript has to recurse, so it's worth discussing the shape before committing to one.
+
+### Design preferences
+
+- No runtime SQL parsing, ever. If a change needs to inspect the query string at runtime to work, it probably belongs in the ts-plugin (which already does its own lightweight runtime scanning for editor support), not in the core library.
+- Adapters (`src/adapters/*.ts`) import the driver's types only, never the driver package itself as a value. This keeps `@owlsql/core/pg` usable without `pg` actually being installed, for anyone who only imports a different adapter.
+- If you extend the SQL subset the parser accepts, update the "Supported SQL subset" and "Limitations" sections in the README in the same PR. A parser change nobody can discover from the docs is half a feature.
+- Prefer a documented scope boundary over a half-correct implementation. Several existing features (LATERAL correlation, WHERE-clause diagnostics with parens) deliberately do less than a full SQL engine would, and say so in the README, rather than guessing.
+
+## Testing
+
+Two layers, and they test different things:
+
+- **Type tests** (`tests/*.test-d.ts`) are pure type assertions. If they compile, the inference is correct; there's no runtime assertion to run. They cover column/alias projection, `@ts-expect-error` cases for queries that should fail to type, permissive-inference locks, and deep-recursion stress.
+- **Runtime tests** (`tests/*.test.ts`) run under vitest and cover the executor/`Result` contract, adapter parameter handling, the CLI, and the ts-plugin's runtime scanners.
+
+CI runs the type tests against a matrix of TypeScript versions, since a template-literal-type change that works on one TypeScript release can silently stop working (or start working differently) on another.
 
 ## Publishing
 
-The package ships compiled JavaScript + declarations from `dist/`. The build is
-wired into `prepublishOnly`, so a normal publish compiles for you:
+The package ships compiled JavaScript and declarations from `dist/`, wired into `prepublishOnly`:
 
 ```bash
 npm version <patch|minor|major>
 npm publish            # runs test:types, then build, then publishes dist/
 ```
 
-Before the first registry publish, the package is still usable via a local path
-(`npm i file:../owlsql`), a tarball (`npm pack`), a workspace
-protocol, or a git URL.
+Before the first registry publish, the package is still usable via a local path (`npm i file:../owlsql`), a tarball (`npm pack`), a workspace protocol, or a git URL.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owlsql/core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owlsql/core",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "bin": {
         "owlsql": "dist/cli/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owlsql/core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Parse SQL in TypeScript template literal types and infer the result shape from your schema — no codegen, no ORM.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- Bumps `version` to 0.1.8 (on top of the already-merged 0.1.7 bump).
- Adds `CHANGELOG.md`, starting at 0.1.8 and covering the audit batch: issues #158-#176 (14 fixes, 5 features), following Keep a Changelog.
- Rewrites `CONTRIBUTING.md`: welcoming intro, an explicit AI/LLM usage section (no AI attribution in commits or PRs, no pasting raw generated text into issues), Issues/PRs guidance, and a Design preferences section documenting conventions this project already follows (no runtime SQL parsing, type-only driver imports in adapters, keeping README's supported-subset docs in sync with parser changes).

No source or test changes.