### PR TITLE
fix: preserve transaction rollback errors

### DIFF
--- a/src/adapters/mssql.ts
+++ b/src/adapters/mssql.ts
@@ -2,6 +2,7 @@ import type { ConnectionPool, Transaction, Request } from 'mssql';
 import type { DialectExecutor, QueryMeta, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
 import { createTypedDb } from '../index.js';
 import { collectNamedParameters } from './named-params.js';
+import { rollbackPreservingError } from './transaction-errors.js';
 
 const MSSQL_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@']);
 
@@ -58,13 +59,17 @@ export function createMssqlTransaction<DB extends SchemaLike>(pool: ConnectionPo
       { ...options, placeholders: 'at' } as Options & { placeholders: 'at' },
     );
 
+    let begun = false;
     try {
       await transaction.begin();
+      begun = true;
       const result = await fn(tx);
       await transaction.commit();
       return result;
     } catch (error) {
-      await transaction.rollback();
+      if (begun) {
+        await rollbackPreservingError(error, () => transaction.rollback());
+      }
       throw error;
     }
   };

--- a/src/adapters/mysql2.ts
+++ b/src/adapters/mysql2.ts
@@ -2,6 +2,7 @@ import type { Pool, Connection } from 'mysql2/promise';
 import type { ExecuteValues } from 'mysql2';
 import type { DialectExecutor, QueryMeta, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
 import { createTypedDb } from '../index.js';
+import { rollbackPreservingError } from './transaction-errors.js';
 
 export type Mysql2Queryable = Pool | Connection;
 
@@ -61,7 +62,7 @@ export function createMysql2Transaction<DB extends SchemaLike>(pool: Pool) {
       await connection.commit();
       return result;
     } catch (error) {
-      await connection.rollback();
+      await rollbackPreservingError(error, () => connection.rollback());
       throw error;
     } finally {
       connection.release();

--- a/src/adapters/pg.ts
+++ b/src/adapters/pg.ts
@@ -1,6 +1,7 @@
 import type { Pool, Client, PoolClient } from 'pg';
 import type { DialectExecutor, SchemaLike, TypedDb, TypedDbOptions } from '../index.js';
 import { createTypedDb } from '../index.js';
+import { rollbackPreservingError } from './transaction-errors.js';
 
 export type PgQueryable = Pool | Client | PoolClient;
 
@@ -56,7 +57,7 @@ export function createPgTransaction<DB extends SchemaLike>(pool: Pool) {
       await client.query('commit');
       return result;
     } catch (error) {
-      await client.query('rollback');
+      await rollbackPreservingError(error, () => client.query('rollback'));
       throw error;
     } finally {
       client.release();

--- a/src/adapters/transaction-errors.ts
+++ b/src/adapters/transaction-errors.ts
@@ -1,0 +1,12 @@
+export async function rollbackPreservingError(
+  originalError: unknown,
+  rollback: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    await rollback();
+  } catch (rollbackError) {
+    if (originalError instanceof Error && (originalError as { cause?: unknown }).cause === undefined) {
+      (originalError as { cause?: unknown }).cause = rollbackError;
+    }
+  }
+}

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -160,4 +160,30 @@ describe('createMssqlTransaction', () => {
     expect(rollback).toHaveBeenCalledOnce();
     expect(commit).not.toHaveBeenCalled();
   });
+
+  it('preserves the callback error when rollback also throws', async () => {
+    const { pool, rollback, commit } = fakeTransactionalPool();
+    const original = new Error('original failure');
+    const rollbackError = new Error('rollback failed');
+    rollback.mockRejectedValue(rollbackError);
+
+    await expect(createMssqlTransaction<DB>(pool)(async () => {
+      throw original;
+    })).rejects.toBe(original);
+
+    expect(original.cause).toBe(rollbackError);
+    expect(rollback).toHaveBeenCalledOnce();
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('does not roll back when begin fails before the transaction starts', async () => {
+    const { pool, begin, rollback, commit } = fakeTransactionalPool();
+    const beginError = new Error('connect failed');
+    begin.mockRejectedValue(beginError);
+
+    await expect(createMssqlTransaction<DB>(pool)(async () => 'done')).rejects.toBe(beginError);
+
+    expect(rollback).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+  });
 });

--- a/tests/adapter-mysql2.test.ts
+++ b/tests/adapter-mysql2.test.ts
@@ -113,4 +113,20 @@ describe('createMysql2Transaction', () => {
     expect(commit).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledOnce();
   });
+
+  it('preserves the callback error when rollback also throws', async () => {
+    const { pool, rollback, commit, release } = fakeTransactionalPool();
+    const original = new Error('original failure');
+    const rollbackError = new Error('rollback failed');
+    rollback.mockRejectedValue(rollbackError);
+
+    await expect(createMysql2Transaction<DB>(pool)(async () => {
+      throw original;
+    })).rejects.toBe(original);
+
+    expect(original.cause).toBe(rollbackError);
+    expect(rollback).toHaveBeenCalledOnce();
+    expect(commit).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/adapter-pg.test.ts
+++ b/tests/adapter-pg.test.ts
@@ -115,6 +115,25 @@ describe('createPgTransaction', () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it('preserves the callback error when rollback also throws', async () => {
+    const { pool, clientQuery, release } = fakeTransactionalPool();
+    const original = new Error('original failure');
+    const rollback = new Error('rollback failed');
+    clientQuery.mockImplementation(async (sql: string) => {
+      if (sql === 'rollback') {
+        throw rollback;
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    await expect(createPgTransaction<DB>(pool)(async () => {
+      throw original;
+    })).rejects.toBe(original);
+
+    expect(original.cause).toBe(rollback);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it('releases even when commit itself throws', async () => {
     const { pool, clientQuery, release } = fakeTransactionalPool();
     clientQuery.mockImplementation(async (sql: string) => {


### PR DESCRIPTION
## Summary
- preserve the original transaction error when rollback also rejects for pg, mysql2, and mssql helpers
- attach the rollback failure to the original `Error.cause` when the original error has no cause yet
- avoid rolling back mssql transactions when `begin()` failed before the transaction started
- add rollback-failure regressions for pg/mysql2/mssql plus the mssql begin-failure case

Fixes #204

## Testing
- `npx vitest run tests/adapter-pg.test.ts tests/adapter-mysql2.test.ts tests/adapter-mssql.test.ts`
- `npm run test:types`
- `npm run test:runtime`
- `npm run build`
- `npm test`
- `git diff --check`
