### PR TITLE
fix(cli): redact a password that contains an unencoded @

### DIFF
--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -40,7 +40,14 @@ const ADO_CREDENTIALS_PATTERN =
 // URL userinfo ("//user:pass@" or a mistyped single-slash ":/user:pass@"). The
 // single-slash form requires a multi-character scheme before the ":/" so that
 // Windows drive-letter paths ("C:/app@prod.db") are not treated as URL userinfo.
-const URL_CREDENTIALS_PATTERN = /(\/\/|(?<=[a-z][a-z0-9+.-]):\/)[^@/]+@/i;
+//
+// The userinfo run is greedy up to the *last* "@" of the authority, because
+// that is the one a URL parser splits on: an unencoded "@" inside a password
+// ("root:p@ss@host") is accepted by `new URL` and by the drivers, and a
+// non-greedy match stopped at the first one and printed the rest of the
+// password (issue #251). "/", "?" and "#" end the authority, so a later "@"
+// in a path or query is never mistaken for userinfo.
+const URL_CREDENTIALS_PATTERN = /(\/\/|(?<=[a-z][a-z0-9+.-]):\/)[^/?#]*@/i;
 
 // The password value of an ADO / DSN "Pwd="/"Password=" pair. The value may be
 // wrapped in double quotes, braces, or single quotes (so an embedded ";" does

--- a/tests/cli-redact.test.ts
+++ b/tests/cli-redact.test.ts
@@ -23,6 +23,21 @@ describe('redactCredentials', () => {
     );
   });
 
+  // Regression for #251: a URL parser splits userinfo at the last "@" of the
+  // authority, so an unencoded "@" in the password is legal - and the tail of
+  // it used to survive redaction.
+  it('replaces a password containing an unencoded @', () => {
+    expect(redactCredentials('mysql://root:p@ss@localhost/db')).toBe('mysql://***@localhost/db');
+    expect(redactCredentials('mysql://root:p@ss@localhost')).toBe('mysql://***@localhost');
+  });
+
+  it('does not read an @ in the path or query as userinfo', () => {
+    expect(redactCredentials('postgres://host/db?application_name=svc@prod')).toBe(
+      'postgres://host/db?application_name=svc@prod',
+    );
+    expect(redactCredentials('mssql://sa:pw@host/db?tag=a@b')).toBe('mssql://***@host/db?tag=a@b');
+  });
+
   it('leaves credential-free URLs untouched', () => {
     expect(redactCredentials('postgres://host/db')).toBe('postgres://host/db');
     expect(redactCredentials('./local.sqlite')).toBe('./local.sqlite');


### PR DESCRIPTION
Fixes #251.

`URL_CREDENTIALS_PATTERN` matched `[^@/]+@`, which stops at the **first** `@`. URL parsers split userinfo at the **last** `@` of the authority, so a password containing an unencoded `@` — accepted by `new URL` and by every driver — was only partly redacted:

```js
redactCredentials('mysql://root:p@ss@localhost/db')
// before: 'mysql://***@ss@localhost/db'   <- leaks "ss"
// after:  'mysql://***@localhost/db'
```

That string reaches stderr through `unrecognizedUrlError`, which is the path #134 added redaction for in the first place.

## The change

The userinfo run is greedy and bounded by the characters that end an authority (`/`, `?`, `#`), so it lands on the last `@` that can legally be a separator, and an `@` in a path or query string is still left alone:

```js
redactCredentials('postgres://host/db?application_name=svc@prod')  // unchanged
redactCredentials('mssql://sa:pw@host/db?tag=a@b')                 // 'mssql://***@host/db?tag=a@b'
```

## Verification

- 183 runtime tests green (was 181), 4 tsconfigs green.
- Both new cases were confirmed red against the pre-fix regex.
- CLI-only, no inference change: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
