### PR TITLE
fix: return node-sqlite write metadata

### DIFF
--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -1,10 +1,13 @@
-import type { DatabaseSync } from 'node:sqlite';
-import type { DialectExecutor } from '../index.js';
+import type { DatabaseSync, StatementSync } from 'node:sqlite';
+import type { DialectExecutor, QueryMeta } from '../index.js';
 import { resolveMixedParameters } from './named-params.js';
 
 type SqliteParam = null | number | bigint | string | NodeJS.ArrayBufferView;
 
 const SQLITE_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@', '$', ':']);
+const DML_KEYWORDS = new Set(['insert', 'update', 'delete', 'replace']);
+const INSERT_ROWID_KEYWORDS = new Set(['insert', 'replace']);
+const RESULT_KEYWORDS = new Set(['select', 'values', 'pragma', 'explain', 'with']);
 
 function toSqliteValue(value: unknown): SqliteParam {
   if (typeof value === 'boolean') {
@@ -19,12 +22,102 @@ function toSqliteValue(value: unknown): SqliteParam {
   return value as SqliteParam;
 }
 
-function hasResultColumns(statement: import('node:sqlite').StatementSync): boolean {
+function readLeadingKeyword(sql: string): string {
+  let rest = sql.trimStart();
+
+  while (rest.startsWith('--') || rest.startsWith('/*')) {
+    if (rest.startsWith('--')) {
+      const newline = rest.indexOf('\n');
+      rest = newline === -1 ? '' : rest.slice(newline + 1).trimStart();
+      continue;
+    }
+
+    const close = rest.indexOf('*/', 2);
+    rest = close === -1 ? '' : rest.slice(close + 2).trimStart();
+  }
+
+  return /^[A-Za-z_][A-Za-z0-9_]*/.exec(rest)?.[0]?.toLowerCase() ?? '';
+}
+
+function isWordChar(char: string | undefined): boolean {
+  return char !== undefined && /[A-Za-z0-9_]/.test(char);
+}
+
+function containsKeywordOutsideLiterals(sql: string, keyword: string): boolean {
+  for (let index = 0; index < sql.length; index += 1) {
+    const char = sql[index];
+
+    if (char === "'") {
+      index += 1;
+      while (index < sql.length) {
+        if (sql[index] === "'") {
+          if (sql[index + 1] === "'") {
+            index += 2;
+            continue;
+          }
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === '-' && sql[index + 1] === '-') {
+      const newline = sql.indexOf('\n', index + 2);
+      index = newline === -1 ? sql.length : newline;
+      continue;
+    }
+
+    if (char === '/' && sql[index + 1] === '*') {
+      const close = sql.indexOf('*/', index + 2);
+      index = close === -1 ? sql.length : close + 1;
+      continue;
+    }
+
+    if (
+      sql.slice(index, index + keyword.length).toLowerCase() === keyword &&
+      !isWordChar(sql[index - 1]) &&
+      !isWordChar(sql[index + keyword.length])
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasResultColumnsFromSql(sql: string): boolean {
+  const keyword = readLeadingKeyword(sql);
+  if (DML_KEYWORDS.has(keyword)) {
+    return containsKeywordOutsideLiterals(sql, 'returning');
+  }
+  return RESULT_KEYWORDS.has(keyword);
+}
+
+function hasResultColumns(statement: StatementSync, sql: string): boolean {
+  if (typeof statement.columns !== 'function') {
+    return hasResultColumnsFromSql(sql);
+  }
+
   try {
     return statement.columns().length > 0;
   } catch {
+    // If metadata introspection itself fails, preserve the old row-returning
+    // path instead of risking `run()` on a statement that actually returns rows.
     return true;
   }
+}
+
+function writeMeta(sql: string, result: ReturnType<StatementSync['run']>): QueryMeta {
+  const keyword = readLeadingKeyword(sql);
+  const meta: QueryMeta = {};
+  if (DML_KEYWORDS.has(keyword)) {
+    meta.rowCount = result.changes;
+  }
+  if (INSERT_ROWID_KEYWORDS.has(keyword) && result.changes !== 0) {
+    meta.lastInsertRowid = result.lastInsertRowid;
+  }
+  return meta;
 }
 
 export function createNodeSqliteExecutor(
@@ -35,16 +128,13 @@ export function createNodeSqliteExecutor(
     const values = params.map(toSqliteValue);
     const { named, positional } = resolveMixedParameters(sql, SQLITE_PARAM_PREFIXES, values);
 
-    if (!hasResultColumns(statement)) {
+    if (!hasResultColumns(statement, sql)) {
       const result = Object.keys(named).length > 0
         ? statement.run(named as Record<string, SqliteParam>, ...(positional as SqliteParam[]))
         : statement.run(...(positional as SqliteParam[]));
       return {
         rows: [],
-        meta: {
-          rowCount: result.changes,
-          lastInsertRowid: result.lastInsertRowid,
-        },
+        meta: writeMeta(sql, result),
       };
     }
 

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -19,6 +19,14 @@ function toSqliteValue(value: unknown): SqliteParam {
   return value as SqliteParam;
 }
 
+function hasResultColumns(statement: import('node:sqlite').StatementSync): boolean {
+  try {
+    return statement.columns().length > 0;
+  } catch {
+    return true;
+  }
+}
+
 export function createNodeSqliteExecutor(
   db: DatabaseSync,
 ): DialectExecutor<'question' | 'at' | 'dollar'> {
@@ -26,6 +34,19 @@ export function createNodeSqliteExecutor(
     const statement = db.prepare(sql);
     const values = params.map(toSqliteValue);
     const { named, positional } = resolveMixedParameters(sql, SQLITE_PARAM_PREFIXES, values);
+
+    if (!hasResultColumns(statement)) {
+      const result = Object.keys(named).length > 0
+        ? statement.run(named as Record<string, SqliteParam>, ...(positional as SqliteParam[]))
+        : statement.run(...(positional as SqliteParam[]));
+      return {
+        rows: [],
+        meta: {
+          rowCount: result.changes,
+          lastInsertRowid: result.lastInsertRowid,
+        },
+      };
+    }
 
     if (Object.keys(named).length > 0) {
       return statement.all(named as Record<string, SqliteParam>, ...(positional as SqliteParam[]));

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createTypedDb, isOk } from '../src/index.js';
 import { createNodeSqliteExecutor } from '../src/adapters/node-sqlite.js';
 import { loadSqlite, sqliteAvailable } from './sqlite-availability.js';
@@ -29,6 +29,7 @@ describe.skipIf(!sqliteAvailable)('createNodeSqliteExecutor', () => {
         { id: 1, name: 'ada' },
         { id: 2, name: 'grace' },
       ]);
+      expect(result.meta).toBeUndefined();
     }
   });
 
@@ -121,20 +122,117 @@ describe.skipIf(!sqliteAvailable)('createNodeSqliteExecutor', () => {
     ]);
   });
 
-  it('supports an INSERT round-trip through the typed client', async () => {
+  it('reports write metadata without leaking stale values through the typed client', async () => {
     const sqlite = seededDatabase();
     const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
 
-    const insert = await db.query('insert into users (id, name) values ($1, $2)', 3, 'lin');
+    const insert = await db.query('insert into users (id, name) values ($1, $2)', 9, 'lin');
     expect(isOk(insert)).toBe(true);
     if (isOk(insert)) {
-      expect(insert.meta).toEqual({ rowCount: 1, lastInsertRowid: 3 });
+      expect(insert.meta).toEqual({ rowCount: 1, lastInsertRowid: 9 });
     }
 
-    const rows = await db.query('select name from users where id = ?', 3);
+    const update = await db.query('update users set name = ? where id = ?', 'ada-lovelace', 1);
+    expect(isOk(update)).toBe(true);
+    if (isOk(update)) {
+      expect(update.meta).toEqual({ rowCount: 1 });
+    }
+
+    const deleted = await db.query('delete from users where id = ?', 2);
+    expect(isOk(deleted)).toBe(true);
+    if (isOk(deleted)) {
+      expect(deleted.meta).toEqual({ rowCount: 1 });
+    }
+
+    const deleteMiss = await db.query('delete from users where id = ?', 12345);
+    expect(isOk(deleteMiss)).toBe(true);
+    if (isOk(deleteMiss)) {
+      expect(deleteMiss.meta).toEqual({ rowCount: 0 });
+    }
+
+    const ddl = await db.query('create table t2 (a integer)');
+    expect(isOk(ddl)).toBe(true);
+    if (isOk(ddl)) {
+      expect(ddl.meta).toEqual({});
+    }
+
+    const rows = await db.query('select name from users where id = ?', 9);
     expect(isOk(rows)).toBe(true);
     if (isOk(rows)) {
       expect(rows.value).toEqual([{ name: 'lin' }]);
     }
+  });
+});
+
+describe('createNodeSqliteExecutor column detection fallback', () => {
+  it('classifies statements from SQL when StatementSync.columns is unavailable', async () => {
+    const insertStatement = {
+      run: vi.fn().mockReturnValue({ changes: 1, lastInsertRowid: 7 }),
+      all: vi.fn().mockReturnValue([]),
+    };
+    const selectStatement = {
+      run: vi.fn(),
+      all: vi.fn().mockReturnValue([{ id: 7 }]),
+    };
+    const ddlStatement = {
+      run: vi.fn().mockReturnValue({ changes: 4, lastInsertRowid: 99 }),
+      all: vi.fn().mockReturnValue([]),
+    };
+    const returningStatement = {
+      run: vi.fn(),
+      all: vi.fn().mockReturnValue([{ id: 8 }]),
+    };
+    const statements: Record<string, unknown> = {
+      'insert into users (name) values (?)': insertStatement,
+      'select id from users': selectStatement,
+      'create table t2 (a integer)': ddlStatement,
+      'insert into users (name) values (?) returning id': returningStatement,
+    };
+    const sqlite = {
+      prepare: vi.fn((sql: string) => statements[sql]),
+    } as unknown as import('node:sqlite').DatabaseSync;
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    await expect(executor('insert into users (name) values (?)', ['ada'])).resolves.toEqual({
+      rows: [],
+      meta: { rowCount: 1, lastInsertRowid: 7 },
+    });
+    expect(insertStatement.run).toHaveBeenCalledWith('ada');
+    expect(insertStatement.all).not.toHaveBeenCalled();
+
+    await expect(executor('select id from users', [])).resolves.toEqual([{ id: 7 }]);
+    expect(selectStatement.all).toHaveBeenCalledWith();
+    expect(selectStatement.run).not.toHaveBeenCalled();
+
+    await expect(executor('create table t2 (a integer)', [])).resolves.toEqual({
+      rows: [],
+      meta: {},
+    });
+    expect(ddlStatement.run).toHaveBeenCalledWith();
+    expect(ddlStatement.all).not.toHaveBeenCalled();
+
+    await expect(
+      executor('insert into users (name) values (?) returning id', ['grace']),
+    ).resolves.toEqual([{ id: 8 }]);
+    expect(returningStatement.all).toHaveBeenCalledWith('grace');
+    expect(returningStatement.run).not.toHaveBeenCalled();
+  });
+
+  it('keeps the row path when StatementSync.columns throws', async () => {
+    const statement = {
+      columns: vi.fn(() => {
+        throw new Error('columns unavailable');
+      }),
+      run: vi.fn(),
+      all: vi.fn().mockReturnValue([{ id: 1 }]),
+    };
+    const sqlite = {
+      prepare: vi.fn(() => statement),
+    } as unknown as import('node:sqlite').DatabaseSync;
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    await expect(executor('select id from users', [])).resolves.toEqual([{ id: 1 }]);
+    expect(statement.all).toHaveBeenCalledWith();
+    expect(statement.run).not.toHaveBeenCalled();
   });
 });

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -127,6 +127,9 @@ describe.skipIf(!sqliteAvailable)('createNodeSqliteExecutor', () => {
 
     const insert = await db.query('insert into users (id, name) values ($1, $2)', 3, 'lin');
     expect(isOk(insert)).toBe(true);
+    if (isOk(insert)) {
+      expect(insert.meta).toEqual({ rowCount: 1, lastInsertRowid: 3 });
+    }
 
     const rows = await db.query('select name from users where id = ?', 3);
     expect(isOk(rows)).toBe(true);


### PR DESCRIPTION
## Summary
- use `StatementSync.columns()` when available to keep row-returning node:sqlite statements on `all()` and no-result statements on `run()`
- feature-detect missing `columns()` and fall back to SQL statement classification for older Node 22 `node:sqlite` builds
- report `rowCount` only for INSERT/UPDATE/DELETE/REPLACE and `lastInsertRowid` only for INSERT/REPLACE with actual changes, avoiding stale connection-scoped values on UPDATE/DELETE/DDL
- add typed-client regressions for INSERT, UPDATE, DELETE, no-op DELETE, DDL, SELECT metadata, plus fallback tests for missing/throwing `columns()`

Fixes #203

## Testing
- npx vitest run tests/adapter-node-sqlite.test.ts
- npm run test:types
- npm run test:runtime
- npm run build
- npm test
- git diff --check
