### PR TITLE
fix(cli): stop typing an unrecognized SQLite declared type as number

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,9 +247,15 @@ prints a clear error telling you which one to install if it's missing.
 `string` but `bigint` as a JS `number` (unless you enable
 `supportBigNumbers`/`bigNumberStrings`); `mssql` (tedious) returns `bigint` as
 `string` but parses `decimal`/`numeric`/`money` into JS `number` (with
-precision loss beyond 2^53). The generated types mirror exactly that. If your
-driver is configured differently, just edit the generated field by hand; it's
-a plain type after that point.
+precision loss beyond 2^53). SQLite has no column types, only affinities, so
+the *declared* type drives the mapping: `INTEGER`/`REAL` and the numeric
+names (`NUMERIC`, `DECIMAL(10,2)`, `MONEY`) become `number`, text-affinity
+types and `JSON` become `string`, `BLOB` and an untyped column become
+`Uint8Array`, and a declared type that says nothing about its contents
+(`GEOMETRY`, a custom name) becomes `unknown` rather than a guess. The
+generated types mirror exactly that. If your driver is configured
+differently, just edit the generated field by hand; it's a plain type after
+that point.
 
 ### 2. Create a typed client
 

--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -12,6 +12,14 @@ export function mapSqliteType(declaredType: string): string {
     return 'string';
   }
 
+  // A JSON column has NUMERIC affinity, and a JSON document is not a
+  // well-formed number, so SQLite stores it as TEXT and node:sqlite hands
+  // back a string. It used to reach the fallback below and be typed `number`
+  // (issue #252).
+  if (type === 'JSON' || type === 'JSONB') {
+    return 'string';
+  }
+
   if (type.includes('INT')) {
     return 'number';
   }
@@ -31,7 +39,16 @@ export function mapSqliteType(declaredType: string): string {
     return 'number';
   }
 
-  return 'number';
+  // The NUMERIC-affinity names people actually declare. Everything past this
+  // point is a type SQLite gives NUMERIC affinity without any hint about what
+  // is stored in it, so it degrades to `unknown` the way an unrecognized type
+  // already does in the other three introspectors - claiming `number` for it
+  // was a guess that a JSON or an enum-ish column silently broke (issue #252).
+  if (type.includes('NUM') || type.includes('DEC') || type.includes('MONEY')) {
+    return 'number';
+  }
+
+  return 'unknown';
 }
 
 interface SqliteTableInfoRow {

--- a/tests/cli-type-mapping.test.ts
+++ b/tests/cli-type-mapping.test.ts
@@ -141,9 +141,18 @@ describe('mapSqliteType', () => {
     expect(mapSqliteType('DATETIME')).toBe('string');
   });
 
-  it('falls back to number for NUMERIC-affinity types', () => {
+  it('maps the NUMERIC-affinity names to number', () => {
     expect(mapSqliteType('NUMERIC')).toBe('number');
     expect(mapSqliteType('DECIMAL(10,2)')).toBe('number');
+  });
+
+  // Regression for #252: a JSON column has NUMERIC affinity but holds text,
+  // and an unrecognized declared type says nothing about what is stored -
+  // both used to be typed `number`.
+  it('maps JSON to string and degrades an unrecognized type to unknown', () => {
+    expect(mapSqliteType('JSON')).toBe('string');
+    expect(mapSqliteType('jsonb')).toBe('string');
+    expect(mapSqliteType('GEOMETRY')).toBe('unknown');
   });
 
   it('accepts lowercase declared types', () => {


### PR DESCRIPTION
Fixes #252.

`mapSqliteType` ended in `return 'number'`, so any declared type it didn't recognize was generated as `number`. The other three introspectors degrade an unknown type to `unknown`; only SQLite guessed.

The guess is wrong in the case that reaches the fallback most often. A `JSON` column has NUMERIC affinity, a JSON document is not a well-formed number, so SQLite keeps it as TEXT and `node:sqlite` hands back a string:

```sql
create table docs (id integer primary key, payload json);
insert into docs (payload) values ('{"a":1}');
-- generated: payload: number
-- actual:    typeof row.payload === 'string'
```

## The change

- `JSON`/`JSONB` → `string`.
- The NUMERIC-affinity names people actually declare (`NUMERIC`, `DECIMAL(10,2)`, `MONEY`) keep mapping to `number`, now explicitly instead of by falling off the end.
- Anything else → `unknown`, matching the other dialects.
- README: the type-mapping paragraph covered pg/mysql2/mssql and said nothing about SQLite; it now spells out the affinity rules the generator follows.

## Verification

- 184 runtime tests green (was 183), 4 tsconfigs green.
- The new case was confirmed red against the pre-fix mapping.
- CLI output change: a schema regenerated over a column with an exotic declared type gains `unknown` where it used to say `number`. That's a generated-file change, not a library inference change — patch under VERSIONING.md, and the old type was wrong anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
