### PR TITLE
fix: escape Postgres enum labels with JSON.stringify

### DIFF
--- a/src/cli/dialects/postgres.ts
+++ b/src/cli/dialects/postgres.ts
@@ -79,8 +79,13 @@ const POSTGRES_ARRAY_TYPE_OVERRIDES: Record<string, string> = {
   numeric: 'number',
 };
 
+// JSON.stringify emits a TypeScript-valid double-quoted literal and escapes
+// backslashes, quotes and control characters - hand-rolled quoting only
+// escaped `'`, so a label ending in a backslash escaped the closing quote and
+// the generated schema.ts stopped parsing. renderKey in src/cli/codegen.ts
+// already quotes identifiers this way.
 function renderEnumUnion(labels: string[]): string {
-  return labels.map((label) => `'${label.replace(/'/g, "\\'")}'`).join(' | ');
+  return labels.map((label) => JSON.stringify(label)).join(' | ');
 }
 
 function scalarType(base: string): string {

--- a/tests/cli-codegen-edge.test.ts
+++ b/tests/cli-codegen-edge.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import ts from 'typescript';
 import { renderSchema } from '../src/cli/codegen.js';
+import { mapPostgresType } from '../src/cli/dialects/postgres.js';
+
+function parseErrorCount(source: string): number {
+  const sourceFile = ts.createSourceFile('schema.ts', source, ts.ScriptTarget.Latest, true);
+  return (sourceFile as unknown as { parseDiagnostics: readonly unknown[] }).parseDiagnostics.length;
+}
 
 describe('renderSchema edge cases', () => {
   it('quotes names that are not valid identifiers, including quotes and backslashes', () => {
@@ -23,6 +30,18 @@ describe('renderSchema edge cases', () => {
         '  };\n' +
         '}\n',
     );
+  });
+
+  it('renders a parseable module for an enum label ending in a backslash (issue #201 repro)', () => {
+    const enums = new Map([['mood', ['a\\', 'b']]]);
+    const rendered = renderSchema([
+      {
+        name: 'items',
+        columns: [{ name: 'kind', tsType: mapPostgresType('mood', enums), nullable: false }],
+      },
+    ]);
+
+    expect(parseErrorCount(rendered)).toBe(0);
   });
 
   it('renders a zero-column table as an empty object', () => {

--- a/tests/cli-pg-introspect.test.ts
+++ b/tests/cli-pg-introspect.test.ts
@@ -40,7 +40,7 @@ describe('introspectPostgres', () => {
         name: 'users',
         columns: [
           { name: 'id', tsType: 'number', nullable: false },
-          { name: 'state', tsType: "'happy' | 'sad'", nullable: true },
+          { name: 'state', tsType: '"happy" | "sad"', nullable: true },
           { name: 'tags', tsType: 'string[]', nullable: true },
         ],
       },

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -71,7 +71,12 @@ describe('mapPostgresType', () => {
 
   it('maps enums to a label union when the enum map is provided', () => {
     const enums = new Map([['mood', ['happy', 'sad']]]);
-    expect(mapPostgresType('mood', enums)).toBe("'happy' | 'sad'");
+    expect(mapPostgresType('mood', enums)).toBe('"happy" | "sad"');
+  });
+
+  it('escapes a label containing a backslash, a quote, or a newline (issue #201 repro)', () => {
+    const enums = new Map([['mood', ['a\\', 'b"c', "d'e", 'f\ng']]]);
+    expect(mapPostgresType('mood', enums)).toBe('"a\\\\" | "b\\"c" | "d\'e" | "f\\ng"');
   });
 
   it('maps an enum array to the raw string pg returns - enum OIDs are dynamic and never registered as arrays', () => {


### PR DESCRIPTION
Closes #201.

## Problem

`renderEnumUnion` built each member by hand and escaped only the single quote:

```ts
labels.map((label) => `'${label.replace(/'/g, "\\'")}'`)
```

A label ending in a backslash escapes its own closing quote, so the literal never closes and swallows the rest of the union:

```ts
kind: 'a\' | 'b';   // 5 syntax errors
```

`owlsql generate` writes the file and exits 0, so it surfaces later as a `tsc` error inside generated code. Postgres accepts `CREATE TYPE mood AS ENUM ('a\', 'b')` with no unusual setup, and label content lands verbatim in a file the project then compiles.

## Fix

`JSON.stringify(label)` — a TypeScript-valid literal with backslashes, quotes and control characters escaped. `renderKey` in `src/cli/codegen.ts` already quotes identifiers this way, so the CLI is now consistent with itself.

**Output change:** enum unions are emitted double-quoted (`"happy" | "sad"` instead of `'happy' | 'sad'`). Same type, and it matches the quoting style of the keys around it.

## Tests

- `tests/cli-type-mapping.test.ts`: labels with a backslash, a double quote, a single quote and a newline all round-trip.
- `tests/cli-codegen-edge.test.ts`: a rendered module using a backslash label parses with zero syntax errors (`ts.createSourceFile`).
- Existing enum expectations updated for the new quoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
