### PR TITLE
feat: validate JOIN ON operands in strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,20 @@ const typo = await db.query('select naem from users');
 The error type propagates wherever you use the rows, surfacing the message in
 hovers and breaking any code that treats them as real data.
 
+Strict mode checks the `SELECT` list, the `WHERE` clause, and `JOIN ... ON`
+conditions:
+
+```ts
+const wrongSide = await db.query(
+  'select u.id from users u join orders o on u.id = o.id',
+);
+//     wrongSide.value ^? QueryTypeError<'unknown column: id'>[] (when orders has no such column)
+```
+
+`GROUP BY`, `HAVING`, and `ORDER BY` are **not** checked — they have their own
+resolution rules (a `SELECT`-list alias, an ordinal, an aggregate), so a name
+there is not necessarily a column of a source table.
+
 ### 9. Joins
 
 `INNER`, `LEFT`, `RIGHT`, `FULL` (with optional `OUTER`), and `CROSS` joins are
@@ -879,7 +893,7 @@ this.**
 | Quoted / schema-qualified ids | `select "id" from public."users"` |
 | Trailing semicolon | `select id from users;` |
 | Typed parameters | `where id = $1` → `query(sql, id: number)` |
-| Strict mode | `{ strict: true }` → unknown column becomes a `QueryTypeError` |
+| Strict mode | `{ strict: true }` → unknown column becomes a `QueryTypeError` (`SELECT` list, `WHERE`, and `JOIN ... ON`) |
 | `WHERE` operators | `=`, `<>`, comparisons, `LIKE`/`ILIKE`, `IN (...)`, `BETWEEN ... AND ...`, `IS [NOT] NULL`, `IS [NOT] DISTINCT FROM`, `AND`/`OR` |
 | `GROUP BY` / `HAVING` / `ORDER BY` / `LIMIT` / `OFFSET` | parsed and skipped; output shape follows the `SELECT` list, `HAVING`/`LIMIT`/`OFFSET` placeholders are typed |
 | `UNION` / `UNION ALL` | result shape is inferred from the first branch |
@@ -961,7 +975,11 @@ This is a focused tool for the common read path, not a full SQL grammar:
   `OUTPUT $action` is recognized and typed as `'INSERT' | 'UPDATE' |
   'DELETE'`.
 - **Unknown columns, tables, or aliases resolve to `unknown`** by default — pass
-  `{ strict: true }` to turn them into a `QueryTypeError` instead.
+  `{ strict: true }` to turn them into a `QueryTypeError` instead. Strict mode
+  covers the `SELECT` list, the `WHERE` clause, and `JOIN ... ON` conditions;
+  `GROUP BY`, `HAVING`, and `ORDER BY` are left alone, since a name there can
+  be a `SELECT`-list alias, an ordinal, or an aggregate rather than a column
+  of a source table.
 - **One statement per query.** A semicolon is only allowed at the end. A
   second statement after one (`select id from users; drop table users`) is a
   `QueryTypeError` in both modes, for the row type and for the parameter

--- a/src/from.ts
+++ b/src/from.ts
@@ -51,7 +51,62 @@ type SplitFromClauseBoundary<
       : { clause: Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>; rest: '' }
     : { clause: Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>; rest: '' };
 
-type TakeFromClause<S extends string> = SplitFromClauseBoundary<S>['clause'];
+export type TakeFromClause<S extends string> = SplitFromClauseBoundary<S>['clause'];
+
+type IsJoinPhraseWord<Word extends string> = Lowercase<Word> extends
+  | 'join'
+  | 'inner'
+  | 'left'
+  | 'right'
+  | 'full'
+  | 'outer'
+  | 'cross'
+  | 'lateral'
+  ? true
+  : false;
+
+// Collects every top-level `ON` condition in a FROM clause into one text, with
+// the groups joined by `and` so the WHERE scanner can validate them in a
+// single pass - the operands are ordinary bare or qualified column references,
+// exactly what ValidateWhereOperand already handles. Depth-tracked, so an `ON`
+// belonging to a derived table's own inner query is left to that query's own
+// parse.
+type ScanJoinOnText<
+  S extends string,
+  Depth extends unknown[] = [],
+  Collecting extends boolean = false,
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? IsKeyword<Head, 'on'> extends true
+      ? ScanJoinOnText<
+          Tail,
+          ApplyParenDelta<Depth, Head>,
+          true,
+          Accumulated extends '' ? '' : `${Accumulated} and`
+        >
+      : IsJoinPhraseWord<Head> extends true
+        ? ScanJoinOnText<Tail, ApplyParenDelta<Depth, Head>, false, Accumulated>
+        : Collecting extends true
+          ? ScanJoinOnText<
+              Tail,
+              ApplyParenDelta<Depth, Head>,
+              true,
+              Accumulated extends '' ? Head : `${Accumulated} ${Head}`
+            >
+          : ScanJoinOnText<Tail, ApplyParenDelta<Depth, Head>, false, Accumulated>
+    : ScanJoinOnText<Tail, ApplyParenDelta<Depth, Head>, Collecting, Accumulated>
+  : Depth extends []
+    ? Collecting extends true
+      ? IsJoinPhraseWord<S> extends true
+        ? Accumulated
+        : Accumulated extends ''
+          ? S
+          : `${Accumulated} ${S}`
+      : Accumulated
+    : Accumulated;
+
+export type ExtractJoinOnText<FromClause extends string> = ScanJoinOnText<Trim<FromClause>>;
 
 export type RestAfterFromClause<AfterFrom extends string> = SplitFromClauseBoundary<AfterFrom>['rest'];
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -17,7 +17,13 @@ import type {
   FunctionOutputName,
   FunctionReturnType,
 } from './functions.js';
-import type { Source, ParseFromClause, RestAfterFromClause } from './from.js';
+import type {
+  Source,
+  ParseFromClause,
+  RestAfterFromClause,
+  TakeFromClause,
+  ExtractJoinOnText,
+} from './from.js';
 import type { IsCaseExpression, SplitCaseExpression, CaseExpressionType } from './case.js';
 import type { ParseWithClause, BuildCteMap } from './cte.js';
 import type { ExtractSelectWhereText, ExtractUpdateDeleteWhereText, WhereClauseError } from './where.js';
@@ -210,6 +216,7 @@ export interface ParsedStatement {
   columns: string;
   sources: Source[];
   whereText: string;
+  fromText: string;
 }
 
 type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer Body
@@ -223,8 +230,12 @@ type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer B
             columns: Columns;
             sources: ParseFromClause<AfterFrom>;
             whereText: ExtractSelectWhereText<RestAfterFromClause<AfterFrom>>;
+            // Kept as raw text rather than pre-extracted ON conditions: the
+            // JOIN ON check only runs in strict mode, and this way the scan
+            // is never instantiated for a non-strict query.
+            fromText: TakeFromClause<AfterFrom>;
           }
-        : { columns: Columns; sources: []; whereText: '' }
+        : { columns: Columns; sources: []; whereText: ''; fromText: '' }
       : never
     : never
   : never;
@@ -237,6 +248,7 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
           columns: ReturningOrOutputColumns<S, 'values'>;
           sources: SingleSource<WordAfterKeyword<S, 'into'>>;
           whereText: '';
+          fromText: '';
         }
       : IsKeyword<Keyword, 'update'> extends true
         ? {
@@ -246,6 +258,7 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
               ...ExtraSourcesAfterKeyword<S, 'from'>,
             ];
             whereText: ExtractUpdateDeleteWhereText<S>;
+            fromText: '';
           }
         : IsKeyword<Keyword, 'delete'> extends true
           ? {
@@ -255,6 +268,7 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
                 ...ExtraSourcesAfterKeyword<S, 'using'>,
               ];
               whereText: ExtractUpdateDeleteWhereText<S>;
+              fromText: '';
             }
           : IsKeyword<Keyword, 'merge'> extends true
             ? {
@@ -266,6 +280,7 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
                 columns: StripPseudoTableQualifiers<OutputClauseColumnsToEnd<S>>;
                 sources: SingleSource<WordAfterKeyword<S, 'into'>>;
                 whereText: '';
+                fromText: '';
               }
             : never
   : never;
@@ -823,20 +838,40 @@ type BuildDerivedSourceMap<
     : BuildDerivedSourceMap<DB, Tail, Strict, Accumulated>
   : Accumulated;
 
+type ApplyClauseError<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  ClauseText extends string,
+  Row,
+> = Trim<ClauseText> extends ''
+  ? Row
+  : [WhereClauseError<DB, Sources, ClauseText>] extends [never]
+    ? Row
+    : WhereClauseError<DB, Sources, ClauseText>;
+
+// JOIN ON conditions are validated the same way the WHERE clause is: the
+// operands are ordinary column references against the same sources, and a
+// wrong side (`o.id` where `o.user_id` was meant) compiles, runs, and returns
+// a wrong result set - exactly what strict mode exists to catch (issue #205).
+// GROUP BY, HAVING and ORDER BY stay out: they have their own resolution
+// rules (SELECT-list aliases, ordinals, aggregates), documented as a
+// limitation in the README.
 type ApplyWhereCheck<
   DB extends SchemaLike,
   Sources extends Source[],
   WhereText extends string,
+  FromText extends string,
   Strict extends boolean,
   Row,
 > = Strict extends true
   ? Row extends QueryTypeError<string>
     ? Row
-    : Trim<WhereText> extends ''
-      ? Row
-      : [WhereClauseError<DB, Sources, WhereText>] extends [never]
-        ? Row
-        : WhereClauseError<DB, Sources, WhereText>
+    : ApplyClauseError<
+        DB,
+        Sources,
+        ExtractJoinOnText<FromText>,
+        ApplyClauseError<DB, Sources, WhereText, Row>
+      >
   : Row;
 
 // Checked in both modes, unlike the schema-driven checks that strict mode
@@ -868,6 +903,7 @@ type InferRowWithChecked<
       columns: infer Columns extends string;
       sources: infer Sources extends Source[];
       whereText: infer WhereText extends string;
+      fromText: infer FromText extends string;
     }
     ? (CteDB & BuildDerivedSourceMap<CteDB, Sources, Strict>) extends infer EffectiveDB extends SchemaLike
       ? Trim<Columns> extends ''
@@ -876,6 +912,7 @@ type InferRowWithChecked<
             EffectiveDB,
             Sources,
             WhereText,
+            FromText,
             Strict,
             IsSelectAll<Columns> extends true
               ? StarRow<EffectiveDB, Sources, Strict>

--- a/tests/join-on-strict.test-d.ts
+++ b/tests/join-on-strict.test-d.ts
@@ -1,0 +1,142 @@
+import type { Query, StrictRow, StrictQuery, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true
+    : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; created_at: string };
+  orders: { id: number; user_id: number; total: number };
+  refunds: { id: number; order_id: number };
+}
+
+type UnknownColumnInOnIsCaught = Expect<
+  Equal<
+    StrictQuery<DB, 'select u.id from users u join orders o on u.id = o.nope'>,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+type UnknownAliasInOnIsCaught = Expect<
+  Equal<
+    StrictQuery<DB, 'select u.id from users u join orders o on u.id = z.user_id'>,
+    QueryTypeError<'unknown alias: z'>[]
+  >
+>;
+
+type ValidOnStillResolves = Expect<
+  Equal<StrictRow<DB, 'select u.id from users u join orders o on u.id = o.user_id'>, { id: number }>
+>;
+
+type TypoInTheSecondJoinIsCaught = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select u.id from users u join orders o on u.id = o.user_id join refunds r on r.nope = o.id'
+    >,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+type ValidTwoJoinChainResolves = Expect<
+  Equal<
+    StrictRow<
+      DB,
+      'select u.id from users u join orders o on u.id = o.user_id join refunds r on r.order_id = o.id'
+    >,
+    { id: number }
+  >
+>;
+
+type LeftJoinOnIsValidatedToo = Expect<
+  Equal<
+    StrictQuery<DB, 'select u.id from users u left join orders o on u.id = o.nope'>,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+type CompoundOnConditionIsValidated = Expect<
+  Equal<
+    StrictQuery<DB, 'select u.id from users u join orders o on u.id = o.user_id and o.nope = 1'>,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+type ValidCompoundOnResolves = Expect<
+  Equal<
+    StrictRow<DB, 'select u.id from users u join orders o on u.id = o.user_id and o.total > 10'>,
+    { id: number }
+  >
+>;
+
+type OnAgainstADerivedTableResolves = Expect<
+  Equal<
+    StrictRow<
+      DB,
+      'select u.id from users u join (select user_id from orders) o on o.user_id = u.id'
+    >,
+    { id: number }
+  >
+>;
+
+type CrossJoinWithoutOnStillResolves = Expect<
+  Equal<StrictRow<DB, 'select u.id from users u cross join orders o'>, { id: number }>
+>;
+
+type OnPlaceholderIsNotValidated = Expect<
+  Equal<
+    StrictRow<DB, 'select u.id from users u join orders o on o.user_id = $1'>,
+    { id: number }
+  >
+>;
+
+type WhereClauseStillCaughtAlongsideAValidOn = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select u.id from users u join orders o on u.id = o.user_id where u.naem = 1'
+    >,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+type NonStrictModeStillIgnoresTheOnClause = Expect<
+  Equal<Query<DB, 'select u.id from users u join orders o on u.id = o.nope'>, { id: number }[]>
+>;
+
+// GROUP BY / HAVING / ORDER BY keep their own resolution rules (SELECT-list
+// aliases, ordinals, aggregates) and stay out of scope - locked in here so
+// the boundary the README documents is a tested one.
+type OrderByIsNotValidated = Expect<
+  Equal<StrictRow<DB, 'select id from users where id = 1 order by nope'>, { id: number }>
+>;
+
+type GroupByIsNotValidated = Expect<
+  Equal<StrictRow<DB, 'select id from users group by nope'>, { id: number }>
+>;
+
+type HavingIsNotValidated = Expect<
+  Equal<StrictRow<DB, 'select id from users where id = 1 having nope > 1'>, { id: number }>
+>;
+
+export type Assertions = [
+  UnknownColumnInOnIsCaught,
+  UnknownAliasInOnIsCaught,
+  ValidOnStillResolves,
+  TypoInTheSecondJoinIsCaught,
+  ValidTwoJoinChainResolves,
+  LeftJoinOnIsValidatedToo,
+  CompoundOnConditionIsValidated,
+  ValidCompoundOnResolves,
+  OnAgainstADerivedTableResolves,
+  CrossJoinWithoutOnStillResolves,
+  OnPlaceholderIsNotValidated,
+  WhereClauseStillCaughtAlongsideAValidOn,
+  NonStrictModeStillIgnoresTheOnClause,
+  OrderByIsNotValidated,
+  GroupByIsNotValidated,
+  HavingIsNotValidated,
+];


### PR DESCRIPTION
Closes #205.

## Problem

Strict mode validated the `SELECT` list and (since #128/#148) the `WHERE` clause. Nothing else:

| query | before |
| --- | --- |
| `select id from users where nope = 1` | `QueryTypeError<'unknown column: nope'>` |
| `select u.id from users u join orders o on u.id = o.nope` | `{ id: number }` |

The join condition is the highest-traffic place to get a column name wrong, and the usual mistake is a wrong *side* (`o.id` where `o.user_id` was meant) — which compiles, runs, and returns a wrong result set instead of an error.

## Fix

`ExtractJoinOnText` (`src/from.ts`) collects every top-level `ON` condition in the FROM clause, joining multiple groups with `and`. It is depth-tracked, so an `ON` inside a derived table's own subquery belongs to that subquery's parse, not this one. The collected text goes through the existing `WhereClauseError` scan — the operands are ordinary bare or qualified column references against the same sources, which `ValidateWhereOperand` already handles (placeholders and literals short-circuit as before).

`ParsedStatement` now carries the FROM clause as raw `fromText` rather than pre-extracted conditions, so the scan is never instantiated for a non-strict query.

### GROUP BY / HAVING / ORDER BY

Deliberately still out of scope — they resolve against `SELECT`-list aliases, ordinals and aggregates, not only source columns. The README said only that unknown columns become a `QueryTypeError` in strict mode, with no clause boundary; it now states the boundary explicitly, and `tests/join-on-strict.test-d.ts` locks it in.

## Tests

`tests/join-on-strict.test-d.ts` (16 assertions): unknown column and unknown alias in `ON`, second join in a chain, `LEFT JOIN`, compound `a = b and c = d` conditions, derived-table joins, `CROSS JOIN` with no `ON`, placeholders, a `WHERE` typo alongside a valid `ON`, non-strict staying permissive, and the three out-of-scope clauses. Five of them fail on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
