### PR TITLE
fix: bound the WHERE clause on any whitespace, not just a space

### DIFF
--- a/src/ts-plugin/diagnostics.cts
+++ b/src/ts-plugin/diagnostics.cts
@@ -37,6 +37,11 @@ const WHERE_TRIGGER_OPERATORS: ReadonlySet<string> = new Set([
   'is',
 ]);
 const WHERE_AND_OR: ReadonlySet<string> = new Set(['and', 'or']);
+// A tagged template spanning several lines separates clauses with a newline
+// (or a tab), not a space, so the boundary walk below has to break words on
+// any whitespace - otherwise `1\norder` reads as one word, no boundary
+// matches, and the WHERE clause runs to the end of the statement.
+const WHITESPACE_CHAR = /\s/;
 const WHERE_TRANSPARENT_WORD = /^not$/i;
 const WHERE_IDENTIFIER_TOKEN = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/;
 const WHERE_PLACEHOLDER_TOKEN = /^(?:\$\d+|\?|@[A-Za-z_][A-Za-z0-9_]*)$/;
@@ -119,7 +124,7 @@ function findWhereClauseText(text: string): { text: string; start: number } | nu
       if (char === '(') boundaryDepth += 1;
       else if (char === ')') boundaryDepth -= 1;
 
-      if (char === undefined || char === ' ') {
+      if (char === undefined || WHITESPACE_CHAR.test(char)) {
         const word = text.slice(wordStart, i).toLowerCase();
         if (boundaryDepth === 0 && WHERE_CLAUSE_BOUNDARY_WORDS.has(word)) {
           end = wordStart;

--- a/tests/ts-plugin-diagnostics.test.ts
+++ b/tests/ts-plugin-diagnostics.test.ts
@@ -236,4 +236,22 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
       diagnosticsFor('select id from users where naem = 1 order by id desc'),
     ).toEqual([{ message: 'unknown column: naem', text: 'naem' }]);
   });
+
+  it('stops the WHERE clause at an ORDER BY on the next line', () => {
+    expect(diagnosticsFor('select id from users\nwhere id = 1\norder by name desc')).toEqual([]);
+  });
+
+  it('stops the WHERE clause at a GROUP BY on the next line', () => {
+    expect(diagnosticsFor('select id from users\nwhere id = 1\ngroup by name')).toEqual([]);
+  });
+
+  it('stops the WHERE clause at a tab-separated LIMIT', () => {
+    expect(diagnosticsFor('select id from users where id = 1\tlimit 10')).toEqual([]);
+  });
+
+  it('still reports a WHERE-clause typo in a multi-line query', () => {
+    expect(diagnosticsFor('select id from users\nwhere naem = 1\norder by name desc')).toEqual([
+      { message: 'unknown column: naem', text: 'naem' },
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #200.

## Problem

`findWhereClauseText` bounds the WHERE clause by walking forward and comparing each word against `WHERE_CLAUSE_BOUNDARY_WORDS`, but it only broke words on a literal space:

```ts
if (char === undefined || char === ' ') {
```

A multi-line tagged template separates clauses with `\n`, so `1\norder` is read as one word, no boundary matches, and the clause runs to the end of the query. `findWhereDiagnostics` then validates the statement's last token as a column reference.

```sql
select id from users
where id = 1
order by created_at desc
```

reported `unknown column: desc`. The same query on one line reported nothing.

## Fix

Break words on any whitespace (`/\s/`). Newlines, tabs and CRLF now bound the clause the same way a space already did; the single-space behaviour the existing tests lock in is unchanged.

## Tests

`tests/ts-plugin-diagnostics.test.ts`: multi-line ORDER BY / GROUP BY and a tab-separated LIMIT produce no diagnostics, and a real multi-line WHERE typo is still reported. The first of those fails on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
