### PR TITLE
fix: keep scanning named parameters after a backslash-escaped quote

### DIFF
--- a/src/adapters/named-params.ts
+++ b/src/adapters/named-params.ts
@@ -1,6 +1,20 @@
 const NAMED_PARAM_BODY = /^[A-Za-z0-9_]+/;
 const DOLLAR_QUOTE_TAG = /^\$([A-Za-z0-9_]*)\$/;
 
+// A quote preceded by an odd run of backslashes is backslash-escaped (MySQL's
+// and SQLite's default `\'`) and doesn't open or close a literal - the run has
+// to be odd, not merely non-empty, since `\\'` is an escaped backslash followed
+// by a real delimiter. Mirrors EndsWithOddBackslashes in src/string.ts and the
+// same check in the ts-plugin's stripStringLiterals; without it every parameter
+// after the escaped quote is read as literal body and silently dropped.
+function isLiteralDelimiter(sql: string, index: number): boolean {
+  let backslashes = 0;
+  while (backslashes < index && sql[index - 1 - backslashes] === '\\') {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 0;
+}
+
 export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string>): string[] {
   const names: string[] = [];
   let insideLiteral = false;
@@ -8,7 +22,7 @@ export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string
   for (let index = 0; index < sql.length; index += 1) {
     const char = sql[index] as string;
 
-    if (char === "'") {
+    if (char === "'" && isLiteralDelimiter(sql, index)) {
       insideLiteral = !insideLiteral;
       continue;
     }
@@ -70,7 +84,7 @@ export function resolveMixedParameters(
   for (let index = 0; index < sql.length; index += 1) {
     const char = sql[index] as string;
 
-    if (char === "'") {
+    if (char === "'" && isLiteralDelimiter(sql, index)) {
       insideLiteral = !insideLiteral;
       continue;
     }

--- a/tests/named-params.test.ts
+++ b/tests/named-params.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { collectNamedParameters } from '../src/adapters/named-params.js';
+import { collectNamedParameters, resolveMixedParameters } from '../src/adapters/named-params.js';
 
 const AT_DOLLAR_COLON: ReadonlySet<string> = new Set(['@', '$', ':']);
 
@@ -39,5 +39,38 @@ describe('collectNamedParameters', () => {
     expect(
       collectNamedParameters('select * from t where a = @id or b = @id', AT_DOLLAR_COLON),
     ).toEqual(['@id']);
+  });
+
+  it('collects parameters that follow a backslash-escaped quote inside a literal', () => {
+    const sql = "select * from t where a = 'it\\'s' and b = @id and c = @other";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id', '@other']);
+  });
+
+  it('treats a doubled backslash before a quote as a real closing delimiter', () => {
+    const sql = "select * from t where a = 'c:\\\\' and b = @id";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id']);
+  });
+
+  it('still skips a parameter inside a literal that contains an escaped quote', () => {
+    const sql = "select * from t where a = 'it\\'s @fake' and b = @id";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id']);
+  });
+});
+
+describe('resolveMixedParameters', () => {
+  it('assigns values to parameters that follow a backslash-escaped quote', () => {
+    const sql = "select * from t where a = 'it\\'s' and b = @id and c = @other";
+    expect(resolveMixedParameters(sql, AT_DOLLAR_COLON, [1, 2])).toEqual({
+      named: { '@id': 1, '@other': 2 },
+      positional: [],
+    });
+  });
+
+  it('does not consume a value for a placeholder inside an escaped-quote literal', () => {
+    const sql = "select * from t where a = 'it\\'s ?' and b = ?";
+    expect(resolveMixedParameters(sql, AT_DOLLAR_COLON, [7])).toEqual({
+      named: {},
+      positional: [7],
+    });
   });
 });


### PR DESCRIPTION
Closes #199.

## Problem

`collectNamedParameters` and `resolveMixedParameters` tracked string literals by flipping a boolean on every `'`. That handles the SQL-standard `''` escape by accident, but not the backslash-escaped `\'` that MySQL and SQLite accept by default: after one, the scanner believes it is inside a literal while it is outside, and everything to the end of the statement is skipped.

```ts
const sql = "select * from t where a = 'it\\'s' and b = @id and c = @other";
collectNamedParameters(sql, new Set(['@']));   // [] -> mssql binds nothing
resolveMixedParameters(sql, prefixes, [1, 2]); // {} -> node-sqlite runs unbound
```

## Fix

A quote only opens or closes a literal when the run of backslashes immediately before it is even. Same rule the type level already uses (`EndsWithOddBackslashes` in `src/string.ts`, #131) and the editor plugin already uses (`stripStringLiterals`, #163) — the runtime scanners were the last place without it.

## Tests

`tests/named-params.test.ts`: parameters after an escaped quote are collected and bound, `\\'` still closes the literal, and a placeholder that really is inside such a literal is still skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
