### PR TITLE
fix: the fifteen bugs found by the 2026-07-28 audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,27 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
   Nothing about what the plugin does changed. The split exists because the two halves reach different TypeScript versions: the library type-checks clean on TypeScript 7, while the plugin needs the classic compiler API that TypeScript 7 removed. A single package can only declare one peer range, and either choice would have misrepresented half the code.
 
+### Fixed
+
+An end-to-end audit of the library, the CLI, and the editor plugin; every entry below was reproduced before it was fixed.
+
+- Placeholders no longer collapse into a single unusable slot. A cast on a numbered placeholder (`$1::int`) now still binds by index, and two distinct `$name` placeholders get a slot each instead of intersecting into `never` ([#228](https://github.com/tiagolauer/OwlSQL/issues/228)).
+- `UPDATE`/`DELETE` without a `FROM`/`USING` clause no longer gains a fabricated second source that matched every table in the schema, which made every `RETURNING` column report `ambiguous column` in strict mode ([#229](https://github.com/tiagolauer/OwlSQL/issues/229)).
+- `INSERT ... SELECT` is callable again: its parameter tuple resolved to `never`, which rejects every call including the zero-argument one. It now falls back to `unknown[]` as documented ([#230](https://github.com/tiagolauer/OwlSQL/issues/230)).
+- `MERGE ... OUTPUT $action` no longer demands an extra argument or fails the placeholder-style check against the mssql executor — `$action` is a pseudo-column, not a placeholder ([#231](https://github.com/tiagolauer/OwlSQL/issues/231)).
+- A semicolon inside a quoted identifier (`"id;x"`, `` `id;x` ``, `[id;x]`) is no longer read as a stacked statement ([#232](https://github.com/tiagolauer/OwlSQL/issues/232)).
+- Strict mode now validates the `WHERE` clause of an `UPDATE`/`DELETE` written without `RETURNING`, which it previously skipped entirely ([#233](https://github.com/tiagolauer/OwlSQL/issues/233)).
+- The mssql and node:sqlite parameter scanners skip SQL comments and quoted identifiers. A `@name`/`$name`/`?` inside a comment was bound as a real parameter, shifting every value after it ([#234](https://github.com/tiagolauer/OwlSQL/issues/234)).
+- `createMssqlExecutor(request)` works for more than one query: a caller-supplied `Request` is reset before binding, instead of throwing on a repeated parameter name and leaking the previous query's values ([#235](https://github.com/tiagolauer/OwlSQL/issues/235)).
+- `owlsql generate --url file:./app.db` works; the bare `file:` prefix was detected but never stripped ([#236](https://github.com/tiagolauer/OwlSQL/issues/236)).
+- The node:sqlite adapter reports write metadata for a CTE-led write (`with ... insert ...`) and for a write with `RETURNING`, both of which previously reported none ([#237](https://github.com/tiagolauer/OwlSQL/issues/237)).
+- `:name` placeholders are typed. The adapter has always bound them; the type layer produced an empty parameter tuple and strict mode flagged them as unknown columns ([#238](https://github.com/tiagolauer/OwlSQL/issues/238)).
+- The editor plugin no longer loses the joined table in a plain `from a join b`, marking every reference to it as an unknown alias. `JOIN ... USING` and comma-joined `FROM` lists are handled too ([#242](https://github.com/tiagolauer/OwlSQL/issues/242)).
+
 ### Added
 
+- `owlsql generate` accepts a SQL Server named instance in the URL form (`mssql://user:pass@host\INSTANCE/db`), and explains what a valid connection string looks like when the URL cannot be parsed at all ([#239](https://github.com/tiagolauer/OwlSQL/issues/239)).
+- `owlsql generate` rejects a `--table` name that matches no table instead of silently generating a schema without it, and warns on an unmatched `--exclude` ([#240](https://github.com/tiagolauer/OwlSQL/issues/240)). Boolean flags now reject a value, so `--check=false` no longer turned the check on ([#241](https://github.com/tiagolauer/OwlSQL/issues/241)).
 - Integration tests running the adapters and `owlsql generate` against real PostgreSQL, MySQL, and SQL Server instances, alongside the existing faked-driver tests.
 - A type-instantiation budget (`npm run test:perf`) that fails CI when a change makes the type-level parser measurably more expensive.
 - [VERSIONING.md](VERSIONING.md), stating what counts as a breaking change for a library whose public API is the types it infers.

--- a/README.md
+++ b/README.md
@@ -433,7 +433,8 @@ The error type propagates wherever you use the rows, surfacing the message in
 hovers and breaking any code that treats them as real data.
 
 Strict mode checks the `SELECT` list, the `WHERE` clause, and `JOIN ... ON`
-conditions:
+conditions — including the `WHERE` of an `UPDATE`/`DELETE` that returns no
+columns, where a typo is most expensive:
 
 ```ts
 const wrongSide = await db.query(
@@ -514,7 +515,9 @@ await db.query('select id from users where id = ?', 1);
 ```
 
 Styles: `'dollar'` (pg, postgres.js), `'question'` (mysql2), `'at'` (mssql).
-`node:sqlite` accepts all three, so leave the option off there.
+`node:sqlite` accepts all three plus `:name`, so leave the option off there.
+A `:name` placeholder is typed like any other but carries no style of its own,
+so it is never checked against a declared dialect.
 
 **Write metadata.** Adapters report driver metadata alongside the rows: on a
 successful `Result`, `result.meta?.rowCount` carries the affected-row count

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ commit it, edit it by hand afterward, rename fields, anything. Running
 
 | Flag | Required | Description |
 | ---- | -------- | ----------- |
-| `--url` | yes | Connection string (or a file path for SQLite). SQL Server accepts both `mssql://user:pass@host:1433/db` (translated to a driver config; `?encrypt=false` and `?trustServerCertificate=true` supported) and an ADO string (`Server=host;Database=db;User Id=u;Password=p`). |
+| `--url` | yes | Connection string (or a file path for SQLite). SQL Server accepts both `mssql://user:pass@host:1433/db` (translated to a driver config; `?encrypt=false` and `?trustServerCertificate=true` supported, and a named instance may be written as `host\INSTANCE`) and an ADO string (`Server=host;Database=db;User Id=u;Password=p`). |
 | `--out` | no | Output file. Defaults to `./schema.ts`. |
 | `--dialect` | no | `postgres` \| `mysql` \| `sqlite` \| `mssql`. Auto-detected from the URL scheme (`postgres://`/`postgresql://`, `mysql://`, `mssql://`/`sqlserver://`); an ADO `Server=...` string also routes to `mssql` — falls back to `sqlite` for a bare file path, so it's only needed when that's ambiguous. |
 | `--schema` | no | Schema/database name to introspect. Defaults to `public` (Postgres), the connected database (MySQL), or `dbo` (SQL Server). Not used for SQLite. |

--- a/src/adapters/mssql.ts
+++ b/src/adapters/mssql.ts
@@ -12,14 +12,29 @@ function isRequestSource(source: MssqlQueryable): source is ConnectionPool | Tra
   return typeof (source as { request?: unknown }).request === 'function';
 }
 
+// A ConnectionPool or an already-open Transaction each need `.request()` called
+// to get a Request bound to that connection/transaction; a Request passed
+// directly is already bound and used as-is - this is what lets a caller route a
+// query through an open transaction instead of always implicitly starting a
+// new, separately-committed request.
+//
+// That Request is reused across every query() on this executor, and node-mssql
+// throws on `input()` for a name it has already seen and never clears the bag
+// between calls - so without the reset a second query with the same @name
+// failed, and one with different names silently carried the first query's
+// values along (issue #235).
+function requestFor(source: MssqlQueryable): Request {
+  if (isRequestSource(source)) {
+    return source.request();
+  }
+
+  source.parameters = {};
+  return source;
+}
+
 export function createMssqlExecutor(source: MssqlQueryable): DialectExecutor<'at'> {
   return async (sql, params) => {
-    // A ConnectionPool or an already-open Transaction each need `.request()`
-    // called to get a Request bound to that connection/transaction; a
-    // Request passed directly is already bound and used as-is - this is what
-    // lets a caller route a query through an open transaction instead of
-    // always implicitly starting a new, separately-committed request.
-    const request = isRequestSource(source) ? source.request() : source;
+    const request = requestFor(source);
 
     collectNamedParameters(sql, MSSQL_PARAM_PREFIXES).forEach((name, index) => {
       request.input(name.slice(1), params[index] ?? null);

--- a/src/adapters/named-params.ts
+++ b/src/adapters/named-params.ts
@@ -1,6 +1,15 @@
 const NAMED_PARAM_BODY = /^[A-Za-z0-9_]+/;
 const DOLLAR_QUOTE_TAG = /^\$([A-Za-z0-9_]*)\$/;
 
+// The three quoting styles the type layer accepts (standard, MySQL, SQL
+// Server). Their bodies are names, not SQL, so a `@`/`$`/`?` inside one is not
+// a placeholder.
+const IDENTIFIER_QUOTE_CLOSERS: ReadonlyMap<string, string> = new Map([
+  ['"', '"'],
+  ['`', '`'],
+  ['[', ']'],
+]);
+
 // A quote preceded by an odd run of backslashes is backslash-escaped (MySQL's
 // and SQLite's default `\'`) and doesn't open or close a literal - the run has
 // to be odd, not merely non-empty, since `\\'` is an escaped backslash followed
@@ -15,47 +24,120 @@ function isLiteralDelimiter(sql: string, index: number): boolean {
   return backslashes % 2 === 0;
 }
 
-export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string>): string[] {
-  const names: string[] = [];
-  let insideLiteral = false;
+function skipSingleQuotedLiteral(sql: string, openIndex: number): number {
+  let index = openIndex + 1;
 
-  for (let index = 0; index < sql.length; index += 1) {
-    const char = sql[index] as string;
-
-    if (char === "'" && isLiteralDelimiter(sql, index)) {
-      insideLiteral = !insideLiteral;
-      continue;
-    }
-    if (insideLiteral) {
-      continue;
-    }
-
-    if (char === '$') {
-      const open = DOLLAR_QUOTE_TAG.exec(sql.slice(index));
-      if (open) {
-        const closer = `$${open[1]}$`;
-        const closeIndex = sql.indexOf(closer, index + open[0].length);
-        index = closeIndex === -1 ? sql.length - 1 : closeIndex + closer.length - 1;
+  while (index < sql.length) {
+    if (sql[index] === "'" && isLiteralDelimiter(sql, index)) {
+      if (sql[index + 1] === "'") {
+        index += 2;
         continue;
       }
+      return index + 1;
+    }
+    index += 1;
+  }
+
+  return sql.length;
+}
+
+function skipDollarQuotedBody(sql: string, openIndex: number): number {
+  const open = DOLLAR_QUOTE_TAG.exec(sql.slice(openIndex));
+  if (!open) {
+    return -1;
+  }
+
+  const closer = `$${open[1]}$`;
+  const closeIndex = sql.indexOf(closer, openIndex + open[0].length);
+  return closeIndex === -1 ? sql.length : closeIndex + closer.length;
+}
+
+// Returns the index just past the non-SQL region opening at `index`, or -1 when
+// nothing opens there. Everything the type-level Normalize strips or masks
+// before computing Params<DB, Q> has to be skipped here too, or the two layers
+// disagree on how many placeholders a query has - comments were the gap, and
+// since binding is positional, one `@word` in a comment shifted every value
+// after it (issue #234).
+function skipNonParameterRegion(sql: string, index: number): number {
+  const char = sql[index];
+
+  if (char === "'") {
+    return skipSingleQuotedLiteral(sql, index);
+  }
+
+  if (char === '-' && sql[index + 1] === '-') {
+    const newline = sql.indexOf('\n', index + 2);
+    return newline === -1 ? sql.length : newline + 1;
+  }
+
+  if (char === '/' && sql[index + 1] === '*') {
+    const close = sql.indexOf('*/', index + 2);
+    return close === -1 ? sql.length : close + 2;
+  }
+
+  if (char === '$') {
+    return skipDollarQuotedBody(sql, index);
+  }
+
+  const closer = char === undefined ? undefined : IDENTIFIER_QUOTE_CLOSERS.get(char);
+  if (closer !== undefined) {
+    const close = sql.indexOf(closer, index + 1);
+    return close === -1 ? sql.length : close + 1;
+  }
+
+  return -1;
+}
+
+type ParameterToken = { kind: 'positional' } | { kind: 'named'; name: string };
+
+function scanParameters(
+  sql: string,
+  prefixes: ReadonlySet<string>,
+  visit: (token: ParameterToken) => void,
+): void {
+  let index = 0;
+
+  while (index < sql.length) {
+    const skipTo = skipNonParameterRegion(sql, index);
+    if (skipTo !== -1) {
+      index = skipTo;
+      continue;
+    }
+
+    const char = sql[index] as string;
+
+    if (char === '?') {
+      visit({ kind: 'positional' });
+      index += 1;
+      continue;
     }
 
     if (prefixes.has(char)) {
       if (sql[index + 1] === char) {
-        index += 1;
+        index += 2;
         continue;
       }
 
       const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
       if (body) {
-        const name = `${char}${body[0]}`;
-        if (!names.includes(name)) {
-          names.push(name);
-        }
-        index += body[0].length;
+        visit({ kind: 'named', name: `${char}${body[0]}` });
+        index += 1 + body[0].length;
+        continue;
       }
     }
+
+    index += 1;
   }
+}
+
+export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string>): string[] {
+  const names: string[] = [];
+
+  scanParameters(sql, prefixes, (token) => {
+    if (token.kind === 'named' && !names.includes(token.name)) {
+      names.push(token.name);
+    }
+  });
 
   return names;
 }
@@ -77,54 +159,25 @@ export function resolveMixedParameters(
   values: readonly unknown[],
 ): MixedParameters {
   const named: Record<string, unknown> = {};
+  const bound = new Set<string>();
   const positional: unknown[] = [];
-  let insideLiteral = false;
   let valueIndex = 0;
 
-  for (let index = 0; index < sql.length; index += 1) {
-    const char = sql[index] as string;
-
-    if (char === "'" && isLiteralDelimiter(sql, index)) {
-      insideLiteral = !insideLiteral;
-      continue;
-    }
-    if (insideLiteral) {
-      continue;
-    }
-
-    if (char === '$') {
-      const open = DOLLAR_QUOTE_TAG.exec(sql.slice(index));
-      if (open) {
-        const closer = `$${open[1]}$`;
-        const closeIndex = sql.indexOf(closer, index + open[0].length);
-        index = closeIndex === -1 ? sql.length - 1 : closeIndex + closer.length - 1;
-        continue;
-      }
-    }
-
-    if (char === '?') {
+  scanParameters(sql, prefixes, (token) => {
+    if (token.kind === 'positional') {
       positional.push(values[valueIndex] ?? null);
       valueIndex += 1;
-      continue;
+      return;
     }
 
-    if (prefixes.has(char)) {
-      if (sql[index + 1] === char) {
-        index += 1;
-        continue;
-      }
-
-      const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
-      if (body) {
-        const name = `${char}${body[0]}`;
-        if (!(name in named)) {
-          named[name] = values[valueIndex] ?? null;
-          valueIndex += 1;
-        }
-        index += body[0].length;
-      }
+    if (bound.has(token.name)) {
+      return;
     }
-  }
+
+    bound.add(token.name);
+    named[token.name] = values[valueIndex] ?? null;
+    valueIndex += 1;
+  });
 
   return { named, positional };
 }

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -8,6 +8,10 @@ const SQLITE_PARAM_PREFIXES: ReadonlySet<string> = new Set(['@', '$', ':']);
 const DML_KEYWORDS = new Set(['insert', 'update', 'delete', 'replace']);
 const INSERT_ROWID_KEYWORDS = new Set(['insert', 'replace']);
 const RESULT_KEYWORDS = new Set(['select', 'values', 'pragma', 'explain', 'with']);
+const STATEMENT_KEYWORDS = new Set([...DML_KEYWORDS, ...RESULT_KEYWORDS]);
+const RETURNING_KEYWORD = /\breturning\b/i;
+const WORD_OR_PAREN = /[()]|[A-Za-z_][A-Za-z0-9_]*/g;
+const WRITE_COUNTERS = 'select changes() as changes, last_insert_rowid() as rowid';
 
 function toSqliteValue(value: unknown): SqliteParam {
   if (typeof value === 'boolean') {
@@ -22,74 +26,97 @@ function toSqliteValue(value: unknown): SqliteParam {
   return value as SqliteParam;
 }
 
-function readLeadingKeyword(sql: string): string {
-  let rest = sql.trimStart();
+function skipLiteral(sql: string, openIndex: number): number {
+  let index = openIndex + 1;
 
-  while (rest.startsWith('--') || rest.startsWith('/*')) {
-    if (rest.startsWith('--')) {
-      const newline = rest.indexOf('\n');
-      rest = newline === -1 ? '' : rest.slice(newline + 1).trimStart();
-      continue;
+  while (index < sql.length) {
+    if (sql[index] === "'") {
+      if (sql[index + 1] === "'") {
+        index += 2;
+        continue;
+      }
+      return index + 1;
     }
-
-    const close = rest.indexOf('*/', 2);
-    rest = close === -1 ? '' : rest.slice(close + 2).trimStart();
+    index += 1;
   }
 
-  return /^[A-Za-z_][A-Za-z0-9_]*/.exec(rest)?.[0]?.toLowerCase() ?? '';
+  return sql.length;
 }
 
-function isWordChar(char: string | undefined): boolean {
-  return char !== undefined && /[A-Za-z0-9_]/.test(char);
-}
+// Blanks literal bodies and comments while keeping every offset, so keyword and
+// paren-depth scanning never reads text that isn't executable SQL.
+function maskLiteralsAndComments(sql: string): string {
+  let masked = '';
+  let index = 0;
 
-function containsKeywordOutsideLiterals(sql: string, keyword: string): boolean {
-  for (let index = 0; index < sql.length; index += 1) {
-    const char = sql[index];
+  while (index < sql.length) {
+    const char = sql[index] as string;
+    let end = -1;
 
     if (char === "'") {
-      index += 1;
-      while (index < sql.length) {
-        if (sql[index] === "'") {
-          if (sql[index + 1] === "'") {
-            index += 2;
-            continue;
-          }
-          break;
-        }
-        index += 1;
-      }
-      continue;
-    }
-
-    if (char === '-' && sql[index + 1] === '-') {
+      end = skipLiteral(sql, index);
+    } else if (char === '-' && sql[index + 1] === '-') {
       const newline = sql.indexOf('\n', index + 2);
-      index = newline === -1 ? sql.length : newline;
-      continue;
-    }
-
-    if (char === '/' && sql[index + 1] === '*') {
+      end = newline === -1 ? sql.length : newline;
+    } else if (char === '/' && sql[index + 1] === '*') {
       const close = sql.indexOf('*/', index + 2);
-      index = close === -1 ? sql.length : close + 1;
+      end = close === -1 ? sql.length : close + 2;
+    }
+
+    if (end === -1) {
+      masked += char;
+      index += 1;
       continue;
     }
 
-    if (
-      sql.slice(index, index + keyword.length).toLowerCase() === keyword &&
-      !isWordChar(sql[index - 1]) &&
-      !isWordChar(sql[index + keyword.length])
-    ) {
-      return true;
+    masked += ' '.repeat(end - index);
+    index = end;
+  }
+
+  return masked;
+}
+
+// The keyword that decides what the statement *does*. A CTE-led write leads
+// with `with`, so reading the first word alone classified `with x as (...)
+// insert into t ...` as a read and dropped its row count (issue #237); the
+// statement keyword is the first one at paren depth 0 after the WITH clause.
+function readStatementKeyword(sql: string): string {
+  const masked = maskLiteralsAndComments(sql);
+  const leading = /^\s*([A-Za-z_][A-Za-z0-9_]*)/.exec(masked)?.[1]?.toLowerCase() ?? '';
+
+  if (leading !== 'with') {
+    return leading;
+  }
+
+  let depth = 0;
+  WORD_OR_PAREN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = WORD_OR_PAREN.exec(masked)) !== null) {
+    const token = match[0];
+
+    if (token === '(') {
+      depth += 1;
+      continue;
+    }
+    if (token === ')') {
+      depth -= 1;
+      continue;
+    }
+
+    const word = token.toLowerCase();
+    if (depth === 0 && word !== 'with' && STATEMENT_KEYWORDS.has(word)) {
+      return word;
     }
   }
 
-  return false;
+  return leading;
 }
 
 function hasResultColumnsFromSql(sql: string): boolean {
-  const keyword = readLeadingKeyword(sql);
+  const keyword = readStatementKeyword(sql);
   if (DML_KEYWORDS.has(keyword)) {
-    return containsKeywordOutsideLiterals(sql, 'returning');
+    return RETURNING_KEYWORD.test(maskLiteralsAndComments(sql));
   }
   return RESULT_KEYWORDS.has(keyword);
 }
@@ -108,16 +135,35 @@ function hasResultColumns(statement: StatementSync, sql: string): boolean {
   }
 }
 
-function writeMeta(sql: string, result: ReturnType<StatementSync['run']>): QueryMeta {
-  const keyword = readLeadingKeyword(sql);
+function buildMeta(keyword: string, changes: number | bigint, rowid: number | bigint): QueryMeta {
   const meta: QueryMeta = {};
   if (DML_KEYWORDS.has(keyword)) {
-    meta.rowCount = result.changes;
+    meta.rowCount = changes;
   }
-  if (INSERT_ROWID_KEYWORDS.has(keyword) && result.changes !== 0) {
-    meta.lastInsertRowid = result.lastInsertRowid;
+  if (INSERT_ROWID_KEYWORDS.has(keyword) && changes !== 0) {
+    meta.lastInsertRowid = rowid;
   }
   return meta;
+}
+
+function writeMeta(keyword: string, result: ReturnType<StatementSync['run']>): QueryMeta {
+  return buildMeta(keyword, result.changes, result.lastInsertRowid);
+}
+
+// `all()` returns rows only, so a write with RETURNING has to read the counters
+// back off the connection - they still describe the statement that just ran.
+// Metadata is the bonus here and the rows are the answer, so a connection that
+// won't report them costs the caller its meta, never its result set.
+function returningMeta(db: DatabaseSync, keyword: string): QueryMeta {
+  try {
+    const counters = db.prepare(WRITE_COUNTERS).get() as
+      | { changes: number | bigint; rowid: number | bigint }
+      | undefined;
+
+    return counters === undefined ? {} : buildMeta(keyword, counters.changes, counters.rowid);
+  } catch {
+    return {};
+  }
 }
 
 export function createNodeSqliteExecutor(
@@ -127,21 +173,27 @@ export function createNodeSqliteExecutor(
     const statement = db.prepare(sql);
     const values = params.map(toSqliteValue);
     const { named, positional } = resolveMixedParameters(sql, SQLITE_PARAM_PREFIXES, values);
+    const keyword = readStatementKeyword(sql);
+    const hasNamed = Object.keys(named).length > 0;
 
     if (!hasResultColumns(statement, sql)) {
-      const result = Object.keys(named).length > 0
+      const result = hasNamed
         ? statement.run(named as Record<string, SqliteParam>, ...(positional as SqliteParam[]))
         : statement.run(...(positional as SqliteParam[]));
       return {
         rows: [],
-        meta: writeMeta(sql, result),
+        meta: writeMeta(keyword, result),
       };
     }
 
-    if (Object.keys(named).length > 0) {
-      return statement.all(named as Record<string, SqliteParam>, ...(positional as SqliteParam[]));
+    const rows = hasNamed
+      ? statement.all(named as Record<string, SqliteParam>, ...(positional as SqliteParam[]))
+      : statement.all(...(positional as SqliteParam[]));
+
+    if (!DML_KEYWORDS.has(keyword)) {
+      return rows;
     }
 
-    return statement.all(...(positional as SqliteParam[]));
+    return { rows, meta: returningMeta(db, keyword) };
   };
 }

--- a/src/cli/dialects/mssql.ts
+++ b/src/cli/dialects/mssql.ts
@@ -51,22 +51,48 @@ export interface MssqlConnectionConfig {
   options: {
     encrypt: boolean;
     trustServerCertificate: boolean;
+    instanceName?: string;
   };
 }
 
 const MSSQL_URL_PATTERN = /^(mssql|sqlserver):\/\//i;
 
+const INSTANCE_SEPARATOR = '\\';
+
+// `host\INSTANCE` is the default shape of a Windows SQL Server install, and a
+// backslash is a forbidden host character, so `new URL` rejects the URL
+// outright. Percent-encoding it first keeps the authority parseable (the host
+// stays opaque for a non-special scheme, so its case survives) and the instance
+// is split back out below into the driver's own instanceName option (#239).
+function parseMssqlUrl(url: string): URL {
+  try {
+    return new URL(url.split(INSTANCE_SEPARATOR).join('%5C'));
+  } catch {
+    throw new Error(
+      'Invalid SQL Server connection URL. Expected mssql://user:password@host[\\INSTANCE][:port]/database, or an ADO string such as "Server=host;Database=db;User Id=user;Password=password".',
+    );
+  }
+}
+
 export function mssqlUrlToConfig(url: string): MssqlConnectionConfig {
-  const parsed = new URL(url);
+  const parsed = parseMssqlUrl(url);
   const flags = parsed.searchParams;
 
+  const host = decodeURIComponent(parsed.hostname);
+  const separatorIndex = host.indexOf(INSTANCE_SEPARATOR);
+  const instanceName = separatorIndex === -1 ? '' : host.slice(separatorIndex + 1);
+
   const config: MssqlConnectionConfig = {
-    server: decodeURIComponent(parsed.hostname),
+    server: separatorIndex === -1 ? host : host.slice(0, separatorIndex),
     options: {
       encrypt: flags.get('encrypt') !== 'false',
       trustServerCertificate: flags.get('trustServerCertificate') === 'true',
     },
   };
+
+  if (instanceName) {
+    config.options.instanceName = instanceName;
+  }
 
   if (parsed.username) {
     config.user = decodeURIComponent(parsed.username);

--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -47,7 +47,11 @@ function isRowidAlias(column: SqliteTableInfoRow, primaryKeyCount: number): bool
   );
 }
 
-const SQLITE_URL_PREFIXES = ['sqlite://', 'sqlite:', 'file://'];
+// Longest first: `file://x` must not be stripped as `file:` and keep a leading
+// `//`. Every spelling detectDialect routes to sqlite has to be listed here, or
+// the prefix survives into existsSync and the file is reported missing under a
+// name nobody wrote (issue #236).
+const SQLITE_URL_PREFIXES = ['sqlite://', 'sqlite:', 'file://', 'file:'];
 
 export function normalizeSqlitePath(url: string): string {
   for (const prefix of SQLITE_URL_PREFIXES) {

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -17,9 +17,9 @@ export interface GenerateOptions {
 }
 
 export type GenerateResult =
-  | { kind: 'written' }
-  | { kind: 'upToDate' }
-  | { kind: 'drift'; summary: string };
+  | { kind: 'written'; warnings?: string[] }
+  | { kind: 'upToDate'; warnings?: string[] }
+  | { kind: 'drift'; summary: string; warnings?: string[] };
 
 const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i;
 
@@ -102,6 +102,18 @@ const INTROSPECTORS: Record<Dialect, (connection: ConnectionInfo) => Promise<Tab
   mssql: introspectMssql,
 };
 
+// A name in --table/--exclude that matches nothing is a typo, and silently
+// honoring it means a table quietly missing from the generated schema, found
+// much later as an `unknown` row type (issue #240).
+function unmatchedNames(requested: string[] | undefined, tables: TableSchema[]): string[] {
+  if (requested === undefined) {
+    return [];
+  }
+
+  const available = new Set(tables.map((table) => table.name.toLowerCase()));
+  return requested.filter((name) => !available.has(name.toLowerCase()));
+}
+
 function filterTables(tables: TableSchema[], options: GenerateOptions): TableSchema[] {
   const include = options.tables?.map((name) => name.toLowerCase());
   const exclude = options.exclude?.map((name) => name.toLowerCase());
@@ -165,23 +177,37 @@ export async function runGenerate(options: GenerateOptions): Promise<GenerateRes
     throw new Error('No tables found. Check the connection URL and --schema, if provided.');
   }
 
+  const availableNames = introspected.map((table) => table.name).join(', ');
+  const missing = unmatchedNames(options.tables, introspected);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `--table matched no such table: ${missing.join(', ')}. Available tables: ${availableNames}`,
+    );
+  }
+
   const tables = filterTables(introspected, options);
 
   if (tables.length === 0) {
-    throw new Error(
-      `No tables left after filtering. Available tables: ${introspected
-        .map((table) => table.name)
-        .join(', ')}`,
-    );
+    throw new Error(`No tables left after filtering. Available tables: ${availableNames}`);
   }
+
+  // An unmatched --exclude only warns: excluding a table that isn't there is
+  // still the outcome the caller asked for, and scripts legitimately exclude
+  // tables that exist in some environments and not others.
+  const notExcluded = unmatchedNames(options.exclude, introspected);
+  const warnings =
+    notExcluded.length === 0
+      ? {}
+      : { warnings: [`--exclude matched no such table: ${notExcluded.join(', ')}`] };
 
   const source = renderSchema(tables);
 
   if (options.check) {
     const existing = await readExistingFile(options.out);
     return existing === source
-      ? { kind: 'upToDate' }
-      : { kind: 'drift', summary: summarizeDrift(existing, source) };
+      ? { kind: 'upToDate', ...warnings }
+      : { kind: 'drift', summary: summarizeDrift(existing, source), ...warnings };
   }
 
   try {
@@ -193,5 +219,5 @@ export async function runGenerate(options: GenerateOptions): Promise<GenerateRes
     throw error;
   }
 
-  return { kind: 'written' };
+  return { kind: 'written', ...warnings };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,6 +50,12 @@ export function parseFlags(args: string[]): Map<string, string> {
     }
 
     if (BOOLEAN_FLAGS.has(name)) {
+      // The value used to be dropped on the floor, so `--check=false` turned
+      // the check on and failed the build it was meant to skip (issue #241).
+      if (equalsIndex !== -1) {
+        throw new Error(`--${name} does not take a value.`);
+      }
+
       flags.set(name, '');
       continue;
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -167,6 +167,10 @@ async function main(): Promise<void> {
     check: flags.has('check'),
   });
 
+  for (const warning of result.warnings ?? []) {
+    process.stderr.write(`Warning: ${warning}\n`);
+  }
+
   if (result.kind === 'written') {
     process.stdout.write(`Wrote ${out}\n`);
     return;

--- a/src/from.ts
+++ b/src/from.ts
@@ -29,7 +29,9 @@ type ClauseBoundary =
   | 'union'
   | 'except'
   | 'intersect'
-  | 'for';
+  | 'for'
+  | 'returning'
+  | 'output';
 
 type IsBoundary<Word extends string> = Lowercase<Word> extends ClauseBoundary
   ? true

--- a/src/params.ts
+++ b/src/params.ts
@@ -66,13 +66,18 @@ export type CleanColumnToken<S extends string> = StripLeadingParens<S> extends i
 
 export type IsPlaceholder<Token extends string> = CleanScanToken<Token> extends '?'
   ? true
-  : CleanScanToken<Token> extends `$$${string}` | `@@${string}` | '$' | '@'
+  : // MERGE's `$action` is a pseudo-column, not a placeholder - ResolveColumnType
+    // already types it as the branch that fired, so counting it here handed the
+    // caller an extra parameter slot (issue #231).
+    Lowercase<CleanScanToken<Token>> extends '$action'
     ? false
-    : CleanScanToken<Token> extends `$${string}`
-      ? true
-      : CleanScanToken<Token> extends `@${string}`
+    : CleanScanToken<Token> extends `$$${string}` | `@@${string}` | '$' | '@'
+      ? false
+      : CleanScanToken<Token> extends `$${string}`
         ? true
-        : false;
+        : CleanScanToken<Token> extends `@${string}`
+          ? true
+          : false;
 
 interface DigitCounters {
   '0': [];
@@ -406,10 +411,18 @@ type StripDoubledAt<S extends string> = S extends `${infer Before}@@${infer Afte
   ? StripDoubledAt<`${Before}${After}`>
   : S;
 
-export type UsedPlaceholderStyles<Q extends string> = Normalize<Q> extends infer Text extends string
+type StripDollarAction<S extends string> = S extends `${infer Before}$action${infer After}`
+  ? StripDollarAction<`${Before}${After}`>
+  : S;
+
+// Lowercased so the `$action` strip is case-insensitive, matching how
+// IsMergeActionPseudoColumn resolves it. Case is irrelevant to the three
+// characters this scans for, so nothing else is affected.
+export type UsedPlaceholderStyles<Q extends string> = Lowercase<Normalize<Q>> extends infer Text extends
+  string
   ?
       | (Text extends `${string}?${string}` ? 'question' : never)
-      | (Text extends `${string}$${string}` ? 'dollar' : never)
+      | (StripDollarAction<Text> extends `${string}$${string}` ? 'dollar' : never)
       | (StripDoubledAt<Text> extends `${string}@${string}` ? 'at' : never)
   : never;
 

--- a/src/params.ts
+++ b/src/params.ts
@@ -357,18 +357,25 @@ type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<
   ? [InsertColumnList<Q>] extends [never]
     ? unknown[]
     : InsertColumnList<Q> extends { columns: infer Columns extends string[]; rest: infer AfterColumns extends string }
-      ? AfterKeyword<AfterColumns, 'values'> extends infer AfterValues
-        ? AfterValues extends string
-          ? ScanValuesGroups<AfterValues, DB, Src['table'], Columns, [], [], []> extends {
-              indexed: infer Indexed extends unknown[];
-              sequential: infer Sequential extends unknown[];
-              sequentialNames: infer SequentialNames extends string[];
-              rest: infer Rest extends string;
-            }
-            ? ScanParams<Rest, DB, [Src], '', '', Indexed, Sequential, SequentialNames>
+      ? // `AfterValues extends string` is distributive (AfterValues is a naked
+        // type parameter), so an INSERT with no VALUES clause - INSERT ...
+        // SELECT - collapsed the whole conditional to `never` instead of
+        // reaching the unknown[] fallback, leaving a rest parameter that no
+        // call can satisfy (issue #230).
+        [AfterKeyword<AfterColumns, 'values'>] extends [never]
+        ? unknown[]
+        : AfterKeyword<AfterColumns, 'values'> extends infer AfterValues
+          ? AfterValues extends string
+            ? ScanValuesGroups<AfterValues, DB, Src['table'], Columns, [], [], []> extends {
+                indexed: infer Indexed extends unknown[];
+                sequential: infer Sequential extends unknown[];
+                sequentialNames: infer SequentialNames extends string[];
+                rest: infer Rest extends string;
+              }
+              ? ScanParams<Rest, DB, [Src], '', '', Indexed, Sequential, SequentialNames>
+              : unknown[]
             : unknown[]
           : unknown[]
-        : unknown[]
       : unknown[]
   : unknown[];
 

--- a/src/params.ts
+++ b/src/params.ts
@@ -49,7 +49,14 @@ type StripTrailingListPunctuation<S extends string> = S extends `${infer Rest})`
     ? StripTrailingListPunctuation<Rest>
     : S;
 
-export type CleanScanToken<S extends string> = StripTrailingListPunctuation<StripLeadingParens<S>>;
+// `$1::int` is the placeholder `$1` carrying a Postgres cast, not a name -
+// without stripping the cast the index is unreadable and the token stops
+// binding by position (issue #228).
+type StripCast<S extends string> = S extends `${infer Before}::${string}` ? Before : S;
+
+export type CleanScanToken<S extends string> = StripCast<
+  StripTrailingListPunctuation<StripLeadingParens<S>>
+>;
 
 export type CleanColumnToken<S extends string> = StripLeadingParens<S> extends infer Stripped extends string
   ? Stripped extends `${string}(${string}`
@@ -100,11 +107,18 @@ type DigitsToCounter<S extends string, Accumulated extends unknown[] = []> =
       : never
     : Accumulated;
 
+// The [never] guard is load-bearing: DigitsToCounter resolves to never for
+// anything that isn't all digits (`$1::int`, `$id`), and `never extends
+// [unknown, ...infer Position]` passes, which routed those tokens into the
+// numbered bucket at a bogus position instead of letting them fall through to
+// the named branch below (issue #228).
 type PlaceholderPosition<Token extends string> =
   CleanScanToken<Token> extends `$${infer Digits}`
-    ? DigitsToCounter<Digits> extends [unknown, ...infer Position extends unknown[]]
-      ? Position
-      : never
+    ? [DigitsToCounter<Digits>] extends [never]
+      ? never
+      : DigitsToCounter<Digits> extends [unknown, ...infer Position extends unknown[]]
+        ? Position
+        : never
     : never;
 
 // A bare `?` is never named - each occurrence is a distinct positional slot.

--- a/src/params.ts
+++ b/src/params.ts
@@ -71,13 +71,18 @@ export type IsPlaceholder<Token extends string> = CleanScanToken<Token> extends 
     // caller an extra parameter slot (issue #231).
     Lowercase<CleanScanToken<Token>> extends '$action'
     ? false
-    : CleanScanToken<Token> extends `$$${string}` | `@@${string}` | '$' | '@'
+    : CleanScanToken<Token> extends `$$${string}` | `@@${string}` | '$' | '@' | ':'
       ? false
       : CleanScanToken<Token> extends `$${string}`
         ? true
         : CleanScanToken<Token> extends `@${string}`
           ? true
-          : false;
+          : // `:name` is the third prefix the node:sqlite adapter binds, and it
+            // was the only one the type layer didn't know about (issue #238).
+            // A `::` cast never reaches here - CleanScanToken strips it.
+            CleanScanToken<Token> extends `:${string}`
+            ? true
+            : false;
 
 interface DigitCounters {
   '0': [];

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -914,15 +914,19 @@ type InferRowWithChecked<
       fromText: infer FromText extends string;
     }
     ? (CteDB & BuildDerivedSourceMap<CteDB, Sources, Strict>) extends infer EffectiveDB extends SchemaLike
-      ? Trim<Columns> extends ''
-        ? EmptyRow
-        : ApplyWhereCheck<
-            EffectiveDB,
-            Sources,
-            WhereText,
-            FromText,
-            Strict,
-            IsSelectAll<Columns> extends true
+      ? // The clause check wraps the empty row too: a write with no RETURNING
+        // projects nothing, but its WHERE clause is still a set of column
+        // references strict mode has to validate - and UPDATE/DELETE is where
+        // a wrong one costs the most (issue #233).
+        ApplyWhereCheck<
+          EffectiveDB,
+          Sources,
+          WhereText,
+          FromText,
+          Strict,
+          Trim<Columns> extends ''
+            ? EmptyRow
+            : IsSelectAll<Columns> extends true
               ? StarRow<EffectiveDB, Sources, Strict>
               : BuildSelection<
                   EffectiveDB,
@@ -932,7 +936,7 @@ type InferRowWithChecked<
                     : [],
                   Strict
                 >
-          >
+        >
       : never
     : never
   : never;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -207,8 +207,16 @@ type SplitAtTopLevelKeyword<
       : never
     : never;
 
-type ExtraSourcesAfterKeyword<S extends string, Keyword extends string> =
-  SplitAtTopLevelKeyword<S, Keyword> extends { after: infer AfterClause extends string }
+// The [never] guard is load-bearing: SplitAtTopLevelKeyword resolves to never
+// when the statement has no such clause, and `never extends { after: infer X
+// extends string }` passes with X inferred as `string`, which would hand
+// ParseFromClause a wildcard table name matching every table in the schema
+// (issue #229).
+type ExtraSourcesAfterKeyword<S extends string, Keyword extends string> = [
+  SplitAtTopLevelKeyword<S, Keyword>,
+] extends [never]
+  ? []
+  : SplitAtTopLevelKeyword<S, Keyword> extends { after: infer AfterClause extends string }
     ? ParseFromClause<AfterClause>
     : [];
 

--- a/src/string.ts
+++ b/src/string.ts
@@ -21,8 +21,12 @@ type CollapseSpaces<S extends string> = S extends `${infer Before}  ${infer Afte
   ? CollapseSpaces<`${Before} ${After}`>
   : S;
 
-type RemoveSemicolons<S extends string> = S extends `${infer Before};${infer After}`
-  ? RemoveSemicolons<`${Before} ${After}`>
+// Only the trailing semicolon is dropped. Scrubbing every semicolon in the
+// string also destroyed the ones inside a quoted identifier (`"id;x"`), and a
+// non-trailing one outside a quote is already rejected by
+// HasNonTrailingSemicolon before anything reads this text (issue #232).
+type RemoveTrailingSemicolons<S extends string> = TrimRight<S> extends `${infer Rest};`
+  ? RemoveTrailingSemicolons<Rest>
   : S;
 
 // A quote preceded by an odd run of backslashes is backslash-escaped (MySQL's
@@ -159,16 +163,44 @@ export type StripCommentsAndMaskLiterals<
               : Accumulated;
 
 export type Normalize<S extends string> = Trim<
-  CollapseSpaces<WhitespaceToSpace<RemoveSemicolons<StripCommentsAndMaskLiterals<S>>>>
+  CollapseSpaces<WhitespaceToSpace<RemoveTrailingSemicolons<StripCommentsAndMaskLiterals<S>>>>
 >;
+
+type HasQuoteChar<S extends string> = S extends
+  | `${string}"${string}`
+  | `${string}\`${string}`
+  | `${string}[${string}`
+  ? true
+  : false;
+
+type AfterIdentifierClose<S extends string, Close extends string> =
+  S extends `${string}${Close}${infer Rest}` ? Rest : '';
+
+// Quoted identifiers are the one piece of a query StripCommentsAndMaskLiterals
+// deliberately leaves intact - the parser needs the name. That makes their
+// bodies the last place raw punctuation survives, so anything scanning the
+// masked text for structure has to blank them first (issue #232).
+type MaskQuotedIdentifiers<S extends string, Accumulated extends string = ''> =
+  HasQuoteChar<S> extends false
+    ? `${Accumulated}${S}`
+    : S extends `"${infer AfterOpen}`
+      ? MaskQuotedIdentifiers<AfterIdentifierClose<AfterOpen, '"'>, `${Accumulated}""`>
+      : S extends `\`${infer AfterOpen}`
+        ? MaskQuotedIdentifiers<AfterIdentifierClose<AfterOpen, '\`'>, `${Accumulated}\`\``>
+        : S extends `[${infer AfterOpen}`
+          ? MaskQuotedIdentifiers<AfterIdentifierClose<AfterOpen, ']'>, `${Accumulated}[]`>
+          : S extends `${infer Head}${infer Rest}`
+            ? MaskQuotedIdentifiers<Rest, `${Accumulated}${Head}`>
+            : Accumulated;
 
 // RemoveSemicolons strips every semicolon, not just a single trailing one, so
 // a second statement after a non-trailing semicolon would otherwise be
 // silently merged into the first. Checked against the comment-stripped,
-// literal-masked text so a semicolon inside a comment or a string literal
-// (already reduced to '') is never mistaken for a statement separator.
+// literal-masked text (so a semicolon inside a comment or a string literal is
+// never mistaken for a separator) with quoted identifiers blanked on top of
+// it, since a column may legally be named `"a;b"`.
 export type HasNonTrailingSemicolon<S extends string> =
-  Trim<StripCommentsAndMaskLiterals<S>> extends `${string};${infer After}`
+  Trim<MaskQuotedIdentifiers<StripCommentsAndMaskLiterals<S>>> extends `${string};${infer After}`
     ? Trim<After> extends ''
       ? false
       : true

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -5,13 +5,23 @@ import { createMssqlExecutor, createMssqlTransaction } from '../src/adapters/mss
 interface FakeRequest {
   input: ReturnType<typeof vi.fn>;
   query: ReturnType<typeof vi.fn>;
+  parameters: Record<string, unknown>;
 }
 
+// Mirrors node-mssql: input() records the parameter and refuses a name it has
+// already seen, and nothing clears the bag on its own.
 function fakeRequest(result: unknown): FakeRequest {
-  return {
-    input: vi.fn(),
+  const request: FakeRequest = {
+    parameters: {},
+    input: vi.fn((name: string, value: unknown) => {
+      if (name in request.parameters) {
+        throw new Error(`The parameter name ${name} has already been declared.`);
+      }
+      request.parameters[name] = value;
+    }),
     query: vi.fn().mockResolvedValue(result),
   };
+  return request;
 }
 
 function fakePool(result: unknown): { pool: ConnectionPool; request: FakeRequest } {
@@ -110,6 +120,29 @@ describe('createMssqlExecutor', () => {
 
     expect((request as unknown as FakeRequest).input.mock.calls).toEqual([['id', 1]]);
     expect(result).toEqual({ rows: [{ id: 1 }], meta: {} });
+  });
+
+  it('reuses a caller-supplied Request across queries with the same parameter name', async () => {
+    const request = fakeRequest({ recordset: [] }) as unknown as Request;
+    const executor = createMssqlExecutor(request);
+
+    await executor('select id from users where id = @id', [1]);
+    await executor('select id from users where id = @id', [2]);
+
+    expect((request as unknown as FakeRequest).input.mock.calls).toEqual([
+      ['id', 1],
+      ['id', 2],
+    ]);
+  });
+
+  it('does not carry a previous query parameters into the next one', async () => {
+    const request = fakeRequest({ recordset: [] }) as unknown as Request;
+    const executor = createMssqlExecutor(request);
+
+    await executor('select id from users where id = @id', [1]);
+    await executor('select id from users where name = @name', ['ada']);
+
+    expect(request.parameters).toEqual({ name: 'ada' });
   });
 
   it('binds a repeated @name once, without misaligning the parameter after it', async () => {

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -62,6 +62,20 @@ describe.skipIf(!sqliteAvailable)('createNodeSqliteExecutor', () => {
     }
   });
 
+  // Regression for #238: the adapter has always bound `:name`, but the type
+  // layer typed the query as taking no parameters at all.
+  it('routes :name placeholders through the named-parameters object', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const result = await db.query('select id, name from users where id = :id', 1);
+
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value).toEqual([{ id: 1, name: 'ada' }]);
+    }
+  });
+
   it('ignores named-parameter lookalikes inside string literals', async () => {
     const sqlite = seededDatabase();
     const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -162,6 +162,59 @@ describe.skipIf(!sqliteAvailable)('createNodeSqliteExecutor', () => {
       expect(rows.value).toEqual([{ name: 'lin' }]);
     }
   });
+
+  // Regression for #237: the leading keyword of a CTE-led write is `with`,
+  // which classified it as a read and dropped its row count.
+  it('reports metadata for a write led by a WITH clause', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const inserted = await db.query(
+      "with seed as (select 'hopper' as name) insert into users (name) select name from seed",
+    );
+    expect(isOk(inserted)).toBe(true);
+    if (isOk(inserted)) {
+      expect(inserted.meta?.rowCount).toBe(1);
+      expect(inserted.meta?.lastInsertRowid).toBe(3);
+    }
+
+    const updated = await db.query(
+      'with targets as (select id from users where id = 1) update users set name = ? where id in (select id from targets)',
+      'ada-lovelace',
+    );
+    expect(isOk(updated)).toBe(true);
+    if (isOk(updated)) {
+      expect(updated.meta).toEqual({ rowCount: 1 });
+    }
+
+    // A CTE-led read is still a read.
+    const read = await db.query('with seed as (select 1 as one) select one from seed');
+    expect(isOk(read)).toBe(true);
+    if (isOk(read)) {
+      expect(read.meta).toBeUndefined();
+    }
+  });
+
+  // Regression for #237: a row-returning write went down the `all()` path,
+  // which returned the rows bare and reported no metadata at all.
+  it('reports metadata for a write with RETURNING', async () => {
+    const sqlite = seededDatabase();
+    const db = createTypedDb<DB>(createNodeSqliteExecutor(sqlite));
+
+    const inserted = await db.query('insert into users (name) values (?) returning id', 'hopper');
+    expect(isOk(inserted)).toBe(true);
+    if (isOk(inserted)) {
+      expect(inserted.value).toEqual([{ id: 3 }]);
+      expect(inserted.meta).toEqual({ rowCount: 1, lastInsertRowid: 3 });
+    }
+
+    const deleted = await db.query('delete from users where id = ? returning name', 1);
+    expect(isOk(deleted)).toBe(true);
+    if (isOk(deleted)) {
+      expect(deleted.value).toEqual([{ name: 'ada' }]);
+      expect(deleted.meta).toEqual({ rowCount: 1 });
+    }
+  });
 });
 
 describe('createNodeSqliteExecutor column detection fallback', () => {
@@ -213,7 +266,7 @@ describe('createNodeSqliteExecutor column detection fallback', () => {
 
     await expect(
       executor('insert into users (name) values (?) returning id', ['grace']),
-    ).resolves.toEqual([{ id: 8 }]);
+    ).resolves.toEqual({ rows: [{ id: 8 }], meta: {} });
     expect(returningStatement.all).toHaveBeenCalledWith('grace');
     expect(returningStatement.run).not.toHaveBeenCalled();
   });

--- a/tests/cli-flags.test.ts
+++ b/tests/cli-flags.test.ts
@@ -61,4 +61,12 @@ describe('parseFlags', () => {
     expect(flags.has('check')).toBe(true);
     expect(flags.get('url')).toBe('postgres://localhost/db');
   });
+
+  // Regression for #241: the value was dropped, so --check=false enabled the
+  // check and exited 1 on drift - the opposite of what was asked for.
+  it('rejects a value on a boolean flag instead of ignoring it', () => {
+    expect(() => parseFlags(['--check=false'])).toThrow('--check does not take a value.');
+    expect(() => parseFlags(['--help=no'])).toThrow('--help does not take a value.');
+    expect(() => parseFlags(['--version=1'])).toThrow('--version does not take a value.');
+  });
 });

--- a/tests/cli-mssql-url.test.ts
+++ b/tests/cli-mssql-url.test.ts
@@ -26,6 +26,35 @@ describe('mssqlUrlToConfig', () => {
       options: { encrypt: false, trustServerCertificate: true },
     });
   });
+
+  // Regression for #239: a backslash is a forbidden host character, so this URL
+  // used to die inside `new URL` with a bare "Invalid URL".
+  it('splits a named instance out of the host', () => {
+    expect(mssqlUrlToConfig('mssql://sa:S3cret@localhost\\SQLEXPRESS/app')).toEqual({
+      server: 'localhost',
+      user: 'sa',
+      password: 'S3cret',
+      database: 'app',
+      options: { encrypt: true, trustServerCertificate: false, instanceName: 'SQLEXPRESS' },
+    });
+  });
+
+  it('keeps a named instance alongside an explicit port', () => {
+    const config = mssqlUrlToConfig('mssql://host\\PROD:1433/db');
+    expect(config.server).toBe('host');
+    expect(config.port).toBe(1433);
+    expect(config.options.instanceName).toBe('PROD');
+  });
+
+  it('explains what a valid connection string looks like instead of throwing "Invalid URL"', () => {
+    expect(() => mssqlUrlToConfig('mssql://host:notaport/db')).toThrow(
+      /Invalid SQL Server connection URL.*ADO string/s,
+    );
+  });
+
+  it('does not leak the password when the URL cannot be parsed', () => {
+    expect(() => mssqlUrlToConfig('mssql://sa:S3cret@host:notaport/db')).not.toThrow(/S3cret/);
+  });
 });
 
 describe('detectDialect for SQL Server inputs', () => {

--- a/tests/cli-ux.test.ts
+++ b/tests/cli-ux.test.ts
@@ -95,6 +95,46 @@ describe.skipIf(!sqliteAvailable)('table filtering', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // Regression for #240: a typo used to be honored silently, so the table it
+  // was meant to name simply went missing from the generated schema.
+  it('rejects a --table name that matches no table, even when others match', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await expect(
+        runGenerate({ url: file, out, tables: ['users', 'ordrs'] }),
+      ).rejects.toThrow('--table matched no such table: ordrs');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns but still generates when --exclude names a table that is not there', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      const result = await runGenerate({ url: file, out, exclude: ['posts', 'ordrs'] });
+      expect(result).toEqual({
+        kind: 'written',
+        warnings: ['--exclude matched no such table: ordrs'],
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports no warnings when every filter name matches', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      expect(await runGenerate({ url: file, out, exclude: ['posts'] })).toEqual({
+        kind: 'written',
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe.skipIf(!sqliteAvailable)('write errors', () => {

--- a/tests/cli-ux.test.ts
+++ b/tests/cli-ux.test.ts
@@ -28,7 +28,20 @@ describe('sqlite URL forms', () => {
     expect(normalizeSqlitePath('sqlite://./app.db')).toBe('./app.db');
     expect(normalizeSqlitePath('sqlite:./app.db')).toBe('./app.db');
     expect(normalizeSqlitePath('file://./app.db')).toBe('./app.db');
+    // Regression for #236: detectDialect accepts this spelling, so the prefix
+    // has to be stripped here too - it used to reach existsSync verbatim.
+    expect(normalizeSqlitePath('file:./app.db')).toBe('./app.db');
     expect(normalizeSqlitePath('./app.db')).toBe('./app.db');
+  });
+
+  it.skipIf(!sqliteAvailable)('introspects through a file: URL', async () => {
+    const { dir, file } = createDatabase();
+    try {
+      const out = join(dir, 'schema.ts');
+      await runGenerate({ url: `file:${file}`, out });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it.skipIf(!sqliteAvailable)('introspects through a sqlite:// URL', async () => {

--- a/tests/dialect-mssql.test-d.ts
+++ b/tests/dialect-mssql.test-d.ts
@@ -1,4 +1,5 @@
-import type { Query, Params, StrictQuery, QueryTypeError } from '../src/index.js';
+import type { Query, Params, StrictQuery, QueryTypeError, Executor } from '../src/index.js';
+import { createTypedDb } from '../src/index.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -10,6 +11,8 @@ type Expect<T extends true> = T;
 interface DB {
   users: { id: number; name: string; email: string };
 }
+
+declare const executor: Executor;
 
 type NamedParamSingle = Expect<
   Equal<Params<DB, 'select id from users where id = @id'>, [number]>
@@ -108,6 +111,30 @@ type MergeActionPseudoColumn = Expect<
   >
 >;
 
+// Regression for #231: `$action` is a pseudo-column, so it must not consume a
+// parameter slot - only the two real @name placeholders do.
+type MergeActionIsNotAParameter = Expect<
+  Equal<
+    Params<
+      DB,
+      'merge into users as target using (values (@id, @name)) as source (id, name) on target.id = source.id when matched then update set target.name = source.name output $action, inserted.id'
+    >,
+    [unknown, unknown]
+  >
+>;
+
+// ...and it must not make the query look dollar-styled, which turned every
+// MERGE into a placeholder-style mismatch against the (always 'at') mssql
+// executor.
+export async function mergeActionPassesThePlaceholderStyleCheck() {
+  const db = createTypedDb<DB, { placeholders: 'at' }>(executor, { placeholders: 'at' });
+  return db.query(
+    'merge into users as target using (values (@id, @name)) as source (id, name) on target.id = source.id when matched then update set target.name = source.name output $action, inserted.id',
+    1,
+    'x',
+  );
+}
+
 type MergeWithoutTargetAlias = Expect<
   Equal<
     Query<
@@ -175,6 +202,7 @@ export type MssqlLock = [
   NoOutputClauseIsEmptyRow,
   MergeOutputClause,
   MergeActionPseudoColumn,
+  MergeActionIsNotAParameter,
   MergeWithoutTargetAlias,
   MergeNoOutputClauseIsEmptyRow,
   MergeStrictRejectsUnknownOutputColumn,

--- a/tests/dml-target.test-d.ts
+++ b/tests/dml-target.test-d.ts
@@ -99,6 +99,39 @@ type UpdateWithoutFromIsUnaffected = Expect<
   Equal<Query<DB, 'update users set name = $1 where id = $2'>, Record<string, never>[]>
 >;
 
+// Regression for #229: with no FROM/USING clause the statement has exactly one
+// source. A fabricated second one (table typed `string`, which resolves against
+// every table in the schema) made every RETURNING column look ambiguous.
+type DeleteWithoutUsingResolvesReturning = Expect<
+  Equal<StrictQuery<DB, 'delete from users where id = 1 returning id'>, { id: number }[]>
+>;
+
+type UpdateWithoutFromResolvesReturning = Expect<
+  Equal<
+    StrictQuery<DB, 'update users set name = $1 where id = $2 returning name'>,
+    { name: string }[]
+  >
+>;
+
+type UpdateWithoutFromStillReportsAnUnknownReturningColumn = Expect<
+  Equal<
+    StrictQuery<DB, 'update users set name = $1 returning nope'>,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+// The phantom source also leaked types in non-strict mode: `balance` belongs to
+// accounts, which this statement never mentions.
+type DeleteWithoutUsingDoesNotBorrowColumnsFromOtherTables = Expect<
+  Equal<Query<DB, 'delete from users where id = 1 returning balance'>, { balance: unknown }[]>
+>;
+
+// RETURNING is a clause boundary, so the WHERE text stops before it instead of
+// swallowing the returned column list.
+type ReturningIsNotScannedAsPartOfTheWhereClause = Expect<
+  Equal<StrictQuery<DB, 'delete from users where id = 1 returning id, name'>, { id: number; name: string }[]>
+>;
+
 export type Assertions = [
   SchemaQualifiedInsertResolvesReturning,
   QuotedInsertTargetResolvesReturning,
@@ -111,4 +144,9 @@ export type Assertions = [
   DeleteUsingRegistersTheExtraTableAsASource,
   UpdateFromStillRejectsATrulyUnknownAlias,
   UpdateWithoutFromIsUnaffected,
+  DeleteWithoutUsingResolvesReturning,
+  UpdateWithoutFromResolvesReturning,
+  UpdateWithoutFromStillReportsAnUnknownReturningColumn,
+  DeleteWithoutUsingDoesNotBorrowColumnsFromOtherTables,
+  ReturningIsNotScannedAsPartOfTheWhereClause,
 ];

--- a/tests/named-params.test.ts
+++ b/tests/named-params.test.ts
@@ -55,6 +55,41 @@ describe('collectNamedParameters', () => {
     const sql = "select * from t where a = 'it\\'s @fake' and b = @id";
     expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id']);
   });
+
+  it('skips a parameter-looking word inside a line comment', () => {
+    const sql = 'select * from t where a = @x -- ping @alice\n and b = @y';
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@x', '@y']);
+  });
+
+  it('skips a parameter-looking word inside a block comment', () => {
+    const sql = 'select * from t where a = @x /* @todo drop @this */ and b = @y';
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@x', '@y']);
+  });
+
+  it('skips a parameter-looking word inside an unterminated block comment', () => {
+    expect(collectNamedParameters('select @x /* @todo', AT_DOLLAR_COLON)).toEqual(['@x']);
+  });
+
+  it('does not treat a quote inside a comment as a literal delimiter', () => {
+    const sql = "select * from t where a = @x -- it's fine\n and b = @y";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@x', '@y']);
+  });
+
+  it('skips a parameter-looking word inside a quoted identifier', () => {
+    expect(
+      collectNamedParameters('select "@a", `@b`, [@c] from t where x = @real', AT_DOLLAR_COLON),
+    ).toEqual(['@real']);
+  });
+
+  it('still treats a -- inside a string literal as literal text', () => {
+    const sql = "select * from t where a = '-- @fake' and b = @id";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id']);
+  });
+
+  it('handles a doubled quote inside a literal', () => {
+    const sql = "select * from t where a = 'it''s @fake' and b = @id";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id']);
+  });
 });
 
 describe('resolveMixedParameters', () => {
@@ -71,6 +106,22 @@ describe('resolveMixedParameters', () => {
     expect(resolveMixedParameters(sql, AT_DOLLAR_COLON, [7])).toEqual({
       named: {},
       positional: [7],
+    });
+  });
+
+  it('does not let a commented-out placeholder shift the values after it', () => {
+    const sql = 'select * from t where a = @x -- ping @alice\n and b = @y';
+    expect(resolveMixedParameters(sql, AT_DOLLAR_COLON, [1, 2])).toEqual({
+      named: { '@x': 1, '@y': 2 },
+      positional: [],
+    });
+  });
+
+  it('does not consume a value for a ? inside a comment', () => {
+    const sql = 'select * from t where a = ? /* is ? right */ and b = ?';
+    expect(resolveMixedParameters(sql, AT_DOLLAR_COLON, [1, 2])).toEqual({
+      named: {},
+      positional: [1, 2],
     });
   });
 });

--- a/tests/params-groups.test-d.ts
+++ b/tests/params-groups.test-d.ts
@@ -1,4 +1,5 @@
-import type { Params } from '../src/index.js';
+import type { Params, Executor } from '../src/index.js';
+import { createTypedDb } from '../src/index.js';
 
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
@@ -67,7 +68,31 @@ type MixedLiteralAndPlaceholderRows = Expect<
   >
 >;
 
+// Regression for #230: an INSERT with no VALUES clause has to reach the
+// documented unknown[] fallback. It used to collapse to `never`, which is a
+// rest parameter no call - not even the zero-argument one - can satisfy.
+type InsertSelectFallsBackToUnknownParams = Expect<
+  Equal<Params<DB, 'insert into users (id, name) select id, name from users'>, unknown[]>
+>;
+
+type InsertSelectWithPlaceholderFallsBackToUnknownParams = Expect<
+  Equal<
+    Params<DB, 'insert into users (id, name) select id, name from users where id = $1'>,
+    unknown[]
+  >
+>;
+
+declare const executor: Executor;
+
+// The tuple assertions above are only half the story: `never` also has to stop
+// reaching the call site, where it rejected even the zero-argument call.
+export async function insertSelectIsCallable() {
+  return createTypedDb<DB>(executor).query('insert into users (id, name) select id, name from users');
+}
+
 export type Assertions = [
+  InsertSelectFallsBackToUnknownParams,
+  InsertSelectWithPlaceholderFallsBackToUnknownParams,
   ParenthesizedWhereGroupResolvesColumns,
   NestedParenGroupsResolveColumns,
   OnConflictUpdatePlaceholderTyped,

--- a/tests/params-index.test-d.ts
+++ b/tests/params-index.test-d.ts
@@ -82,6 +82,23 @@ type DistinctNamedDollarPlaceholdersGetTheirOwnSlots = Expect<
   >
 >;
 
+// Regression for #238: `:name` is bound by the node:sqlite adapter, so the
+// type layer has to see it too - it used to produce an empty tuple.
+type ColonNamedParamsGetSlots = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = :id and name = :nm'>,
+    [number, string]
+  >
+>;
+
+type RepeatedColonNamedPlaceholderOccupiesOneSlot = Expect<
+  Equal<Params<DB, 'select id from users where id = :id or parent_id = :id'>, [number]>
+>;
+
+type CastIsNotAColonPlaceholder = Expect<
+  Equal<Params<DB, 'select id from users where name = id::text'>, []>
+>;
+
 // Same root cause: a Postgres cast attached to a numbered placeholder made the
 // index unreadable, so `$2::int` no longer bound to the second slot.
 type CastOnNumberedPlaceholderStillBindsByIndex = Expect<
@@ -124,6 +141,9 @@ export type Assertions = [
   MixedQuestionMarksAndRepeatedNamedPlaceholderBindCorrectly,
   SystemVariableIsNotPlaceholder,
   DistinctNamedDollarPlaceholdersGetTheirOwnSlots,
+  ColonNamedParamsGetSlots,
+  RepeatedColonNamedPlaceholderOccupiesOneSlot,
+  CastIsNotAColonPlaceholder,
   CastOnNumberedPlaceholderStillBindsByIndex,
   CastOnFirstNumberedPlaceholderStillBindsByIndex,
   InsertOutOfOrderPlaceholdersBindByIndex,

--- a/tests/params-index.test-d.ts
+++ b/tests/params-index.test-d.ts
@@ -72,6 +72,32 @@ type SystemVariableIsNotPlaceholder = Expect<
   Equal<Params<DB, 'select id from users where id = @@rowcount'>, []>
 >;
 
+// Regression for #228: two *distinct* named dollar placeholders each need their
+// own slot. They used to share slot 0 of the numbered bucket, so their types
+// were intersected into `never` and the query became impossible to call.
+type DistinctNamedDollarPlaceholdersGetTheirOwnSlots = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = $id and name = $nm'>,
+    [number, string]
+  >
+>;
+
+// Same root cause: a Postgres cast attached to a numbered placeholder made the
+// index unreadable, so `$2::int` no longer bound to the second slot.
+type CastOnNumberedPlaceholderStillBindsByIndex = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = $2::int and name = $1'>,
+    [string, number]
+  >
+>;
+
+type CastOnFirstNumberedPlaceholderStillBindsByIndex = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = $1::int and name = $2'>,
+    [number, string]
+  >
+>;
+
 type InsertOutOfOrderPlaceholdersBindByIndex = Expect<
   Equal<
     Params<DB, 'insert into users (id, name) values ($2, $1)'>,
@@ -97,6 +123,9 @@ export type Assertions = [
   RepeatedNamedDollarPlaceholderOccupiesOneSlot,
   MixedQuestionMarksAndRepeatedNamedPlaceholderBindCorrectly,
   SystemVariableIsNotPlaceholder,
+  DistinctNamedDollarPlaceholdersGetTheirOwnSlots,
+  CastOnNumberedPlaceholderStillBindsByIndex,
+  CastOnFirstNumberedPlaceholderStillBindsByIndex,
   InsertOutOfOrderPlaceholdersBindByIndex,
   InsertInOrderStillWorks,
 ];

--- a/tests/semicolon.test-d.ts
+++ b/tests/semicolon.test-d.ts
@@ -42,6 +42,27 @@ type SemicolonInsideCommentIsFine = Expect<
   >
 >;
 
+// Regression for #232: quoted identifiers are left intact for the parser, so
+// their bodies are the last place a raw `;` survives the masking pass.
+type SemicolonInsideDoubleQuotedIdentifierIsFine = Expect<
+  Equal<Query<DB, 'select "id;x" from users'>, { 'id;x': unknown }[]>
+>;
+
+type SemicolonInsideBacktickIdentifierIsFine = Expect<
+  Equal<Query<DB, 'select `id;x` from users'>, { 'id;x': unknown }[]>
+>;
+
+type SemicolonInsideBracketIdentifierIsFine = Expect<
+  Equal<Query<DB, 'select [id;x] from users'>, { 'id;x': unknown }[]>
+>;
+
+type QuotedIdentifierDoesNotHideARealStackedStatement = Expect<
+  Equal<
+    Query<DB, 'select "id" from users; drop table users'>,
+    QueryTypeError<'multiple statements are not supported: found a semicolon before the end of the query'>[]
+  >
+>;
+
 type NonTrailingSemicolonIsRejectedInStrictMode = Expect<
   Equal<
     StrictRow<DB, 'select id from users; select name from users'>,
@@ -74,6 +95,10 @@ export type Assertions = [
   SemicolonInsideLiteralIsFine,
   SemicolonInsideDollarQuotedLiteralIsFine,
   SemicolonInsideCommentIsFine,
+  SemicolonInsideDoubleQuotedIdentifierIsFine,
+  SemicolonInsideBacktickIdentifierIsFine,
+  SemicolonInsideBracketIdentifierIsFine,
+  QuotedIdentifierDoesNotHideARealStackedStatement,
   NonTrailingSemicolonIsRejectedInStrictMode,
   NonTrailingSemicolonIsRejectedInNonStrictMode,
   NonTrailingSemicolonIsRejectedForParams,

--- a/tests/strict-blind-spots.test-d.ts
+++ b/tests/strict-blind-spots.test-d.ts
@@ -77,7 +77,41 @@ type LooseAmbiguityKeepsFirstMatch = Expect<
   >
 >;
 
+// Regression for #233: a write with no RETURNING projects nothing, and the
+// empty-row short circuit used to return before the WHERE clause was ever
+// scanned - so strict mode passed a typo in the one place it costs most.
+type DeleteWithoutReturningStillValidatesWhere = Expect<
+  Equal<
+    StrictRow<DB, 'delete from users where naem = 1'>,
+    QueryTypeError<'unknown column: naem'>
+  >
+>;
+
+type UpdateWithoutReturningStillValidatesWhere = Expect<
+  Equal<
+    StrictRow<DB, 'update users set name = 1 where naem = 1'>,
+    QueryTypeError<'unknown column: naem'>
+  >
+>;
+
+type ValidDeleteWhereStillResolvesToTheEmptyRow = Expect<
+  Equal<StrictRow<DB, 'delete from users where id = 1'>, Record<string, never>>
+>;
+
+type DeleteWithoutAWhereClauseIsUnaffected = Expect<
+  Equal<StrictRow<DB, 'delete from users'>, Record<string, never>>
+>;
+
+type NonStrictDeleteIgnoresTheTypo = Expect<
+  Equal<Query<DB, 'delete from users where naem = 1'>, Record<string, never>[]>
+>;
+
 export type Assertions = [
+  DeleteWithoutReturningStillValidatesWhere,
+  UpdateWithoutReturningStillValidatesWhere,
+  ValidDeleteWhereStillResolvesToTheEmptyRow,
+  DeleteWithoutAWhereClauseIsUnaffected,
+  NonStrictDeleteIgnoresTheTypo,
   TypoInsideFunctionArgIsCaught,
   ValidFunctionArgResolves,
   NestedFunctionArgIsCaught,

--- a/tests/where-strict.test-d.ts
+++ b/tests/where-strict.test-d.ts
@@ -16,6 +16,12 @@ type ValidWhereStillResolves = Expect<
   Equal<StrictQuery<DB, 'select id from users where name = $1'>, { id: number }[]>
 >;
 
+// Regression for #238: a `:name` placeholder is a placeholder, not a column,
+// so strict mode must not try to resolve it against the schema.
+type ColonPlaceholderIsNotValidatedAsAColumn = Expect<
+  Equal<StrictQuery<DB, 'select id from users where name = :name'>, { id: number }[]>
+>;
+
 type UnknownColumnOnComparisonLhs = Expect<
   Equal<
     StrictQuery<DB, "select id from users where naem = 'x'">,
@@ -225,6 +231,7 @@ type NotFormComposesWithAndBoundary = Expect<
 
 export type WhereStrictLock = [
   ValidWhereStillResolves,
+  ColonPlaceholderIsNotValidatedAsAColumn,
   UnknownColumnOnComparisonLhs,
   UnknownColumnOnLike,
   UnknownColumnOnIn,

--- a/ts-plugin/src/sql-context.cts
+++ b/ts-plugin/src/sql-context.cts
@@ -10,7 +10,17 @@ const QUALIFIED_TRAILING_TOKEN = /(?:([A-Za-z_][A-Za-z0-9_]*)\.)?([A-Za-z0-9_]*)
 const FROM_JOIN_TABLE_START = /(?:\bfrom|\bjoin)\s+([A-Za-z0-9_]*)$/i;
 const FROM_LIST_COMMA_START = /,\s*([A-Za-z0-9_]*)$/;
 const FROM_TABLE = /\bfrom\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)/i;
-const FROM_OR_JOIN_SOURCE = /\b(from|join)\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)(?:\s+(as\s+)?([A-Za-z_][A-Za-z0-9_]*))?/gid;
+// The alias sits in a lookahead so it is never consumed. As a plain group it
+// swallowed whatever followed the table - including the `join` keyword of the
+// next source, which then went unscanned and turned every reference to that
+// table into a false "unknown alias" (issue #242). A comma anchor picks up
+// old-style comma-joined FROM lists, and is only honored inside the FROM
+// clause so a SELECT-list comma is not read as another table.
+const FROM_OR_JOIN_SOURCE =
+  /(?:\b(?:from|join)\s+|,\s*)(?:[A-Za-z_][A-Za-z0-9_]*\.)?(?<table>[A-Za-z_][A-Za-z0-9_]*)(?=(?:\s+(?:as\s+)?(?<alias>[A-Za-z_][A-Za-z0-9_]*))?)/gid;
+const FROM_KEYWORD = /\bfrom\b/i;
+const CLAUSE_AFTER_FROM =
+  /\b(?:where|group|having|order|limit|offset|union|except|intersect|window|fetch|for|returning|set|values)\b/i;
 const WORD_CHAR = /[A-Za-z0-9_]/;
 const WORD_START_CHAR = /[A-Za-z_]/;
 // Postgres dollar-quoted string opener: `$$` or `$tag$`, where the tag is an
@@ -20,6 +30,7 @@ const DOLLAR_QUOTE_OPEN = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/;
 
 const RESERVED_AFTER_SOURCE = new Set([
   'on',
+  'using',
   'where',
   'join',
   'inner',
@@ -28,12 +39,21 @@ const RESERVED_AFTER_SOURCE = new Set([
   'full',
   'outer',
   'cross',
+  'natural',
+  'lateral',
   'group',
   'order',
   'having',
   'limit',
   'offset',
+  'fetch',
   'union',
+  'except',
+  'intersect',
+  'window',
+  'for',
+  'returning',
+  'values',
   'set',
   'as',
 ]);
@@ -335,17 +355,30 @@ function findSources(fullLiteralText: string): QuerySource[] {
   // heuristic scanner can compute anyway.
   const { remainder, remainderStart, cteNames } = stripWithClause(stripped);
   const cteNameSet = new Set(cteNames.map((name) => name.toLowerCase()));
+  const fromClause = fromClauseRange(remainder);
   const sources: QuerySource[] = [];
 
   FROM_OR_JOIN_SOURCE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = FROM_OR_JOIN_SOURCE.exec(remainder)) !== null) {
-    const table = match[2];
-    const tableSpan = (match as unknown as { indices?: Array<[number, number] | undefined> }).indices?.[2];
+    const groups = match.groups;
+    const spans = (
+      match as unknown as {
+        indices?: { groups?: Record<string, [number, number] | undefined> };
+      }
+    ).indices?.groups;
+    const table = groups?.['table'];
+    const tableSpan = spans?.['table'];
     if (!table || !tableSpan || cteNameSet.has(table.toLowerCase())) {
       continue;
     }
-    const rawAlias = match[4] ?? null;
+    if (
+      match[0].startsWith(',') &&
+      (match.index < fromClause.start || match.index >= fromClause.end)
+    ) {
+      continue;
+    }
+    const rawAlias = groups?.['alias'] ?? null;
     const alias = rawAlias && !RESERVED_AFTER_SOURCE.has(rawAlias.toLowerCase()) ? rawAlias : table;
     sources.push({
       table,
@@ -358,9 +391,30 @@ function findSources(fullLiteralText: string): QuerySource[] {
   return sources;
 }
 
+function fromClauseRange(text: string): { start: number; end: number } {
+  const from = FROM_KEYWORD.exec(text);
+  if (!from) {
+    return { start: -1, end: -1 };
+  }
+
+  const start = from.index;
+  const boundary = CLAUSE_AFTER_FROM.exec(text.slice(start + from[0].length));
+  const end =
+    boundary === null ? text.length : start + from[0].length + boundary.index;
+
+  return { start, end };
+}
+
+// Falls back to the table name, the way the type-level FindSourceByName in
+// src/parse.ts already resolves either way. A source this scanner failed to
+// pick up is then simply not reported on, instead of being reported wrongly.
 function findSourceByAlias(sources: QuerySource[], alias: string): QuerySource | null {
   const lowerAlias = alias.toLowerCase();
-  return sources.find((source) => source.alias.toLowerCase() === lowerAlias) ?? null;
+  return (
+    sources.find((source) => source.alias.toLowerCase() === lowerAlias) ??
+    sources.find((source) => source.table.toLowerCase() === lowerAlias) ??
+    null
+  );
 }
 
 function getQualifierBefore(text: string, wordStart: number): string | null {

--- a/ts-plugin/tests/diagnostics.test.ts
+++ b/ts-plugin/tests/diagnostics.test.ts
@@ -254,4 +254,26 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
       { message: 'unknown column: naem', text: 'naem' },
     ]);
   });
+
+  // Regression for #242: the joined table was never scanned when the first
+  // table had no alias, so every reference to it read as an unknown alias.
+  it('reports nothing for a plain join written without aliases', () => {
+    expect(
+      diagnosticsFor('select posts.title from users join posts on users.id = posts.user_id'),
+    ).toEqual([]);
+  });
+
+  it('reports nothing for a join written with USING', () => {
+    expect(diagnosticsFor('select posts.title from users join posts using (id)')).toEqual([]);
+  });
+
+  it('reports nothing for a comma-joined FROM list', () => {
+    expect(diagnosticsFor('select posts.title from users, posts where users.id = 1')).toEqual([]);
+  });
+
+  it('still reports a typo on a joined table written without aliases', () => {
+    expect(
+      diagnosticsFor('select posts.titel from users join posts on users.id = posts.user_id'),
+    ).toEqual([{ message: 'unknown column: titel', text: 'titel' }]);
+  });
 });

--- a/ts-plugin/tests/sql-context.test.ts
+++ b/ts-plugin/tests/sql-context.test.ts
@@ -270,6 +270,55 @@ describe('findSources', () => {
     ]);
   });
 
+  // Regression for #242: the alias group used to consume the word after the
+  // table. When the first table had no alias that word was the next `join`
+  // keyword, so the joined table was never scanned at all.
+  it('captures a joined source when the first table has no alias', () => {
+    const sources = findSources('select posts.title from users join posts on users.id = posts.user_id');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+      { table: 'posts', alias: 'posts' },
+    ]);
+  });
+
+  it('captures an aliased joined source when the first table has no alias', () => {
+    const sources = findSources('select p.title from users join posts p on users.id = p.user_id');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+      { table: 'posts', alias: 'p' },
+    ]);
+  });
+
+  it('does not read the USING keyword as an alias', () => {
+    const sources = findSources('select posts.title from users join posts using (id)');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+      { table: 'posts', alias: 'posts' },
+    ]);
+  });
+
+  it('captures a comma-joined FROM list', () => {
+    const sources = findSources('select users.id, posts.title from users, posts where users.id = 1');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+      { table: 'posts', alias: 'posts' },
+    ]);
+  });
+
+  it('does not read a SELECT-list comma as another table', () => {
+    const sources = findSources('select id, name from users');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('does not read a comma inside a WHERE clause as another table', () => {
+    const sources = findSources('select id from users where id in (1, 2)');
+    expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
   it('ignores a FROM inside a $$ dollar-quoted body (issue #209 repro)', () => {
     const sources = findSources('select id, name from users where note = $$ pulled from orders $$');
     expect(sources.map((s) => ({ table: s.table, alias: s.alias }))).toEqual([
@@ -384,6 +433,13 @@ describe('findSourceByAlias', () => {
   it('returns null for an alias that is not present', () => {
     const sources = findSources('select u.id from users u');
     expect(findSourceByAlias(sources, 'p')).toBeNull();
+  });
+
+  // Matches how the type-level FindSourceByName resolves: alias first, then the
+  // table name. A qualifier that names the table is never a wrong diagnostic.
+  it('falls back to the table name when no alias matches', () => {
+    const sources = findSources('select users.id from users u');
+    expect(findSourceByAlias(sources, 'users')?.table).toBe('users');
   });
 });
 


### PR DESCRIPTION
Fixes every issue opened by the 2026-07-28 audit: #228, #229, #230, #231, #232, #233, #234, #235, #236, #237, #238, #239, #240, #241, #242.

One commit per issue, in dependency order — #229 lands before #233 (once strict mode validates the WHERE of a write, the fabricated source would have made every unqualified column ambiguous), and #228 before #238. A single branch rather than a stack: #224 was marked merged while its content never reached master, and this is fifteen changes.

Every fix ships its regression test, and each test was checked to fail against the pre-fix code.

## The three that shared a root cause

`#228`, `#229` and `#230` were all the same trap: a conditional type whose left side resolves to `never`.

```ts
Alias<X> extends { shape: infer S extends string } ? A : B   // never resolves to A, with S inferred as `string`
T extends string ? A : B                                     // T is a naked type parameter and never, so it distributes to never
```

- **#229** — `SplitAtTopLevelKeyword` is `never` when there is no FROM/USING clause, so `ParseFromClause` was handed the type `string` as a table name. `ResolveKey<DB, string>` matches every table, so every `RETURNING` column looked like it came from two sources: `delete from users where id = 1 returning id` returned `QueryTypeError<"ambiguous column: id">`. Non-strict mode borrowed columns from unrelated tables instead of resolving them to `unknown`.
- **#228** — `DigitsToCounter` is `never` for anything that isn't all digits, so `$1::int` and `$id` were routed into the numbered bucket at slot 0. Two of them intersected into `never`: a parameter tuple no argument can satisfy. Casts also now bind by index, which is what `CleanScanToken` stripping them buys.
- **#230** — `AfterValues extends string` distributed over `never`, so an INSERT with no VALUES clause collapsed the whole conditional instead of reaching the documented `unknown[]`. `db.query('insert into users (id, name) select ...')` could not be written at all — a rest parameter typed `never` rejects even the zero-argument call.

The guard used throughout the codebase is `[X] extends [never] ? ... : ...`; these three were the places it was missing.

## Type layer

- **#231** — `$action` is a MERGE pseudo-column, and `ResolveColumnType` already typed it as such, but `IsPlaceholder` matched any `$…`. So a MERGE with `output $action` demanded an extra argument *and* reported the query as dollar-styled, failing the placeholder-style check against the mssql executor — the only dialect that has MERGE OUTPUT at all.
- **#232** — quoted identifiers are deliberately left intact by the masking pass, which makes their bodies the last place raw punctuation survives. Two things read that punctuation as SQL: the stacked-statement guard, and `RemoveSemicolons`, which scrubbed *every* semicolon rather than the trailing one and so mangled `"id;x"` even once the guard passed. Both fixed; all three quoting styles covered.
- **#233** — a write without RETURNING projects nothing, and the empty-row short circuit returned before the clause check ran. Strict mode is documented as covering the WHERE clause; it skipped the two statements where a wrong condition costs the most.
- **#238** — `SQLITE_PARAM_PREFIXES` has bound `:` since the adapter was written, but the type layer produced an empty tuple for `where id = :id` and strict mode reported `:id` as an unknown column.

## Runtime

- **#234** — both parameter scanners walked past `--` and `/* */` comments as if they were SQL. Binding is positional, so a `@word` in a comment ate one value and the last real placeholder got `null`. `Params<DB, Q>` is computed from text that *does* strip comments, so nothing at compile time could see the disagreement. The two near-identical loops are now one walker.
- **#235** — `MssqlQueryable` accepts a `Request`, node-mssql refuses `input()` for a name it has already declared, and nothing clears the bag between calls. So a caller-supplied Request worked exactly once per parameter name. The test fake now mirrors node-mssql's real `input()` contract instead of accepting everything.
- **#237** — a CTE-led write was classified by its first word (`with`) and lost its row count; a write with RETURNING goes down `all()` and reported no metadata at all. The RETURNING counters are read back off the connection best-effort: metadata is the bonus, the rows are the answer.

## CLI and editor plugin

- **#236** — `file:./app.db` was detected as SQLite but the prefix was never stripped, so the file was reported missing under a path nobody wrote.
- **#239** — `host\INSTANCE` is the default Windows shape and a backslash is a forbidden host character, so `new URL` rejected it outright. Now parsed into the driver's `instanceName`, and a genuinely malformed URL gets a message saying what a valid one looks like — carrying no part of the URL, so a password cannot leak through it.
- **#240** — `--table users,ordrs` generated a schema without the typo'd table and printed `Wrote ./schema.ts`. Now an error. An unmatched `--exclude` only warns: excluding a table that isn't there is still the outcome asked for.
- **#241** — `--check=false` turned the check *on* and exited 1 on drift.
- **#242** — the plugin's source scanner consumed the word after a table as a candidate alias. With no alias on the first table that word was the next `join` keyword, so the joined table was never scanned and every reference to it read as an unknown alias. Only the bare `a join b` broke — with `inner join` or an alias the consumed word was something else — which is exactly the shape the existing tests covered. `JOIN ... USING` and comma-joined FROM lists are handled too, and `findSourceByAlias` now falls back to the table name like the type-level resolver, so a source the heuristic misses means no diagnostic rather than a wrong one.

## Verification

- 179 runtime tests (was 156) and 4 tsconfigs green; 153 ts-plugin tests (was 142) green.
- Type budget: **170,045 instantiations, 92% of the 185,000 ceiling** (baseline was 166,512 / 90%). The +2.1% is the case-insensitive `$action` strip and the quoted-identifier mask, both on paths every query touches. Under budget, so the ceiling is left where it is.
- Integration tests not run here — they need the compose stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
