### PR TITLE
test: run the adapters and the CLI against real databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,57 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run test:runtime
+
+  integration:
+    name: Integration tests (real databases)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: owlsql
+          POSTGRES_PASSWORD: owlsql
+          POSTGRES_DB: owlsql
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U owlsql -d owlsql"
+          --health-interval 3s
+          --health-timeout 5s
+          --health-retries 30
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: owlsql
+          MYSQL_DATABASE: owlsql
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -powlsql"
+          --health-interval 3s
+          --health-timeout 5s
+          --health-retries 40
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: Owlsql_Passw0rd
+        ports:
+          - 1434:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P Owlsql_Passw0rd -C -Q 'select 1'"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 40
+    env:
+      OWLSQL_PG_URL: postgres://owlsql:owlsql@127.0.0.1:5433/owlsql
+      OWLSQL_MYSQL_URL: mysql://root:owlsql@127.0.0.1:3307/owlsql
+      OWLSQL_MSSQL_URL: mssql://sa:Owlsql_Passw0rd@127.0.0.1:1434/master?encrypt=false&trustServerCertificate=true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run test:integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to this project, following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). This log starts at 0.1.8; earlier history lives in git and the GitHub releases page.
 
+## [Unreleased]
+
+### Added
+
+- Integration tests running the adapters and `owlsql generate` against real PostgreSQL, MySQL, and SQL Server instances, alongside the existing faked-driver tests.
+
 ## [0.1.8] - 2026-07-24
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,11 @@ You'll need Node 20 or later. The `node:sqlite` adapter and the CLI's SQLite int
 
 ```bash
 npm install
-npm test              # types + runtime
-npm run test:types    # tsc --noEmit over src + tests
-npm run test:runtime  # vitest
-npm run build         # emit dist/ with .d.ts
+npm test                  # types + runtime
+npm run test:types        # tsc --noEmit over src + tests
+npm run test:runtime      # vitest
+npm run test:integration  # vitest against real databases, see Testing below
+npm run build             # emit dist/ with .d.ts
 ```
 
 ### Fixing a bug
@@ -57,12 +58,29 @@ Open an issue before writing the implementation if the feature touches the publi
 
 ## Testing
 
-Two layers, and they test different things:
+Three layers, and they test different things:
 
 - **Type tests** (`tests/*.test-d.ts`) are pure type assertions. If they compile, the inference is correct; there's no runtime assertion to run. They cover column/alias projection, `@ts-expect-error` cases for queries that should fail to type, permissive-inference locks, and deep-recursion stress.
-- **Runtime tests** (`tests/*.test.ts`) run under vitest and cover the executor/`Result` contract, adapter parameter handling, the CLI, and the ts-plugin's runtime scanners.
+- **Runtime tests** (`tests/*.test.ts`) run under vitest and cover the executor/`Result` contract, adapter parameter handling, the CLI, and the ts-plugin's runtime scanners. Drivers are faked here, so these prove the adapter's own logic, not what a real server sends back.
+- **Integration tests** (`tests/integration/*.test.ts`) run the adapters and the `generate` CLI against real PostgreSQL, MySQL, and SQL Server instances. They cover what a fake driver can't: how each driver actually decodes a column (`bigint`, `numeric`, `tinyint(1)`, `bit`), the metadata a real result carries, and whether a rolled-back transaction really left no rows behind.
 
 CI runs the type tests against a matrix of TypeScript versions, since a template-literal-type change that works on one TypeScript release can silently stop working (or start working differently) on another.
+
+### Running the integration tests
+
+Each database is gated on its own environment variable. Unset it and that suite skips; set it to something unreachable and the suite fails rather than skipping silently, so a broken CI service can't pass as a green run.
+
+```bash
+docker compose -f docker-compose.integration.yml up -d
+```
+
+```bash
+OWLSQL_PG_URL='postgres://owlsql:owlsql@127.0.0.1:5433/owlsql' OWLSQL_MYSQL_URL='mysql://root:owlsql@127.0.0.1:3307/owlsql' OWLSQL_MSSQL_URL='mssql://sa:Owlsql_Passw0rd@127.0.0.1:1434/master?encrypt=false&trustServerCertificate=true' npm run test:integration
+```
+
+The compose file maps non-default host ports (5433/3307/1434) so it doesn't collide with a PostgreSQL or MySQL you already run locally. SQLite needs no container — `node:sqlite` is tested against real database files in the regular runtime suite.
+
+Each suite creates and drops its own `it_*` tables, so the three databases can be shared with anything else you have running in them.
 
 ## Publishing
 

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,0 +1,44 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: owlsql
+      POSTGRES_PASSWORD: owlsql
+      POSTGRES_DB: owlsql
+    ports:
+      - '5433:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U owlsql -d owlsql']
+      interval: 3s
+      timeout: 5s
+      retries: 30
+
+  mysql:
+    image: mysql:8.4
+    environment:
+      MYSQL_ROOT_PASSWORD: owlsql
+      MYSQL_DATABASE: owlsql
+    ports:
+      - '3307:3306'
+    healthcheck:
+      test: ['CMD', 'mysqladmin', 'ping', '-h', '127.0.0.1', '-uroot', '-powlsql']
+      interval: 3s
+      timeout: 5s
+      retries: 40
+
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: 'Y'
+      MSSQL_SA_PASSWORD: 'Owlsql_Passw0rd'
+    ports:
+      - '1434:1433'
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          '/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -C -Q "select 1"',
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 40

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "typecheck": "tsc --noEmit",
     "test:types": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.ts-plugin.json && tsc --noEmit -p tsconfig.ts-plugin-tests.json",
     "test:runtime": "vitest run",
+    "test:integration": "vitest run tests/integration",
     "test": "npm run test:types && npm run test:runtime",
     "prepublishOnly": "npm run test && npm run build"
   },

--- a/tests/integration/cli-generate.test.ts
+++ b/tests/integration/cli-generate.test.ts
@@ -1,0 +1,203 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Pool } from 'pg';
+import { createPool, type Pool as MysqlPool } from 'mysql2/promise';
+import { ConnectionPool, type config as MssqlConfig } from 'mssql';
+import { runGenerate } from '../../src/cli/generate.js';
+import { mssqlUrlToConfig } from '../../src/cli/dialects/mssql.js';
+import {
+  MSSQL_URL_ENV,
+  MYSQL_URL_ENV,
+  PG_URL_ENV,
+  mssqlUrl,
+  mysqlUrl,
+  pgUrl,
+  requireUrl,
+} from './databases.js';
+
+function makeOutputPath(): { dir: string; file: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'owlsql-generate-'));
+  return { dir, file: join(dir, 'schema.ts') };
+}
+
+describe.skipIf(pgUrl === undefined)('owlsql generate against a real PostgreSQL server', () => {
+  const output = makeOutputPath();
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: requireUrl(pgUrl, PG_URL_ENV) });
+    await pool.query('drop table if exists it_gen_pg');
+    await pool.query('drop type if exists it_gen_mood');
+    await pool.query(`create type it_gen_mood as enum ('happy', 'sad')`);
+    await pool.query(`
+      create table it_gen_pg (
+        id serial primary key,
+        name text not null,
+        bio text,
+        total bigint not null,
+        price numeric(10, 2) not null,
+        tags text[] not null,
+        mood it_gen_mood not null,
+        created_at timestamptz not null
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    await pool.query('drop table if exists it_gen_pg');
+    await pool.query('drop type if exists it_gen_mood');
+    await pool.end();
+    rmSync(output.dir, { recursive: true, force: true });
+  });
+
+  it('introspects columns, nullability, enums, and arrays into a schema file', async () => {
+    const result = await runGenerate({
+      url: requireUrl(pgUrl, PG_URL_ENV),
+      out: output.file,
+      tables: ['it_gen_pg'],
+    });
+
+    expect(result).toEqual({ kind: 'written' });
+    expect(await readFile(output.file, 'utf8')).toBe(
+      'export interface DB {\n' +
+        '  it_gen_pg: {\n' +
+        '    id: number;\n' +
+        '    name: string;\n' +
+        '    bio: string | null;\n' +
+        '    total: string;\n' +
+        '    price: string;\n' +
+        '    tags: string[];\n' +
+        '    mood: "happy" | "sad";\n' +
+        '    created_at: Date;\n' +
+        '  };\n' +
+        '}\n',
+    );
+  });
+
+  it('reports an up-to-date file as unchanged and a stale one as drifted', async () => {
+    const options = {
+      url: requireUrl(pgUrl, PG_URL_ENV),
+      out: output.file,
+      tables: ['it_gen_pg'],
+      check: true,
+    };
+
+    expect(await runGenerate(options)).toEqual({ kind: 'upToDate' });
+
+    await pool.query('alter table it_gen_pg add column extra text');
+    const drifted = await runGenerate(options);
+
+    expect(drifted.kind).toBe('drift');
+  });
+});
+
+describe.skipIf(mysqlUrl === undefined)('owlsql generate against a real MySQL server', () => {
+  const output = makeOutputPath();
+  let pool: MysqlPool;
+
+  beforeAll(async () => {
+    pool = createPool(requireUrl(mysqlUrl, MYSQL_URL_ENV));
+    await pool.query('drop table if exists it_gen_mysql');
+    await pool.query(`
+      create table it_gen_mysql (
+        id int auto_increment primary key,
+        name varchar(64) not null,
+        bio text,
+        flag tinyint(1) not null,
+        bits bit(1) not null,
+        total bigint not null,
+        price decimal(10, 2) not null,
+        created_at datetime not null
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    await pool.query('drop table if exists it_gen_mysql');
+    await pool.end();
+    rmSync(output.dir, { recursive: true, force: true });
+  });
+
+  it('maps tinyint(1) and bit(1) to what mysql2 actually returns', async () => {
+    const result = await runGenerate({
+      url: requireUrl(mysqlUrl, MYSQL_URL_ENV),
+      out: output.file,
+      tables: ['it_gen_mysql'],
+    });
+
+    expect(result).toEqual({ kind: 'written' });
+    expect(await readFile(output.file, 'utf8')).toBe(
+      'export interface DB {\n' +
+        '  it_gen_mysql: {\n' +
+        '    id: number;\n' +
+        '    name: string;\n' +
+        '    bio: string | null;\n' +
+        '    flag: number;\n' +
+        '    bits: Buffer;\n' +
+        '    total: number;\n' +
+        '    price: string;\n' +
+        '    created_at: Date;\n' +
+        '  };\n' +
+        '}\n',
+    );
+  });
+});
+
+describe.skipIf(mssqlUrl === undefined)('owlsql generate against a real SQL Server', () => {
+  const output = makeOutputPath();
+  let pool: ConnectionPool;
+
+  beforeAll(async () => {
+    const config = mssqlUrlToConfig(requireUrl(mssqlUrl, MSSQL_URL_ENV)) as MssqlConfig;
+    pool = new ConnectionPool(config);
+    await pool.connect();
+    await pool
+      .request()
+      .query(`if object_id('it_gen_mssql', 'U') is not null drop table it_gen_mssql`);
+    await pool.request().query(`
+      create table it_gen_mssql (
+        id int identity(1, 1) primary key,
+        name nvarchar(64) not null,
+        bio nvarchar(max) null,
+        total bigint not null,
+        price decimal(10, 2) not null,
+        active bit not null,
+        created_at datetime2 not null
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    await pool
+      .request()
+      .query(`if object_id('it_gen_mssql', 'U') is not null drop table it_gen_mssql`);
+    await pool.close();
+    rmSync(output.dir, { recursive: true, force: true });
+  });
+
+  it('introspects sys.tables into a schema file', async () => {
+    const result = await runGenerate({
+      url: requireUrl(mssqlUrl, MSSQL_URL_ENV),
+      out: output.file,
+      tables: ['it_gen_mssql'],
+    });
+
+    expect(result).toEqual({ kind: 'written' });
+    expect(await readFile(output.file, 'utf8')).toBe(
+      'export interface DB {\n' +
+        '  it_gen_mssql: {\n' +
+        '    id: number;\n' +
+        '    name: string;\n' +
+        '    bio: string | null;\n' +
+        '    total: string;\n' +
+        '    price: number;\n' +
+        '    active: boolean;\n' +
+        '    created_at: Date;\n' +
+        '  };\n' +
+        '}\n',
+    );
+  });
+});

--- a/tests/integration/databases.ts
+++ b/tests/integration/databases.ts
@@ -1,0 +1,31 @@
+import type { ExecutorResult, QueryMeta } from '../../src/index.js';
+
+export const PG_URL_ENV = 'OWLSQL_PG_URL';
+export const MYSQL_URL_ENV = 'OWLSQL_MYSQL_URL';
+export const MSSQL_URL_ENV = 'OWLSQL_MSSQL_URL';
+
+function readUrl(name: string): string | undefined {
+  const value = process.env[name];
+  return value !== undefined && value.length > 0 ? value : undefined;
+}
+
+export const pgUrl = readUrl(PG_URL_ENV);
+export const mysqlUrl = readUrl(MYSQL_URL_ENV);
+export const mssqlUrl = readUrl(MSSQL_URL_ENV);
+
+export function requireUrl(url: string | undefined, name: string): string {
+  if (url === undefined) {
+    throw new Error(
+      `${name} is not set. Start the integration databases with: docker compose -f docker-compose.integration.yml up -d`,
+    );
+  }
+  return url;
+}
+
+export function rowsOf(result: ExecutorResult): unknown[] {
+  return Array.isArray(result) ? result : result.rows;
+}
+
+export function metaOf(result: ExecutorResult): QueryMeta {
+  return Array.isArray(result) ? {} : (result.meta ?? {});
+}

--- a/tests/integration/kysely.test.ts
+++ b/tests/integration/kysely.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Kysely, PostgresDialect } from 'kysely';
+import { Pool } from 'pg';
+import { createKyselyExecutor } from '../../src/adapters/kysely.js';
+import { PG_URL_ENV, metaOf, pgUrl, requireUrl, rowsOf } from './databases.js';
+
+interface KyselyDB {
+  it_kysely_rows: { id: number; name: string };
+}
+
+describe.skipIf(pgUrl === undefined)('kysely adapter against a real PostgreSQL server', () => {
+  let db: Kysely<KyselyDB>;
+
+  beforeAll(async () => {
+    db = new Kysely<KyselyDB>({
+      dialect: new PostgresDialect({
+        pool: new Pool({ connectionString: requireUrl(pgUrl, PG_URL_ENV) }),
+      }),
+    });
+    const executor = createKyselyExecutor(db);
+    await executor('drop table if exists it_kysely_rows', []);
+    await executor(
+      'create table it_kysely_rows (id serial primary key, name text not null)',
+      [],
+    );
+  });
+
+  afterAll(async () => {
+    await createKyselyExecutor(db)('drop table if exists it_kysely_rows', []);
+    await db.destroy();
+  });
+
+  it('runs a parameterized query through kysely and reads the rows back', async () => {
+    const executor = createKyselyExecutor(db);
+
+    await executor('insert into it_kysely_rows (name) values ($1)', ['ada']);
+    const result = await executor('select name from it_kysely_rows where name = $1', ['ada']);
+
+    expect(rowsOf(result)).toEqual([{ name: 'ada' }]);
+  });
+
+  it('reports the affected row count as a bigint', async () => {
+    const executor = createKyselyExecutor(db);
+
+    const inserted = await executor('insert into it_kysely_rows (name) values ($1)', ['grace']);
+
+    expect(metaOf(inserted).rowCount).toBe(1n);
+  });
+});

--- a/tests/integration/mssql.test.ts
+++ b/tests/integration/mssql.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ConnectionPool, type config as MssqlConfig } from 'mssql';
+import { createMssqlExecutor, createMssqlTransaction } from '../../src/adapters/mssql.js';
+import { mssqlUrlToConfig } from '../../src/cli/dialects/mssql.js';
+import { isOk } from '../../src/index.js';
+import { MSSQL_URL_ENV, metaOf, mssqlUrl, requireUrl, rowsOf } from './databases.js';
+
+interface DB {
+  it_mssql_rows: {
+    id: number;
+    name: string;
+    total: string;
+    price: number;
+    active: boolean;
+  };
+}
+
+describe.skipIf(mssqlUrl === undefined)('mssql adapter against a real SQL Server', () => {
+  let pool: ConnectionPool;
+
+  beforeAll(async () => {
+    const config = mssqlUrlToConfig(requireUrl(mssqlUrl, MSSQL_URL_ENV)) as MssqlConfig;
+    pool = new ConnectionPool(config);
+    await pool.connect();
+    await pool.request().query(`
+      if object_id('it_mssql_rows', 'U') is not null drop table it_mssql_rows
+    `);
+    await pool.request().query(`
+      create table it_mssql_rows (
+        id int identity(1, 1) primary key,
+        name nvarchar(64) not null,
+        total bigint not null,
+        price decimal(10, 2) not null,
+        active bit not null
+      )
+    `);
+    await pool
+      .request()
+      .query(`insert into it_mssql_rows (name, total, price, active) values ('ada', 42, 19.90, 1)`);
+  });
+
+  afterAll(async () => {
+    await pool
+      .request()
+      .query(`if object_id('it_mssql_rows', 'U') is not null drop table it_mssql_rows`);
+    await pool.close();
+  });
+
+  it('decodes bigint as a string, bit as a boolean, and decimal as a number', async () => {
+    const executor = createMssqlExecutor(pool);
+
+    const result = await executor('select total, price, active from it_mssql_rows', []);
+
+    expect(rowsOf(result)).toEqual([{ total: '42', price: 19.9, active: true }]);
+  });
+
+  it('binds named parameters to the slots they appear in', async () => {
+    const executor = createMssqlExecutor(pool);
+
+    const matching = await executor(
+      'select name from it_mssql_rows where name = @name and total = @total',
+      ['ada', 42],
+    );
+    const swapped = await executor(
+      'select name from it_mssql_rows where name = @name and total = @total',
+      ['ada', 41],
+    );
+
+    expect(rowsOf(matching)).toEqual([{ name: 'ada' }]);
+    expect(rowsOf(swapped)).toEqual([]);
+  });
+
+  it('binds a repeated named parameter from a single value slot', async () => {
+    const executor = createMssqlExecutor(pool);
+
+    const result = await executor('select @word as first, @word as second', ['owl']);
+
+    expect(rowsOf(result)).toEqual([{ first: 'owl', second: 'owl' }]);
+  });
+
+  it('sends an undefined parameter as null', async () => {
+    const executor = createMssqlExecutor(pool);
+
+    const result = await executor(
+      'select name from it_mssql_rows where @missing is null and name = @name',
+      [undefined, 'ada'],
+    );
+
+    expect(rowsOf(result)).toEqual([{ name: 'ada' }]);
+  });
+
+  it('reports rowsAffected for an insert, an update, and a delete', async () => {
+    const executor = createMssqlExecutor(pool);
+
+    const inserted = await executor(
+      `insert into it_mssql_rows (name, total, price, active) values ('grace', 1, 1.00, 0)`,
+      [],
+    );
+    const updated = await executor(
+      `update it_mssql_rows set active = 1 where name = 'grace'`,
+      [],
+    );
+    const deleted = await executor(`delete from it_mssql_rows where name = 'grace'`, []);
+
+    expect(metaOf(inserted)).toEqual({ rowCount: 1 });
+    expect(metaOf(updated)).toEqual({ rowCount: 1 });
+    expect(metaOf(deleted)).toEqual({ rowCount: 1 });
+  });
+
+  it('commits writes made inside a transaction callback', async () => {
+    const inserted = await createMssqlTransaction<DB>(pool)(async (tx) =>
+      tx.query(
+        'insert into it_mssql_rows (name, total, price, active) values (@name, @total, @price, @active)',
+        'committed',
+        '1',
+        1,
+        true,
+      ),
+    );
+
+    expect(isOk(inserted)).toBe(true);
+    const check = await pool
+      .request()
+      .query(`select name from it_mssql_rows where name = 'committed'`);
+    expect(check.recordset).toEqual([{ name: 'committed' }]);
+  });
+
+  it('leaves no rows behind when the transaction callback throws', async () => {
+    await expect(
+      createMssqlTransaction<DB>(pool)(async (tx) => {
+        await tx.query(
+          'insert into it_mssql_rows (name, total, price, active) values (@name, @total, @price, @active)',
+          'rolled-back',
+          '1',
+          1,
+          true,
+        );
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    const check = await pool
+      .request()
+      .query(`select name from it_mssql_rows where name = 'rolled-back'`);
+    expect(check.recordset).toEqual([]);
+  });
+});

--- a/tests/integration/mysql2.test.ts
+++ b/tests/integration/mysql2.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createPool, type Pool } from 'mysql2/promise';
+import { createMysql2Executor, createMysql2Transaction } from '../../src/adapters/mysql2.js';
+import { isOk } from '../../src/index.js';
+import { MYSQL_URL_ENV, metaOf, mysqlUrl, requireUrl, rowsOf } from './databases.js';
+
+interface DB {
+  it_mysql_rows: {
+    id: number;
+    name: string;
+    flag: number | null;
+    bits: Buffer | null;
+    total: number | null;
+    price: string | null;
+    payload: unknown;
+  };
+}
+
+function firstRow(rows: unknown[]): Record<string, unknown> {
+  return rows[0] as Record<string, unknown>;
+}
+
+describe.skipIf(mysqlUrl === undefined)('mysql2 adapter against a real MySQL server', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = createPool(requireUrl(mysqlUrl, MYSQL_URL_ENV));
+    await pool.query('drop table if exists it_mysql_rows');
+    await pool.query(`
+      create table it_mysql_rows (
+        id int auto_increment primary key,
+        name varchar(64) not null,
+        flag tinyint(1),
+        bits bit(1),
+        total bigint,
+        price decimal(10, 2),
+        payload json
+      )
+    `);
+    await pool.query(
+      `insert into it_mysql_rows (name, flag, bits, total, price, payload)
+       values ('ada', 1, b'1', 42, 19.90, '{"tier":"gold"}')`,
+    );
+  });
+
+  afterAll(async () => {
+    await pool.query('drop table if exists it_mysql_rows');
+    await pool.end();
+  });
+
+  it('decodes tinyint(1) as a number, not a boolean', async () => {
+    const executor = createMysql2Executor(pool);
+
+    const result = await executor('select flag from it_mysql_rows where name = ?', ['ada']);
+
+    expect(firstRow(rowsOf(result)).flag).toBe(1);
+  });
+
+  it('decodes bit(1) as a Buffer', async () => {
+    const executor = createMysql2Executor(pool);
+
+    const result = await executor('select bits from it_mysql_rows where name = ?', ['ada']);
+
+    expect(Buffer.isBuffer(firstRow(rowsOf(result)).bits)).toBe(true);
+  });
+
+  it('decodes bigint as a number and decimal as a string, matching the generated schema', async () => {
+    const executor = createMysql2Executor(pool);
+
+    const result = await executor('select total, price from it_mysql_rows where name = ?', ['ada']);
+
+    expect(rowsOf(result)).toEqual([{ total: 42, price: '19.90' }]);
+  });
+
+  it('decodes json into a parsed value', async () => {
+    const executor = createMysql2Executor(pool);
+
+    const result = await executor('select payload from it_mysql_rows where name = ?', ['ada']);
+
+    expect(firstRow(rowsOf(result)).payload).toEqual({ tier: 'gold' });
+  });
+
+  it('binds question-mark parameters in order', async () => {
+    const executor = createMysql2Executor(pool);
+
+    const matching = await executor('select name from it_mysql_rows where name = ? and total = ?', [
+      'ada',
+      42,
+    ]);
+    const swapped = await executor('select name from it_mysql_rows where name = ? and total = ?', [
+      'ada',
+      41,
+    ]);
+
+    expect(rowsOf(matching)).toEqual([{ name: 'ada' }]);
+    expect(rowsOf(swapped)).toEqual([]);
+  });
+
+  it('sends an undefined parameter as null instead of throwing', async () => {
+    const executor = createMysql2Executor(pool);
+
+    const result = await executor('select (? is null) as was_null', [undefined]);
+
+    expect(firstRow(rowsOf(result)).was_null).toBe(1);
+  });
+
+  it('reports affectedRows and insertId for an insert', async () => {
+    const executor = createMysql2Executor(pool);
+
+    const inserted = await executor('insert into it_mysql_rows (name) values (?)', ['grace']);
+    const meta = metaOf(inserted);
+
+    expect(meta.rowCount).toBe(1);
+    expect(typeof meta.lastInsertRowid).toBe('number');
+
+    const deleted = await executor('delete from it_mysql_rows where name = ?', ['grace']);
+    expect(metaOf(deleted).rowCount).toBe(1);
+  });
+
+  it('commits writes made inside a transaction callback', async () => {
+    const inserted = await createMysql2Transaction<DB>(pool)(async (tx) =>
+      tx.query('insert into it_mysql_rows (name) values (?)', 'committed'),
+    );
+
+    expect(isOk(inserted)).toBe(true);
+    const [rows] = await pool.query('select name from it_mysql_rows where name = ?', ['committed']);
+    expect(rows).toEqual([{ name: 'committed' }]);
+  });
+
+  it('leaves no rows behind when the transaction callback throws', async () => {
+    await expect(
+      createMysql2Transaction<DB>(pool)(async (tx) => {
+        await tx.query('insert into it_mysql_rows (name) values (?)', 'rolled-back');
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    const [rows] = await pool.query('select name from it_mysql_rows where name = ?', [
+      'rolled-back',
+    ]);
+    expect(rows).toEqual([]);
+  });
+});

--- a/tests/integration/pg.test.ts
+++ b/tests/integration/pg.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Pool } from 'pg';
+import { createPgExecutor, createPgTransaction } from '../../src/adapters/pg.js';
+import { isOk } from '../../src/index.js';
+import { PG_URL_ENV, metaOf, pgUrl, requireUrl, rowsOf } from './databases.js';
+
+interface DB {
+  it_pg_rows: {
+    id: number;
+    name: string;
+    bio: string | null;
+    total: string;
+    price: string;
+    active: boolean;
+  };
+}
+
+describe.skipIf(pgUrl === undefined)('pg adapter against a real PostgreSQL server', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: requireUrl(pgUrl, PG_URL_ENV) });
+    await pool.query('drop table if exists it_pg_rows');
+    await pool.query(`
+      create table it_pg_rows (
+        id serial primary key,
+        name text not null,
+        bio text,
+        total bigint not null,
+        price numeric(10, 2) not null,
+        active boolean not null
+      )
+    `);
+    await pool.query(
+      `insert into it_pg_rows (name, bio, total, price, active)
+       values ('ada', null, 9007199254740993, 19.90, true)`,
+    );
+  });
+
+  afterAll(async () => {
+    await pool.query('drop table if exists it_pg_rows');
+    await pool.end();
+  });
+
+  it('reads rows back through the executor', async () => {
+    const executor = createPgExecutor(pool);
+
+    const result = await executor('select name, active from it_pg_rows', []);
+
+    expect(rowsOf(result)).toEqual([{ name: 'ada', active: true }]);
+  });
+
+  it('decodes bigint and numeric columns as strings, matching the generated schema', async () => {
+    const executor = createPgExecutor(pool);
+
+    const result = await executor('select total, price from it_pg_rows', []);
+
+    expect(rowsOf(result)).toEqual([{ total: '9007199254740993', price: '19.90' }]);
+  });
+
+  it('decodes count(*) as a string, matching the documented aggregate caveat', async () => {
+    const executor = createPgExecutor(pool);
+
+    const result = await executor('select count(*) as total from it_pg_rows', []);
+
+    expect(rowsOf(result)).toEqual([{ total: '1' }]);
+  });
+
+  it('binds numbered parameters to the right slots', async () => {
+    const executor = createPgExecutor(pool);
+
+    const result = await executor('select $2::text as second, $1::text as first', ['a', 'b']);
+
+    expect(rowsOf(result)).toEqual([{ second: 'b', first: 'a' }]);
+  });
+
+  it('sends an undefined parameter as null', async () => {
+    const executor = createPgExecutor(pool);
+
+    const result = await executor('select name from it_pg_rows where bio is not distinct from $1', [
+      undefined,
+    ]);
+
+    expect(rowsOf(result)).toEqual([{ name: 'ada' }]);
+  });
+
+  it('reports rowCount for an insert, an update, and a delete', async () => {
+    const executor = createPgExecutor(pool);
+
+    const inserted = await executor(
+      `insert into it_pg_rows (name, total, price, active) values ('grace', 1, 1.00, false)`,
+      [],
+    );
+    const updated = await executor(`update it_pg_rows set active = true where name = 'grace'`, []);
+    const deleted = await executor(`delete from it_pg_rows where name = 'grace'`, []);
+
+    expect(metaOf(inserted)).toEqual({ rowCount: 1 });
+    expect(metaOf(updated)).toEqual({ rowCount: 1 });
+    expect(metaOf(deleted)).toEqual({ rowCount: 1 });
+  });
+
+  it('commits writes made inside a transaction callback', async () => {
+    const inserted = await createPgTransaction<DB>(pool)(async (tx) =>
+      tx.query(
+        'insert into it_pg_rows (name, total, price, active) values ($1, $2, $3, $4)',
+        'committed',
+        '1',
+        '1.00',
+        true,
+      ),
+    );
+
+    expect(isOk(inserted)).toBe(true);
+    const { rows } = await pool.query('select name from it_pg_rows where name = $1', ['committed']);
+    expect(rows).toEqual([{ name: 'committed' }]);
+  });
+
+  it('leaves no rows behind when the transaction callback throws', async () => {
+    await expect(
+      createPgTransaction<DB>(pool)(async (tx) => {
+        await tx.query(
+          'insert into it_pg_rows (name, total, price, active) values ($1, $2, $3, $4)',
+          'rolled-back',
+          '1',
+          '1.00',
+          true,
+        );
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    const { rows } = await pool.query('select name from it_pg_rows where name = $1', [
+      'rolled-back',
+    ]);
+    expect(rows).toEqual([]);
+  });
+});

--- a/tests/integration/postgres-js.test.ts
+++ b/tests/integration/postgres-js.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import postgres from 'postgres';
+import {
+  createPostgresJsExecutor,
+  createPostgresJsTransaction,
+} from '../../src/adapters/postgres.js';
+import { isOk } from '../../src/index.js';
+import { PG_URL_ENV, metaOf, pgUrl, requireUrl, rowsOf } from './databases.js';
+
+interface DB {
+  it_postgres_js_rows: {
+    id: number;
+    name: string;
+    total: string;
+    active: boolean;
+  };
+}
+
+describe.skipIf(pgUrl === undefined)('postgres.js adapter against a real PostgreSQL server', () => {
+  let sql: postgres.Sql;
+
+  beforeAll(async () => {
+    sql = postgres(requireUrl(pgUrl, PG_URL_ENV));
+    await sql.unsafe('drop table if exists it_postgres_js_rows');
+    await sql.unsafe(`
+      create table it_postgres_js_rows (
+        id serial primary key,
+        name text not null,
+        total bigint not null,
+        active boolean not null
+      )
+    `);
+    await sql.unsafe(`insert into it_postgres_js_rows (name, total, active) values ('ada', 42, true)`);
+  });
+
+  afterAll(async () => {
+    await sql.unsafe('drop table if exists it_postgres_js_rows');
+    await sql.end();
+  });
+
+  it('reads rows back through the executor', async () => {
+    const executor = createPostgresJsExecutor(sql);
+
+    const result = await executor('select name, total, active from it_postgres_js_rows', []);
+
+    expect(rowsOf(result)).toEqual([{ name: 'ada', total: '42', active: true }]);
+  });
+
+  it('binds numbered parameters to the right slots', async () => {
+    const executor = createPostgresJsExecutor(sql);
+
+    const result = await executor('select $2::text as second, $1::text as first', ['a', 'b']);
+
+    expect(rowsOf(result)).toEqual([{ second: 'b', first: 'a' }]);
+  });
+
+  it('sends an undefined parameter as null instead of throwing', async () => {
+    const executor = createPostgresJsExecutor(sql);
+
+    const result = await executor('select ($1::text is null) as was_null', [undefined]);
+
+    expect(rowsOf(result)).toEqual([{ was_null: true }]);
+  });
+
+  it('reports rowCount for an insert and a delete', async () => {
+    const executor = createPostgresJsExecutor(sql);
+
+    const inserted = await executor(
+      `insert into it_postgres_js_rows (name, total, active) values ('grace', 1, false)`,
+      [],
+    );
+    const deleted = await executor(`delete from it_postgres_js_rows where name = 'grace'`, []);
+
+    expect(metaOf(inserted)).toEqual({ rowCount: 1 });
+    expect(metaOf(deleted)).toEqual({ rowCount: 1 });
+  });
+
+  it('commits writes made inside a transaction callback', async () => {
+    const inserted = await createPostgresJsTransaction<DB>(sql)(async (tx) =>
+      tx.query(
+        'insert into it_postgres_js_rows (name, total, active) values ($1, $2, $3)',
+        'committed',
+        '1',
+        true,
+      ),
+    );
+
+    expect(isOk(inserted)).toBe(true);
+    const rows = await sql.unsafe(
+      `select name from it_postgres_js_rows where name = 'committed'`,
+    );
+    expect([...rows]).toEqual([{ name: 'committed' }]);
+  });
+
+  it('leaves no rows behind when the transaction callback throws', async () => {
+    await expect(
+      createPostgresJsTransaction<DB>(sql)(async (tx) => {
+        await tx.query(
+          'insert into it_postgres_js_rows (name, total, active) values ($1, $2, $3)',
+          'rolled-back',
+          '1',
+          true,
+        );
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    const rows = await sql.unsafe(
+      `select name from it_postgres_js_rows where name = 'rolled-back'`,
+    );
+    expect([...rows]).toEqual([]);
+  });
+});


### PR DESCRIPTION
First of four stacked PRs closing the gaps I wanted shut before tagging 1.0. Review in order; each one builds on the last.

Every adapter except `node:sqlite` was only ever tested against a faked driver. That proves the adapter's own logic and nothing more — it can't show how a real server decodes a `bigint`, what metadata a real result carries, or whether a rolled-back transaction actually left no rows behind. #203 and #204 were both that class of bug.

`tests/integration` now runs pg, postgres.js, mysql2, mssql, kysely and `owlsql generate` against real PostgreSQL 17, MySQL 8.4 and SQL Server 2022, with a compose file for local runs and service containers in CI.

Each database is gated on its own env var. Unset skips the suite; set but unreachable **fails** it, so a broken CI service can't pass as a green run.

Ports are 5433/3307/1434 rather than the defaults, because a locally running PostgreSQL will otherwise hijack the connection — which is exactly what happened to me while writing this.

36 tests, all passing against the three containers.