### PR TITLE
fix: reject a stacked second statement in non-strict mode too

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,6 +957,12 @@ This is a focused tool for the common read path, not a full SQL grammar:
   'DELETE'`.
 - **Unknown columns, tables, or aliases resolve to `unknown`** by default — pass
   `{ strict: true }` to turn them into a `QueryTypeError` instead.
+- **One statement per query.** A semicolon is only allowed at the end. A
+  second statement after one (`select id from users; drop table users`) is a
+  `QueryTypeError` in both modes, for the row type and for the parameter
+  tuple — this isn't a schema question, so strict mode has nothing to be
+  stricter about, and inferring a row from two merged statements would be
+  confidently wrong rather than merely permissive.
 
 These are deliberate scope choices; the [FAQ](#faq) covers how to work around
 them.

--- a/src/params.ts
+++ b/src/params.ts
@@ -6,6 +6,7 @@ import type {
   IsKeyword,
   ExtractParenGroup,
   Digit,
+  HasNonTrailingSemicolon,
 } from './string.js';
 import type {
   Source,
@@ -16,6 +17,7 @@ import type {
   ResolveKey,
   AfterKeyword,
   SplitColumnList,
+  MultipleStatementsError,
 } from './parse.js';
 import type { ParseWithClause } from './cte.js';
 
@@ -412,7 +414,16 @@ type OuterAndCteParams<
       : unknown[]
   : unknown[];
 
+// Same guard InferRowWith applies (issue #206): the parameter tuple is
+// derived from the merged text too, so a stacked statement would otherwise
+// hand the caller a normal-looking signature covering placeholders from two
+// different statements. The error tuple makes the call site fail instead.
 export type InferParams<DB extends SchemaLike, Q extends string> =
+  HasNonTrailingSemicolon<Q> extends true
+    ? [MultipleStatementsError]
+    : InferParamsChecked<DB, Q>;
+
+type InferParamsChecked<DB extends SchemaLike, Q extends string> =
   IsKeyword<FirstWord<Normalize<Q>>, 'insert'> extends true
     ? InsertParamTypes<DB, Normalize<Q>>
     : ResolveCteContext<DB, Q, false> extends {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -839,14 +839,21 @@ type ApplyWhereCheck<
         : WhereClauseError<DB, Sources, WhereText>
   : Row;
 
+// Checked in both modes, unlike the schema-driven checks that strict mode
+// gates: how many statements a string holds is not a schema question, and
+// Normalize strips every semicolon, so a stacked statement is folded into the
+// first one and the inferred row describes something the driver will not do
+// (issue #206). Non-strict inference is permissive - `unknown` where it can't
+// tell - but never knowingly wrong.
+export type MultipleStatementsError =
+  QueryTypeError<'multiple statements are not supported: found a semicolon before the end of the query'>;
+
 export type InferRowWith<
   DB extends SchemaLike,
   Q extends string,
   Strict extends boolean,
-> = Strict extends true
-  ? HasNonTrailingSemicolon<Q> extends true
-    ? QueryTypeError<'multiple statements are not supported: found a semicolon before the end of the query'>
-    : InferRowWithChecked<DB, Q, Strict>
+> = HasNonTrailingSemicolon<Q> extends true
+  ? MultipleStatementsError
   : InferRowWithChecked<DB, Q, Strict>;
 
 type InferRowWithChecked<

--- a/tests/semicolon.test-d.ts
+++ b/tests/semicolon.test-d.ts
@@ -1,4 +1,4 @@
-import type { Query, StrictRow, QueryTypeError } from '../src/index.js';
+import type { Query, Params, StrictRow, QueryTypeError } from '../src/index.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -49,8 +49,22 @@ type NonTrailingSemicolonIsRejectedInStrictMode = Expect<
   >
 >;
 
-type NonStrictModeStillMergesNonTrailingSemicolon = Expect<
-  Equal<Query<DB, 'select id from users; select name from users'>, { id: number }[]>
+type NonTrailingSemicolonIsRejectedInNonStrictMode = Expect<
+  Equal<
+    Query<DB, 'select id from users; select name from users'>,
+    QueryTypeError<'multiple statements are not supported: found a semicolon before the end of the query'>[]
+  >
+>;
+
+type NonTrailingSemicolonIsRejectedForParams = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = ?; delete from users where id = ?'>,
+    [QueryTypeError<'multiple statements are not supported: found a semicolon before the end of the query'>]
+  >
+>;
+
+type TrailingSemicolonStillTypesParams = Expect<
+  Equal<Params<DB, 'select id from users where id = ?;'>, [number]>
 >;
 
 export type Assertions = [
@@ -61,5 +75,7 @@ export type Assertions = [
   SemicolonInsideDollarQuotedLiteralIsFine,
   SemicolonInsideCommentIsFine,
   NonTrailingSemicolonIsRejectedInStrictMode,
-  NonStrictModeStillMergesNonTrailingSemicolon,
+  NonTrailingSemicolonIsRejectedInNonStrictMode,
+  NonTrailingSemicolonIsRejectedForParams,
+  TrailingSemicolonStillTypesParams,
 ];


### PR DESCRIPTION
Closes #206.

## Problem

`HasNonTrailingSemicolon` (#139) was wired into `InferRowWith` only on the strict branch, and non-strict is the default:

```ts
type Loose = Row<DB, 'select id from users; drop table users'>;
// { id: number }

type P = Params<DB, 'select id from users where id = ?; delete from users where id = ?'>;
// [number, number]
```

`Normalize` strips every semicolon, so the second statement is folded into the first and the inferred type describes something the driver will not do. That is worse than a missing check: the rest of the non-strict contract is "unknown things become `unknown`" — less information, never wrong information. Whether a string holds two statements is not a schema question, so there is nothing for strict mode to be stricter about. mysql2 with `multipleStatements: true` and `node:sqlite`'s `exec` path will both actually run the second one.

## Fix

- `InferRowWith` runs the guard ahead of the `Strict extends true` branch, so both modes return `QueryTypeError<'multiple statements are not supported: ...'>`.
- `InferParams` gets the same guard and returns `[MultipleStatementsError]`, so the call site fails instead of receiving a plausible-looking two-parameter signature.
- The error type is now a named `MultipleStatementsError` shared by both.

**Breaking for non-strict users** who currently rely on a stacked statement typing as its first statement. That inference was wrong, and a trailing semicolon (`select id from users;`) is unaffected.

## Tests

`tests/semicolon.test-d.ts`: non-strict row type and `Params` both reject a stacked statement; a trailing semicolon still types parameters normally. Existing cases for literals, dollar-quoted bodies and comments containing a semicolon still pass. README's Limitations section documents the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
