### PR TITLE
test: fail CI when the type-level parser gets more expensive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,18 @@ jobs:
       - run: npm ci
       - run: npm run test:runtime
 
+  type-budget:
+    name: Type-instantiation budget
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run test:perf
+
   integration:
     name: Integration tests (real databases)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+tests/perf/generated/
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 ### Added
 
 - Integration tests running the adapters and `owlsql generate` against real PostgreSQL, MySQL, and SQL Server instances, alongside the existing faked-driver tests.
+- A type-instantiation budget (`npm run test:perf`) that fails CI when a change makes the type-level parser measurably more expensive.
 
 ## [0.1.8] - 2026-07-24
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ npm test                  # types + runtime
 npm run test:types        # tsc --noEmit over src + tests
 npm run test:runtime      # vitest
 npm run test:integration  # vitest against real databases, see Testing below
+npm run test:perf         # type-instantiation budget, see Testing below
 npm run build             # emit dist/ with .d.ts
 ```
 
@@ -81,6 +82,18 @@ OWLSQL_PG_URL='postgres://owlsql:owlsql@127.0.0.1:5433/owlsql' OWLSQL_MYSQL_URL=
 The compose file maps non-default host ports (5433/3307/1434) so it doesn't collide with a PostgreSQL or MySQL you already run locally. SQLite needs no container — `node:sqlite` is tested against real database files in the regular runtime suite.
 
 Each suite creates and drops its own `it_*` tables, so the three databases can be shared with anything else you have running in them.
+
+### The type-instantiation budget
+
+The parser is recursive template literal types, so the cost that actually reaches users is compile time, and nothing about a passing type test tells you whether a change made `tsc` work three times harder for the same answer.
+
+```bash
+npm run test:perf
+```
+
+That generates a fixture (100 tables, 32 queries covering joins, `GROUP BY`, `CASE`, CTEs, `UNION`, strict mode, and typed params), type-checks it with `tsc --extendedDiagnostics`, and fails if the instantiation count goes over the budget in `scripts/type-budget.mjs`. Instantiation count is used rather than wall-clock time because it's deterministic: the same input and the same TypeScript version give the same number on any machine, so it can be a hard threshold instead of a flaky one. That's also why this runs on the lockfile's TypeScript version only, while the type tests run against the whole supported matrix.
+
+If your change legitimately costs more, raise the budget in the same commit rather than leaving it to drift. A reviewer can then see how much more expensive the feature made every query in every user's project.
 
 ## Publishing
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:types": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.ts-plugin.json && tsc --noEmit -p tsconfig.ts-plugin-tests.json",
     "test:runtime": "vitest run",
     "test:integration": "vitest run tests/integration",
+    "test:perf": "node scripts/type-budget.mjs",
     "test": "npm run test:types && npm run test:runtime",
     "prepublishOnly": "npm run test && npm run build"
   },

--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -1,0 +1,162 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TABLE_COUNT = 100;
+const FILLER_COLUMNS = 6;
+const SHAPE_REPEATS = 4;
+
+const MAX_INSTANTIATIONS = 185_000;
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PERF_DIR = join(ROOT, 'tests', 'perf');
+const GENERATED_DIR = join(PERF_DIR, 'generated');
+
+function tableName(index) {
+  return `t_${String(index).padStart(3, '0')}`;
+}
+
+function renderTable(index) {
+  const filler = Array.from(
+    { length: FILLER_COLUMNS },
+    (_unused, column) => `    col_${column}: string | null;`,
+  ).join('\n');
+
+  return [
+    `  ${tableName(index)}: {`,
+    '    id: number;',
+    '    name: string;',
+    '    email: string | null;',
+    '    status: string;',
+    '    active: boolean;',
+    '    amount: number;',
+    '    created_at: Date;',
+    filler,
+    '  };',
+  ].join('\n');
+}
+
+function renderSchema() {
+  const tables = Array.from({ length: TABLE_COUNT }, (_unused, index) => renderTable(index));
+  return `export interface DB {\n${tables.join('\n')}\n}\n`;
+}
+
+const SHAPES = [
+  (a) => ({ sql: `select id, name, email, created_at from ${a}`, kind: 'row' }),
+  (a) => ({ sql: `select * from ${a}`, kind: 'row' }),
+  (a, b) => ({
+    sql: `select x.id, y.name, y.amount from ${a} as x join ${b} as y on x.id = y.id`,
+    kind: 'row',
+  }),
+  (a) => ({ sql: `select status, count(*) as total from ${a} group by status`, kind: 'row' }),
+  (a) => ({
+    sql: `select id, case when active then 'on' else 'off' end as label from ${a}`,
+    kind: 'row',
+  }),
+  (a) => ({
+    sql: `with recent as (select id, name from ${a} where amount > $1) select id, name from recent`,
+    kind: 'params',
+  }),
+  (a) => ({ sql: `select id, name from ${a} where id = $1 and status = $2`, kind: 'strict' }),
+  (a, b) => ({ sql: `select id from ${a} union all select id from ${b}`, kind: 'row' }),
+];
+
+function renderQueries() {
+  const lines = [
+    "import type { Query, StrictQuery, Params } from '../../../src/index.js';",
+    "import type { DB } from './schema.js';",
+    '',
+    'type RowKeys<Result extends readonly unknown[]> = keyof Result[number];',
+    '',
+  ];
+
+  let index = 0;
+  for (let repeat = 0; repeat < SHAPE_REPEATS; repeat += 1) {
+    for (const shape of SHAPES) {
+      const first = tableName((index * 7) % TABLE_COUNT);
+      const second = tableName((index * 13 + 1) % TABLE_COUNT);
+      const { sql, kind } = shape(first, second);
+
+      if (kind === 'params') {
+        lines.push(`export declare const p${index}: Params<DB, "${sql}">;`);
+        lines.push(`export declare const k${index}: RowKeys<Query<DB, "${sql}">>;`);
+      } else if (kind === 'strict') {
+        lines.push(`export declare const k${index}: RowKeys<StrictQuery<DB, "${sql}">>;`);
+        lines.push(`export declare const p${index}: Params<DB, "${sql}">;`);
+      } else {
+        lines.push(`export declare const k${index}: RowKeys<Query<DB, "${sql}">>;`);
+      }
+
+      index += 1;
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function writeFixture() {
+  rmSync(GENERATED_DIR, { recursive: true, force: true });
+  mkdirSync(GENERATED_DIR, { recursive: true });
+  writeFileSync(join(GENERATED_DIR, 'schema.ts'), renderSchema(), 'utf8');
+  writeFileSync(join(GENERATED_DIR, 'queries.ts'), renderQueries(), 'utf8');
+}
+
+function readDiagnostic(output, label) {
+  const match = new RegExp(`^${label}:\\s+([\\d.]+)`, 'm').exec(output);
+  return match === null ? null : Number(match[1]);
+}
+
+function compile() {
+  const tsc = join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc');
+  try {
+    return execFileSync(
+      process.execPath,
+      [tsc, '--noEmit', '--extendedDiagnostics', '-p', join(PERF_DIR, 'tsconfig.json')],
+      { encoding: 'utf8' },
+    );
+  } catch (error) {
+    process.stderr.write(`${error.stdout ?? ''}${error.stderr ?? ''}\n`);
+    throw new Error('The type-budget fixture failed to compile.');
+  }
+}
+
+function main() {
+  writeFixture();
+  const output = compile();
+
+  const instantiations = readDiagnostic(output, 'Instantiations');
+  if (instantiations === null) {
+    throw new Error('Could not read the instantiation count from tsc --extendedDiagnostics.');
+  }
+
+  const types = readDiagnostic(output, 'Types');
+  const checkTime = readDiagnostic(output, 'Check time');
+  const budgetUsed = Math.round((instantiations / MAX_INSTANTIATIONS) * 100);
+
+  process.stdout.write(
+    [
+      `Tables:         ${TABLE_COUNT}`,
+      `Queries:        ${SHAPES.length * SHAPE_REPEATS}`,
+      `Types:          ${types ?? 'n/a'}`,
+      `Check time:     ${checkTime ?? 'n/a'}s`,
+      `Instantiations: ${instantiations} (${budgetUsed}% of the ${MAX_INSTANTIATIONS} budget)`,
+      '',
+    ].join('\n'),
+  );
+
+  if (instantiations > MAX_INSTANTIATIONS) {
+    process.stderr.write(
+      [
+        `Type-instantiation budget exceeded: ${instantiations} > ${MAX_INSTANTIATIONS}.`,
+        'Either the change made the parser recurse harder than it needs to, or the extra cost is',
+        'understood and intended - in which case raise MAX_INSTANTIATIONS in scripts/type-budget.mjs',
+        'in the same commit, so the new baseline is reviewed instead of drifting silently.',
+        '',
+      ].join('\n'),
+    );
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/tests/perf/tsconfig.json
+++ b/tests/perf/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["generated"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
   "include": ["src", "tests", "vitest.config.ts"],
   "exclude": [
     "src/ts-plugin",
+    "tests/perf",
     "tests/ts-plugin-sql-context.test.ts",
     "tests/ts-plugin-completions.test.ts",
     "tests/ts-plugin-hover.test.ts",


### PR DESCRIPTION
Second of four. Stacked on #221.

The parser is recursive template literal types, so the cost that reaches users is compile time — and a passing type test says nothing about it. A change can keep every inference correct while making `tsc` do three times the work, and nothing in CI would notice. `tests/depth.test-d.ts` checks correctness, not cost.

`npm run test:perf` generates a fixture of 100 tables and 32 queries (joins, `GROUP BY`, `CASE`, CTEs, `UNION`, strict mode, typed params), type-checks it with `tsc --extendedDiagnostics`, and fails when the instantiation count goes over budget.

Instantiations rather than wall-clock time because they're deterministic: same input, same TypeScript version, same number on any machine. That makes a hard threshold possible instead of a flaky one, and it's why the job pins the lockfile's TypeScript instead of running the whole matrix.

Baseline is 166512 against a budget of 185000. Cost is linear with a fixed overhead — 32 queries measured 166512, 64 measured 237044, so roughly 96k for the schema plus 2.2k per query. I checked the guard actually goes red by dropping the budget to 100k.

Raising the budget when a feature genuinely costs more is expected; doing it in the same commit keeps the new baseline in front of a reviewer.