### PR TITLE
fix: mask Postgres dollar-quoted strings in the editor plugin

### DIFF
--- a/src/ts-plugin/sql-context.cts
+++ b/src/ts-plugin/sql-context.cts
@@ -13,6 +13,10 @@ const FROM_TABLE = /\bfrom\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]
 const FROM_OR_JOIN_SOURCE = /\b(from|join)\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)(?:\s+(as\s+)?([A-Za-z_][A-Za-z0-9_]*))?/gid;
 const WORD_CHAR = /[A-Za-z0-9_]/;
 const WORD_START_CHAR = /[A-Za-z_]/;
+// Postgres dollar-quoted string opener: `$$` or `$tag$`, where the tag is an
+// identifier (so a `$1` placeholder never matches). The closer is the exact
+// same delimiter, which is what makes the body free of quoting rules.
+const DOLLAR_QUOTE_OPEN = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/;
 
 const RESERVED_AFTER_SOURCE = new Set([
   'on',
@@ -95,6 +99,26 @@ function stripStringLiterals(text: string): StrippedText {
       precedingBackslashes = 0;
       i += 1;
       continue;
+    }
+
+    if (char === '$') {
+      // Dollar-quoted body: mask the delimiters and everything between them,
+      // so FROM/JOIN/column scanning never reads string content as SQL. The
+      // runtime scanners in src/adapters/named-params.ts already skip these
+      // (issue #140); an unterminated open runs to the end of the text, the
+      // same way the block-comment branch below behaves.
+      const open = DOLLAR_QUOTE_OPEN.exec(text.slice(i));
+      if (open) {
+        const delimiter = open[0];
+        const closeIndex = text.indexOf(delimiter, i + delimiter.length);
+        const end = closeIndex === -1 ? text.length : closeIndex + delimiter.length;
+        while (i < end) {
+          stripped += text[i] === '\n' ? '\n' : ' ';
+          i += 1;
+        }
+        precedingBackslashes = 0;
+        continue;
+      }
     }
 
     if (char === '-' && text[i + 1] === '-') {

--- a/tests/ts-plugin-sql-context.test.ts
+++ b/tests/ts-plugin-sql-context.test.ts
@@ -270,6 +270,41 @@ describe('findSources', () => {
     ]);
   });
 
+  it('ignores a FROM inside a $$ dollar-quoted body (issue #209 repro)', () => {
+    const sources = findSources('select id, name from users where note = $$ pulled from orders $$');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('ignores a JOIN inside a $tag$ dollar-quoted body', () => {
+    const sources = findSources('select id from users where note = $note$ join orders o $note$');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('still resolves sources written after a dollar-quoted body', () => {
+    const sources = findSources('select id from users u join posts p on p.note = $$ from ghosts $$');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'u' },
+      { table: 'posts', alias: 'p' },
+    ]);
+  });
+
+  it('does not treat a $1 placeholder as a dollar-quote opener', () => {
+    const sources = findSources('select id from users where id = $1 and name = $2');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('keeps table spans aligned across a dollar-quoted body', () => {
+    const text = 'select id from users where note = $$ x $$ and id = 1';
+    const [source] = findSources(text);
+    expect(source && text.slice(source.tableStart, source.tableEnd)).toBe('users');
+  });
+
   it('reports the table token span for each source', () => {
     const text = 'select id from users';
     const sources = findSources(text);


### PR DESCRIPTION
Closes #209.

## Problem

`stripStringLiterals` in `src/ts-plugin/sql-context.cts` masks `'...'` literals and both comment forms, but has no notion of a Postgres dollar-quoted string. Its body reached every consumer of the stripped text as if it were SQL:

```sql
select id, name from users where note = $$ pulled from orders $$
```

`findSources` saw a second source `orders` (→ `unknown table: orders`, or a silently widened bare-column scope when the table does exist), and `findWhereClauseText` / `getQueryDiagnostics` scanned the body for clause keywords and column-shaped tokens.

The type level (`StripCommentsAndMaskLiterals`, #202) and the runtime scanners (`named-params.ts`, #140) both already handle this — the editor plugin was the last holdout, the same way #131/#163 split before.

## Fix

A dollar-quote branch in the main loop, alongside `'`, `--` and `/*`. The delimiter is `$$` or `$tag$` with an identifier tag, so a `$1` placeholder never matches; the body is replaced one character per character (newlines preserved) so every offset the diagnostics use stays aligned. An unterminated open runs to the end of the text, matching the block-comment branch.

## Tests

`tests/ts-plugin-sql-context.test.ts`: `FROM`/`JOIN` inside `$$` and `$tag$` bodies are ignored, real sources after such a body still resolve, `$1`/`$2` are not openers, and table spans stay aligned across a masked body. Three of the five fail on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
