### PR TITLE
fix: createTypedDb silently drops options when DB type arg is explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ By default an unknown column or table resolves to `unknown` (permissive). Pass
 human-readable message, so a typo is impossible to ignore:
 
 ```ts
-const db = createTypedDb<DB>(executor, { strict: true });
+const db = createTypedDb<DB, { strict: true }>(executor, { strict: true });
 
 const ok = await db.query('select id, name from users');
 //     ok.value ^? { id: number; name: string }[]
@@ -548,7 +548,7 @@ Under the hood, each helper does exactly what you'd otherwise write by hand:
 
 ```ts
 const client = await pool.connect();
-const tx = createTypedDb<DB>(createPgExecutor(client), { placeholders: 'dollar' });
+const tx = createTypedDb<DB, { placeholders: 'dollar' }>(createPgExecutor(client), { placeholders: 'dollar' });
 
 try {
   await client.query('begin');
@@ -796,7 +796,7 @@ only once the query is finished.
 
 | Export | Kind | Description |
 | ------ | ---- | ----------- |
-| `createTypedDb<DB>(executor, options?)` | function | Build a schema-bound client. `options.strict` enables [strict mode](#8-strict-mode--turn-typos-into-type-errors); `options.placeholders` enables [placeholder-style checking](#10-typed-parameters). |
+| `createTypedDb<DB>(executor)` / `createTypedDb<DB, Options>(executor, options?)` | function | Build a schema-bound client. When passing `options`, `DB` and `Options` must **both** be given explicitly — `createTypedDb<DB>(executor, options)` with a single type argument is a compile error, not a silent no-op. `options.strict` enables [strict mode](#8-strict-mode--turn-typos-into-type-errors); `options.placeholders` enables [placeholder-style checking](#10-typed-parameters). |
 | `TypedDb<DB, Strict?, Style?>` | interface | The client; has `query<Q>(sql, ...params)`. |
 | `TypedDbOptions` | interface | `{ strict?: boolean; placeholders?: PlaceholderStyle }`. |
 | `Executor` | type | `(sql: string, params: readonly unknown[]) => Promise<ExecutorResult>`. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,13 @@ function describeCause(cause: unknown): string {
   return String(cause);
 }
 
+export function createTypedDb<DB extends SchemaLike>(
+  executor: Executor,
+): TypedDb<DB, false, PlaceholderStyle>;
+export function createTypedDb<DB extends SchemaLike, const Options extends TypedDbOptions>(
+  executor: Executor,
+  options?: Options,
+): TypedDb<DB, Options extends { strict: true } ? true : false, OptionsStyle<Options>>;
 export function createTypedDb<
   DB extends SchemaLike,
   const Options extends TypedDbOptions = TypedDbOptions,

--- a/tests/strict.test-d.ts
+++ b/tests/strict.test-d.ts
@@ -36,6 +36,13 @@ type LooseQueryStaysPermissive = Expect<
 
 declare const strictDb: ReturnType<typeof createTypedDb<DB, { strict: true }>>;
 declare const looseDb: ReturnType<typeof createTypedDb<DB, {}>>;
+declare const executorForArityCheck: (
+  sql: string,
+  params: readonly unknown[],
+) => Promise<unknown[]>;
+
+// @ts-expect-error passing options with only DB explicit must not silently default to non-strict
+createTypedDb<DB>(executorForArityCheck, { strict: true });
 
 export async function strictClientSurfacesErrors() {
   const good = await strictDb.query('select id, name from users');


### PR DESCRIPTION
## Summary

- `createTypedDb<DB>(executor, { strict: true })` — the README's canonical strict-mode example — silently never enabled strict mode. Same root cause also broke `createTypedDb<DB>(executor, { placeholders: 'dollar' })`.
- Root cause: TypeScript falls back to a type parameter's default instead of inferring it from the call whenever explicit type arguments are given for only a prefix of the parameter list. `Options` defaulted to `TypedDbOptions`, so supplying `<DB>` alone made `Options` silently resolve to the default, discarding whatever was actually passed in the `options` argument. No error, no strict mode, no placeholder-style check.
- Fix: split `createTypedDb` into overloads — one for the no-options case (`DB` only), one that requires both `DB` and `Options` explicit whenever an `options` argument is passed (no default on `Options` in that overload). The previously-broken single-type-arg-plus-options call now fails to compile instead of silently defaulting.
- Updated the two README examples that used the broken form (strict mode section, pg transaction example) plus the API reference table.
- Added a `@ts-expect-error` regression case in `tests/strict.test-d.ts` locking in that the broken form no longer compiles.

## Test plan

- [x] `tsc --noEmit -p tsconfig.json` — clean, 0 errors (full src + tests, including all `.test-d.ts` files)
- [x] Confirmed old broken call form (`createTypedDb<DB>(executor, { strict: true })`) now fails to compile (verified via scratch `@ts-expect-error` file before adding the permanent regression test)
- [x] `vitest run tests/runtime.test.ts tests/adapter-node-sqlite.test.ts` — 18/18 passing