### PR TITLE
fix: keep the original error when a transaction rollback fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,11 @@ Kysely users should use Kysely's own `db.transaction()`. `node:sqlite` is a
 single connection, so plain `begin`/`commit` statements are safe there and no
 helper is provided.
 
+If the rollback *itself* fails, the helper throws an `AggregateError` whose
+`errors[0]` is the original failure and `errors[1]` is the rollback failure —
+the error that caused the transaction to be abandoned is never replaced by a
+cleanup error.
+
 Under the hood, each helper does exactly what you'd otherwise write by hand:
 
 ```ts

--- a/src/adapters/mssql.ts
+++ b/src/adapters/mssql.ts
@@ -2,6 +2,7 @@ import type { ConnectionPool, Transaction, Request } from 'mssql';
 import type { DialectExecutor, QueryMeta, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
 import { createTypedDb } from '../index.js';
 import { collectNamedParameters } from './named-params.js';
+import { rollbackAndRethrow } from './transaction.js';
 
 const MSSQL_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@']);
 
@@ -58,14 +59,18 @@ export function createMssqlTransaction<DB extends SchemaLike>(pool: ConnectionPo
       { ...options, placeholders: 'at' } as Options & { placeholders: 'at' },
     );
 
+    // begin() stays outside the try: node-mssql throws "Transaction has not
+    // begun" when rollback() runs on a transaction that never started, so a
+    // pool that can't reach the server would report a transaction-state
+    // problem instead of the connection failure that actually happened.
+    await transaction.begin();
+
     try {
-      await transaction.begin();
       const result = await fn(tx);
       await transaction.commit();
       return result;
     } catch (error) {
-      await transaction.rollback();
-      throw error;
+      return await rollbackAndRethrow(error, () => transaction.rollback());
     }
   };
 }

--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -2,6 +2,7 @@ import type { Pool, Connection } from 'mysql2/promise';
 import type { ExecuteValues } from 'mysql2';
 import type { DialectExecutor, QueryMeta, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
 import { createTypedDb } from '../index.js';
+import { rollbackAndRethrow } from './transaction.js';
 
 export type Mysql2Queryable = Pool | Connection;
 
@@ -61,8 +62,7 @@ export function createMysql2Transaction<DB extends SchemaLike>(pool: Pool) {
       await connection.commit();
       return result;
     } catch (error) {
-      await connection.rollback();
-      throw error;
+      return await rollbackAndRethrow(error, () => connection.rollback());
     } finally {
       connection.release();
     }

--- a/src/adapters/pg.ts
+++ b/src/adapters/pg.ts
@@ -1,6 +1,7 @@
 import type { Pool, Client, PoolClient } from 'pg';
 import type { DialectExecutor, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
 import { createTypedDb } from '../index.js';
+import { rollbackAndRethrow } from './transaction.js';
 
 export type PgQueryable = Pool | Client | PoolClient;
 
@@ -56,8 +57,7 @@ export function createPgTransaction<DB extends SchemaLike>(pool: Pool) {
       await client.query('commit');
       return result;
     } catch (error) {
-      await client.query('rollback');
-      throw error;
+      return await rollbackAndRethrow(error, () => client.query('rollback'));
     } finally {
       client.release();
     }

--- a/src/adapters/transaction.ts
+++ b/src/adapters/transaction.ts
@@ -1,0 +1,24 @@
+// A rollback that fails must not replace the failure that caused it. The
+// original error is what explains why the transaction was abandoned; a
+// cleanup failure on top of it ("Transaction has not begun", a dead
+// connection) sends the reader looking in the wrong place entirely.
+//
+// When the rollback succeeds the original error propagates untouched. When it
+// fails both are surfaced as an AggregateError with the original first, so
+// `errors[0]` is always the real cause - formatCliError in src/cli/index.ts
+// already unwraps AggregateError, so there is precedent for the shape.
+export async function rollbackAndRethrow(
+  error: unknown,
+  rollback: () => Promise<unknown>,
+): Promise<never> {
+  try {
+    await rollback();
+  } catch (rollbackError) {
+    throw new AggregateError(
+      [error, rollbackError],
+      'The transaction failed and rolling it back failed too.',
+    );
+  }
+
+  throw error;
+}

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -160,4 +160,31 @@ describe('createMssqlTransaction', () => {
     expect(rollback).toHaveBeenCalledOnce();
     expect(commit).not.toHaveBeenCalled();
   });
+
+  it('keeps the original error when the rollback itself fails (issue #204 repro)', async () => {
+    const { pool, rollback } = fakeTransactionalPool();
+    rollback.mockRejectedValue(new Error('Transaction has not begun'));
+
+    const thrown = await createMssqlTransaction<DB>(pool)(async () => {
+      throw new Error('boom');
+    }).catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    const errors = (thrown as AggregateError).errors as Error[];
+    expect(errors.map((error) => error.message)).toEqual([
+      'boom',
+      'Transaction has not begun',
+    ]);
+  });
+
+  it('does not roll back a transaction that never began', async () => {
+    const { pool, begin, rollback } = fakeTransactionalPool();
+    begin.mockRejectedValue(new Error('connection refused'));
+
+    await expect(
+      createMssqlTransaction<DB>(pool)(async () => 'unreachable'),
+    ).rejects.toThrow('connection refused');
+
+    expect(rollback).not.toHaveBeenCalled();
+  });
 });

--- a/tests/adapter-mysql2.test.ts
+++ b/tests/adapter-mysql2.test.ts
@@ -113,4 +113,18 @@ describe('createMysql2Transaction', () => {
     expect(commit).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledOnce();
   });
+
+  it('keeps the original error when the rollback itself fails (issue #204 repro)', async () => {
+    const { pool, rollback, release } = fakeTransactionalPool();
+    rollback.mockRejectedValue(new Error('connection lost'));
+
+    const thrown = await createMysql2Transaction<DB>(pool)(async () => {
+      throw new Error('boom');
+    }).catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    const errors = (thrown as AggregateError).errors as Error[];
+    expect(errors.map((error) => error.message)).toEqual(['boom', 'connection lost']);
+    expect(release).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/adapter-pg.test.ts
+++ b/tests/adapter-pg.test.ts
@@ -130,4 +130,23 @@ describe('createPgTransaction', () => {
 
     expect(release).toHaveBeenCalledOnce();
   });
+
+  it('keeps the original error when the rollback itself fails (issue #204 repro)', async () => {
+    const { pool, clientQuery, release } = fakeTransactionalPool();
+    clientQuery.mockImplementation(async (sql: string) => {
+      if (sql === 'rollback') {
+        throw new Error('connection terminated');
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const thrown = await createPgTransaction<DB>(pool)(async () => {
+      throw new Error('boom');
+    }).catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(AggregateError);
+    const errors = (thrown as AggregateError).errors as Error[];
+    expect(errors.map((error) => error.message)).toEqual(['boom', 'connection terminated']);
+    expect(release).toHaveBeenCalledOnce();
+  });
 });


### PR DESCRIPTION
Closes #204.

## Problem

```ts
} catch (error) {
  await transaction.rollback();  // if this rejects...
  throw error;                   // ...this never runs
}
```

The caller sees the cleanup failure and the original cause is gone. For `createMssqlTransaction` this was guaranteed, not hypothetical: `begin()` ran inside the `try`, so a pool that cannot reach the server went straight to `rollback()` on a transaction that never started, and node-mssql's `TransactionError: Transaction has not begun` replaced the connection error.

## Fix

A shared `rollbackAndRethrow(error, rollback)` in `src/adapters/transaction.ts`:

- rollback succeeds → the original error propagates untouched (unchanged behaviour);
- rollback fails → `AggregateError([original, rollbackError])`, original first, so the real cause is always `errors[0]` and the cleanup failure is still visible. `formatCliError` already unwraps `AggregateError`.

`createMssqlTransaction` now calls `begin()` outside the `try`, so a failed begin propagates as itself and no rollback is attempted on a transaction that never started.

Used by `createPgTransaction`, `createMysql2Transaction` and `createMssqlTransaction`. `createPostgresJsTransaction` delegates to postgres.js's own `sql.begin(...)` and is unchanged.

## Tests

Per adapter: a failing rollback yields an `AggregateError` whose errors are `[original, rollbackFailure]`, and pg/mysql2 still release the connection. For mssql: a failing `begin()` propagates as itself with `rollback` never called.

README documents the `AggregateError` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
