### PR TITLE
fix: ignore dollar-quoted strings for placeholder style

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -1,4 +1,12 @@
-import type { Normalize, FirstWord, DropFirstWord, Trim, IsKeyword, ExtractParenGroup } from './string.js';
+import type {
+  Normalize,
+  FirstWord,
+  DropFirstWord,
+  Trim,
+  IsKeyword,
+  ExtractParenGroup,
+  Digit,
+} from './string.js';
 import type {
   Source,
   SchemaLike,
@@ -56,8 +64,6 @@ export type IsPlaceholder<Token extends string> = CleanScanToken<Token> extends 
       : CleanScanToken<Token> extends `@${string}`
         ? true
         : false;
-
-type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
 
 interface DigitCounters {
   '0': [];

--- a/src/string.ts
+++ b/src/string.ts
@@ -50,73 +50,116 @@ ${infer Rest}`
 
 type AfterBlockComment<S extends string> = S extends `${string}*/${infer Rest}` ? Rest : '';
 
-type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+export type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
 
-type ContainsWhitespace<S extends string> = S extends `${string}${Whitespace}${string}` ? true : false;
+type LowerAlpha =
+  | 'a'
+  | 'b'
+  | 'c'
+  | 'd'
+  | 'e'
+  | 'f'
+  | 'g'
+  | 'h'
+  | 'i'
+  | 'j'
+  | 'k'
+  | 'l'
+  | 'm'
+  | 'n'
+  | 'o'
+  | 'p'
+  | 'q'
+  | 'r'
+  | 's'
+  | 't'
+  | 'u'
+  | 'v'
+  | 'w'
+  | 'x'
+  | 'y'
+  | 'z';
 
-type IsDollarQuoteTag<S extends string> = S extends ''
-  ? false
-  : S extends `${Digit}${string}`
-    ? false
-    : ContainsWhitespace<S> extends true
-      ? false
-      : true;
+type UpperAlpha = Uppercase<LowerAlpha>;
 
-type MaskDollarQuotedBodies<
-  S extends string,
-  Accumulated extends string = '',
-> = S extends `${infer Before}$${infer AfterDollar}`
-  ? AfterDollar extends `$${infer AfterOpen}`
-    ? AfterOpen extends `${string}$$${infer Rest}`
-      ? MaskDollarQuotedBodies<Rest, `${Accumulated}${Before}''`>
-      : `${Accumulated}${S}`
-    : AfterDollar extends `${infer Tag}$${infer AfterOpen}`
-      ? IsDollarQuoteTag<Tag> extends true
-        ? AfterOpen extends `${string}$${Tag}$${infer Rest}`
-          ? MaskDollarQuotedBodies<Rest, `${Accumulated}${Before}''`>
-          : `${Accumulated}${S}`
-        : MaskDollarQuotedBodies<AfterDollar, `${Accumulated}${Before}$`>
-      : `${Accumulated}${S}`
-  : `${Accumulated}${S}`;
+type IdentifierStart = LowerAlpha | UpperAlpha | '_';
+
+type IdentifierChar = IdentifierStart | Digit;
+
+type IsIdentifierTail<S extends string> = S extends ''
+  ? true
+  : S extends `${infer Head}${infer Rest}`
+    ? Head extends IdentifierChar
+      ? IsIdentifierTail<Rest>
+      : false
+    : false;
+
+type IsDollarQuoteTag<S extends string> = S extends `${infer Head}${infer Rest}`
+  ? Head extends IdentifierStart
+    ? IsIdentifierTail<Rest>
+    : false
+  : false;
+
+type DollarQuoteOpen<S extends string> = S extends `$${infer AfterOpen}`
+  ? { tag: ''; afterOpen: AfterOpen }
+  : S extends `${infer Tag}$${infer AfterOpen}`
+    ? IsDollarQuoteTag<Tag> extends true
+      ? { tag: Tag; afterOpen: AfterOpen }
+      : never
+    : never;
+
+type SkipDollarQuotedBody<S extends string, Tag extends string> = Tag extends ''
+  ? S extends `${string}$$${infer Rest}`
+    ? { rest: Rest }
+    : never
+  : S extends `${string}$${Tag}$${infer Rest}`
+    ? { rest: Rest }
+    : never;
+
+type HasMaskableToken<S extends string> = S extends
+  | `${string}'${string}`
+  | `${string}--${string}`
+  | `${string}/*${string}`
+  | `${string}$${string}`
+  ? true
+  : false;
 
 export type StripCommentsAndMaskLiterals<
   S extends string,
   Accumulated extends string = '',
-> = S extends `${infer BeforeQuote}'${infer AfterQuote}`
-  ? BeforeQuote extends `${infer BeforeDash}--${infer AfterDash}`
-    ? BeforeDash extends `${infer BeforeBlock}/*${infer AfterBlock}`
-      ? StripCommentsAndMaskLiterals<
-          AfterBlockComment<`${AfterBlock}--${AfterDash}'${AfterQuote}`>,
-          `${Accumulated}${BeforeBlock} `
-        >
-      : StripCommentsAndMaskLiterals<
-          AfterLineComment<`${AfterDash}'${AfterQuote}`>,
-          `${Accumulated}${BeforeDash} `
-        >
-    : BeforeQuote extends `${infer BeforeBlock}/*${infer AfterBlock}`
-      ? StripCommentsAndMaskLiterals<
-          AfterBlockComment<`${AfterBlock}'${AfterQuote}`>,
-          `${Accumulated}${BeforeBlock} `
-        >
-      : SkipLiteralBody<AfterQuote> extends { rest: infer Rest extends string }
-        ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${BeforeQuote}''`>
+> = S extends ''
+  ? Accumulated
+  : HasMaskableToken<S> extends false
+    ? `${Accumulated}${S}`
+    : S extends `'${infer AfterQuote}`
+      ? SkipLiteralBody<AfterQuote> extends { rest: infer Rest extends string }
+        ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}''`>
         : `${Accumulated}${S}`
-  : S extends `${infer BeforeDash}--${infer AfterDash}`
-    ? BeforeDash extends `${infer BeforeBlock}/*${infer AfterBlock}`
-      ? StripCommentsAndMaskLiterals<
-          AfterBlockComment<`${AfterBlock}--${AfterDash}`>,
-          `${Accumulated}${BeforeBlock} `
-        >
-      : StripCommentsAndMaskLiterals<AfterLineComment<AfterDash>, `${Accumulated}${BeforeDash} `>
-    : S extends `${infer BeforeBlock}/*${infer AfterBlock}`
-      ? StripCommentsAndMaskLiterals<
-          AfterBlockComment<AfterBlock>,
-          `${Accumulated}${BeforeBlock} `
-        >
-      : `${Accumulated}${S}`;
+      : S extends `--${infer AfterDash}`
+        ? StripCommentsAndMaskLiterals<AfterLineComment<AfterDash>, `${Accumulated} `>
+        : S extends `/*${infer AfterBlock}`
+          ? StripCommentsAndMaskLiterals<AfterBlockComment<AfterBlock>, `${Accumulated} `>
+          : S extends `$${infer AfterDollar}`
+            ? [DollarQuoteOpen<AfterDollar>] extends [never]
+              ? S extends `${infer Head}${infer Rest}`
+                ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${Head}`>
+                : Accumulated
+              : DollarQuoteOpen<AfterDollar> extends {
+                    tag: infer Tag extends string;
+                    afterOpen: infer AfterOpen extends string;
+                  }
+                ? [SkipDollarQuotedBody<AfterOpen, Tag>] extends [never]
+                  ? `${Accumulated}${S}`
+                  : SkipDollarQuotedBody<AfterOpen, Tag> extends { rest: infer Rest extends string }
+                    ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}''`>
+                    : Accumulated
+                : Accumulated
+            : S extends `${infer Head}${infer Rest}`
+              ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${Head}`>
+              : Accumulated;
 
 export type Normalize<S extends string> = Trim<
-  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<StripCommentsAndMaskLiterals<MaskDollarQuotedBodies<S>>>>>
+  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<StripCommentsAndMaskLiterals<S>>>>
 >;
 
 // RemoveSemicolons strips every semicolon, not just a single trailing one, so
@@ -125,7 +168,7 @@ export type Normalize<S extends string> = Trim<
 // literal-masked text so a semicolon inside a comment or a string literal
 // (already reduced to '') is never mistaken for a statement separator.
 export type HasNonTrailingSemicolon<S extends string> =
-  Trim<StripCommentsAndMaskLiterals<MaskDollarQuotedBodies<S>>> extends `${string};${infer After}`
+  Trim<StripCommentsAndMaskLiterals<S>> extends `${string};${infer After}`
     ? Trim<After> extends ''
       ? false
       : true

--- a/src/string.ts
+++ b/src/string.ts
@@ -50,6 +50,35 @@ ${infer Rest}`
 
 type AfterBlockComment<S extends string> = S extends `${string}*/${infer Rest}` ? Rest : '';
 
+type Digit = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+
+type ContainsWhitespace<S extends string> = S extends `${string}${Whitespace}${string}` ? true : false;
+
+type IsDollarQuoteTag<S extends string> = S extends ''
+  ? false
+  : S extends `${Digit}${string}`
+    ? false
+    : ContainsWhitespace<S> extends true
+      ? false
+      : true;
+
+type MaskDollarQuotedBodies<
+  S extends string,
+  Accumulated extends string = '',
+> = S extends `${infer Before}$${infer AfterDollar}`
+  ? AfterDollar extends `$${infer AfterOpen}`
+    ? AfterOpen extends `${string}$$${infer Rest}`
+      ? MaskDollarQuotedBodies<Rest, `${Accumulated}${Before}''`>
+      : `${Accumulated}${S}`
+    : AfterDollar extends `${infer Tag}$${infer AfterOpen}`
+      ? IsDollarQuoteTag<Tag> extends true
+        ? AfterOpen extends `${string}$${Tag}$${infer Rest}`
+          ? MaskDollarQuotedBodies<Rest, `${Accumulated}${Before}''`>
+          : `${Accumulated}${S}`
+        : MaskDollarQuotedBodies<AfterDollar, `${Accumulated}${Before}$`>
+      : `${Accumulated}${S}`
+  : `${Accumulated}${S}`;
+
 export type StripCommentsAndMaskLiterals<
   S extends string,
   Accumulated extends string = '',
@@ -87,7 +116,7 @@ export type StripCommentsAndMaskLiterals<
       : `${Accumulated}${S}`;
 
 export type Normalize<S extends string> = Trim<
-  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<StripCommentsAndMaskLiterals<S>>>>
+  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<StripCommentsAndMaskLiterals<MaskDollarQuotedBodies<S>>>>>
 >;
 
 // RemoveSemicolons strips every semicolon, not just a single trailing one, so
@@ -96,7 +125,7 @@ export type Normalize<S extends string> = Trim<
 // literal-masked text so a semicolon inside a comment or a string literal
 // (already reduced to '') is never mistaken for a statement separator.
 export type HasNonTrailingSemicolon<S extends string> =
-  Trim<StripCommentsAndMaskLiterals<S>> extends `${string};${infer After}`
+  Trim<StripCommentsAndMaskLiterals<MaskDollarQuotedBodies<S>>> extends `${string};${infer After}`
     ? Trim<After> extends ''
       ? false
       : true

--- a/tests/dialect-brand.test-d.ts
+++ b/tests/dialect-brand.test-d.ts
@@ -21,6 +21,16 @@ export async function placeholderStyleCallSites() {
 
   await mysqlDb.query('select id from users where id = ?', 1);
 
+  await mysqlDb.query(
+    'select id from users where name = ? and id in (select 1 where $$x$$ = $$x$$)',
+    'ada',
+  );
+
+  await mysqlDb.query(
+    'select id from users where name = ? and id in (select 1 where $tag$x$tag$ = $tag$x$tag$)',
+    'ada',
+  );
+
   // @ts-expect-error a question-style client rejects $n placeholders
   await mysqlDb.query('select id from users where id = $1', 1);
 

--- a/tests/dialect-brand.test-d.ts
+++ b/tests/dialect-brand.test-d.ts
@@ -31,6 +31,19 @@ export async function placeholderStyleCallSites() {
     'ada',
   );
 
+  await mysqlDb.query(
+    'select id from users where name = ? and note = $$this body mentions $1$$',
+    'ada',
+  );
+
+  await mysqlDb.query(
+    'select id from users where name = ? and note = $tag$this body mentions $1$tag$',
+    'ada',
+  );
+
+  // @ts-expect-error a question-style client still rejects $n placeholders outside dollar-quoted bodies
+  await mysqlDb.query('select id from users where id = $1 and note = $$x$$', 1);
+
   // @ts-expect-error a question-style client rejects $n placeholders
   await mysqlDb.query('select id from users where id = $1', 1);
 

--- a/tests/semicolon.test-d.ts
+++ b/tests/semicolon.test-d.ts
@@ -27,6 +27,10 @@ type SemicolonInsideLiteralIsFine = Expect<
   Equal<StrictRow<DB, "select id from users where name = 'a;b'">, { id: number }>
 >;
 
+type SemicolonInsideDollarQuotedLiteralIsFine = Expect<
+  Equal<StrictRow<DB, 'select id from users where name = $$a;b$$'>, { id: number }>
+>;
+
 type SemicolonInsideCommentIsFine = Expect<
   Equal<
     StrictRow<
@@ -54,6 +58,7 @@ export type Assertions = [
   TrailingSemicolonWithSpaceIsFine,
   NoSemicolonIsFine,
   SemicolonInsideLiteralIsFine,
+  SemicolonInsideDollarQuotedLiteralIsFine,
   SemicolonInsideCommentIsFine,
   NonTrailingSemicolonIsRejectedInStrictMode,
   NonStrictModeStillMergesNonTrailingSemicolon,

--- a/tests/string-literal.test-d.ts
+++ b/tests/string-literal.test-d.ts
@@ -62,6 +62,20 @@ type DollarInsideLiteralIsNotPlaceholder = Expect<
   Equal<Params<DB, "select id from users where note = 'costs $5 today'">, []>
 >;
 
+type UntaggedDollarQuoteDelimitersInsideLiteralsDoNotSwallowFromClause = Expect<
+  Equal<
+    Query<DB, "select '$$' as a, name from users where note = '$$'">,
+    { a: string; name: string }[]
+  >
+>;
+
+type TaggedDollarQuoteDelimitersInsideLiteralsDoNotSwallowFromClause = Expect<
+  Equal<
+    Query<DB, "select '$t$' as a, name from users where note = '$t$'">,
+    { a: string; name: string }[]
+  >
+>;
+
 type QuestionMarkInsideLiteralIsNotPlaceholder = Expect<
   Equal<Params<DB, "select id from users where note = 'why?'">, []>
 >;
@@ -105,6 +119,8 @@ export type Assertions = [
   BackslashEscapedQuoteStillFindsWhereClauseStrict,
   EscapedBackslashThenRealCloseIsNotMistakenForEscape,
   DollarInsideLiteralIsNotPlaceholder,
+  UntaggedDollarQuoteDelimitersInsideLiteralsDoNotSwallowFromClause,
+  TaggedDollarQuoteDelimitersInsideLiteralsDoNotSwallowFromClause,
   QuestionMarkInsideLiteralIsNotPlaceholder,
   AtInsideCteLiteralKeepsParamTyping,
   SemicolonInsideLiteralDoesNotSplit,


### PR DESCRIPTION
## Summary
- fold Postgres dollar-quote masking into `StripCommentsAndMaskLiterals` so single quotes, comments, and dollar quotes are resolved in one outside-context scan
- tighten dollar-quote tags to Postgres identifier characters before masking
- keep placeholder-style and strict semicolon checks from scanning inside `$$...$$` or `$tag$...$tag$`
- add regressions for `$1` inside dollar quotes, `$1` outside still rejected, ordinary string literals containing dollar-quote delimiters, and dollar-quoted semicolons in strict mode

Fixes #202

## Testing
- npm run test:types
- npm run test:runtime
- npm run build
- npm test
- git diff --check
