### PR TITLE
fix(adapters): stop reading a backslash before a closing quote as an escape

### DIFF
--- a/src/adapters/named-params.ts
+++ b/src/adapters/named-params.ts
@@ -10,25 +10,22 @@ const IDENTIFIER_QUOTE_CLOSERS: ReadonlyMap<string, string> = new Map([
   ['[', ']'],
 ]);
 
-// A quote preceded by an odd run of backslashes is backslash-escaped (MySQL's
-// and SQLite's default `\'`) and doesn't open or close a literal - the run has
-// to be odd, not merely non-empty, since `\\'` is an escaped backslash followed
-// by a real delimiter. Mirrors EndsWithOddBackslashes in src/string.ts and the
-// same check in the ts-plugin's stripStringLiterals; without it every parameter
-// after the escaped quote is read as literal body and silently dropped.
-function isLiteralDelimiter(sql: string, index: number): boolean {
-  let backslashes = 0;
-  while (backslashes < index && sql[index - 1 - backslashes] === '\\') {
-    backslashes += 1;
-  }
-  return backslashes % 2 === 0;
-}
-
+// Doubling (`''`) is the only escape this scanner honours, because the only
+// two adapters that use it - mssql and node:sqlite - run on engines where a
+// backslash is an ordinary character: `'C:\'` is a *complete* literal in both
+// T-SQL and SQLite. Treating that closing quote as escaped (MySQL's `\'`, the
+// rule this scanner used to apply to every dialect) ran the literal on to the
+// end of the statement and swallowed every parameter after it - silently
+// wrong rows on SQLite, an unbound @name on SQL Server (issue #248).
+//
+// The type-level masking in src/string.ts keeps the backslash rule: it has no
+// dialect to key off, and dropping it there would break the MySQL queries it
+// covers today.
 function skipSingleQuotedLiteral(sql: string, openIndex: number): number {
   let index = openIndex + 1;
 
   while (index < sql.length) {
-    if (sql[index] === "'" && isLiteralDelimiter(sql, index)) {
+    if (sql[index] === "'") {
       if (sql[index + 1] === "'") {
         index += 2;
         continue;

--- a/tests/adapter-mssql.test.ts
+++ b/tests/adapter-mssql.test.ts
@@ -93,6 +93,18 @@ describe('createMssqlExecutor', () => {
     expect(request.input).not.toHaveBeenCalled();
   });
 
+  // Regression for #248: T-SQL has no backslash escape, so 'C:\' is a complete
+  // literal. Reading that quote as escaped ran the literal to the end of the
+  // statement, @id was never declared, and the driver rejected the query.
+  it('binds a parameter that follows a path literal ending in a backslash', async () => {
+    const { pool, request } = fakePool({ recordset: [] });
+    const executor = createMssqlExecutor(pool);
+
+    await executor("select * from files where path = 'C:\\' and id = @id", [7]);
+
+    expect(request.input.mock.calls).toEqual([['id', 7]]);
+  });
+
   it('returns empty rows and rowCount metadata when a write produces no recordset', async () => {
     const { pool } = fakePool({ recordset: undefined, rowsAffected: [3] });
     const executor = createMssqlExecutor(pool);

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -88,6 +88,22 @@ describe.skipIf(!sqliteAvailable)('createNodeSqliteExecutor', () => {
     }
   });
 
+  // Regression for #248: SQLite has no backslash escape, so 'C:\' is a
+  // complete literal and the ? after it is a real placeholder. The scanner
+  // used to read that quote as escaped, run the literal to the end of the
+  // statement, and return a silently empty result set.
+  it('binds a placeholder that follows a literal ending in a backslash', async () => {
+    const DatabaseSync = loadSqlite();
+    const sqlite = new DatabaseSync(':memory:');
+    sqlite.exec('create table files (id integer primary key, path text)');
+    sqlite.prepare('insert into files (id, path) values (?, ?)').run(1, 'C:\\');
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    const rows = await executor("select id from files where path = 'C:\\' and id = ?", [1]);
+
+    expect(rows).toEqual([{ id: 1 }]);
+  });
+
   it('coerces boolean and Date params to driver-supported values', async () => {
     const DatabaseSync = loadSqlite();
     const sqlite = new DatabaseSync(':memory:');

--- a/tests/named-params.test.ts
+++ b/tests/named-params.test.ts
@@ -41,9 +41,11 @@ describe('collectNamedParameters', () => {
     ).toEqual(['@id']);
   });
 
-  it('collects parameters that follow a backslash-escaped quote inside a literal', () => {
-    const sql = "select * from t where a = 'it\\'s' and b = @id and c = @other";
-    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id', '@other']);
+  // T-SQL and SQLite, the two engines behind this scanner, have no backslash
+  // escape: a literal ending in a backslash closes at that quote (issue #248).
+  it('closes a literal ending in a backslash and collects what follows', () => {
+    const sql = "select * from t where p = 'C:\\' and id = @id";
+    expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id']);
   });
 
   it('treats a doubled backslash before a quote as a real closing delimiter', () => {
@@ -51,8 +53,8 @@ describe('collectNamedParameters', () => {
     expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id']);
   });
 
-  it('still skips a parameter inside a literal that contains an escaped quote', () => {
-    const sql = "select * from t where a = 'it\\'s @fake' and b = @id";
+  it('skips a parameter inside a literal whose body holds a backslash', () => {
+    const sql = "select * from t where a = 'c:\\dir @fake' and b = @id";
     expect(collectNamedParameters(sql, AT_DOLLAR_COLON)).toEqual(['@id']);
   });
 
@@ -93,16 +95,16 @@ describe('collectNamedParameters', () => {
 });
 
 describe('resolveMixedParameters', () => {
-  it('assigns values to parameters that follow a backslash-escaped quote', () => {
-    const sql = "select * from t where a = 'it\\'s' and b = @id and c = @other";
+  it('assigns values to parameters that follow a literal ending in a backslash', () => {
+    const sql = "select * from t where p = 'C:\\' and b = @id and c = @other";
     expect(resolveMixedParameters(sql, AT_DOLLAR_COLON, [1, 2])).toEqual({
       named: { '@id': 1, '@other': 2 },
       positional: [],
     });
   });
 
-  it('does not consume a value for a placeholder inside an escaped-quote literal', () => {
-    const sql = "select * from t where a = 'it\\'s ?' and b = ?";
+  it('does not consume a value for a placeholder inside a literal holding a backslash', () => {
+    const sql = "select * from t where a = 'c:\\dir ?' and b = ?";
     expect(resolveMixedParameters(sql, AT_DOLLAR_COLON, [7])).toEqual({
       named: {},
       positional: [7],


### PR DESCRIPTION
Fixes #248.

The named-parameter scanner in `src/adapters/named-params.ts` treated a quote preceded by an odd run of backslashes as escaped. That rule is MySQL's, and mysql2 is the one adapter that never uses this scanner. The two that do — mssql and node:sqlite — run on engines where a backslash is an ordinary character, so `'C:\'` is a **complete** literal in both T-SQL and SQLite.

So the scanner walked past the real closing quote and consumed the rest of the statement:

```js
// mssql: input() is never called, and the driver rejects a query
// referencing an @id it was never given
await executor(String.raw`select * from files where path = 'C:\' and id = @id`, [7]);

// node:sqlite: no exception, just the wrong result set
await executor(String.raw`select id from files where path = 'C:\' and id = ?`, [1]);
// [] instead of [{ id: 1 }]
```

Checked against a live `node:sqlite`: `select 'C:\' as p, ? as n` binds fine at the engine, so the desync is entirely on our side.

## The change

Doubling (`''`) is now the only escape this scanner honours — the rule both engines actually implement. No dialect flag: the scanner has exactly two callers and both want the same answer.

The type-level masking in `src/string.ts` keeps the backslash rule on purpose. It has no dialect to key off, and removing it there would break the MySQL queries it covers today.

## About #131

The backslash rule came from the fix for #131, which was right about MySQL semantics but applied it in a scanner used only by non-MySQL adapters. Three of that issue's tests asserted behaviour neither engine has; they now assert what the engines parse, and both adapters get an end-to-end regression test.

## Verification

- 181 runtime tests green (was 179), 4 tsconfigs green.
- Both new tests were confirmed red against the pre-fix code.
- No inference change, so no version-policy implication: runtime-only, patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
