### PR TITLE
fix(cli): reject an empty --table/--exclude list instead of dropping the filter

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -89,7 +89,11 @@ function parseDialect(raw: string | undefined): Dialect | undefined {
   return raw as Dialect;
 }
 
-function parseTableList(raw: string | undefined): string[] | undefined {
+// An empty list used to collapse to `undefined`, which downstream means "no
+// filter at all" - so `--table=` (an unset variable in a CI script) quietly
+// generated the whole schema and reported success. Same class of silence as
+// #240, where a name matching no table was ignored (issue #253).
+export function parseTableList(raw: string | undefined, flag: string): string[] | undefined {
   if (raw === undefined) {
     return undefined;
   }
@@ -99,7 +103,11 @@ function parseTableList(raw: string | undefined): string[] | undefined {
     .map((name) => name.trim())
     .filter((name) => name.length > 0);
 
-  return names.length > 0 ? names : undefined;
+  if (names.length === 0) {
+    throw new Error(`--${flag} needs at least one table name.`);
+  }
+
+  return names;
 }
 
 function readVersion(): string {
@@ -168,8 +176,8 @@ async function main(): Promise<void> {
     out,
     dialect: parseDialect(flags.get('dialect')),
     schema: flags.get('schema'),
-    tables: parseTableList(flags.get('table')),
-    exclude: parseTableList(flags.get('exclude')),
+    tables: parseTableList(flags.get('table'), 'table'),
+    exclude: parseTableList(flags.get('exclude'), 'exclude'),
     check: flags.has('check'),
   });
 

--- a/tests/cli-flags.test.ts
+++ b/tests/cli-flags.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseFlags } from '../src/cli/index';
+import { parseFlags, parseTableList } from '../src/cli/index';
 
 describe('parseFlags', () => {
   it('parses the spaced form', () => {
@@ -68,5 +68,26 @@ describe('parseFlags', () => {
     expect(() => parseFlags(['--check=false'])).toThrow('--check does not take a value.');
     expect(() => parseFlags(['--help=no'])).toThrow('--help does not take a value.');
     expect(() => parseFlags(['--version=1'])).toThrow('--version does not take a value.');
+  });
+});
+
+describe('parseTableList', () => {
+  it('splits and trims a list', () => {
+    expect(parseTableList('users, posts ,orders', 'table')).toEqual(['users', 'posts', 'orders']);
+  });
+
+  it('returns undefined when the flag was not given', () => {
+    expect(parseTableList(undefined, 'table')).toBeUndefined();
+  });
+
+  // Regression for #253: an empty list collapsed to undefined, which means
+  // "no filter" downstream - so --table= generated the whole schema and
+  // printed the usual success line.
+  it('rejects a list with no usable name instead of silently dropping the filter', () => {
+    expect(() => parseTableList('', 'table')).toThrow('--table needs at least one table name.');
+    expect(() => parseTableList(' , ,', 'table')).toThrow('--table needs at least one table name.');
+    expect(() => parseTableList('', 'exclude')).toThrow(
+      '--exclude needs at least one table name.',
+    );
   });
 });


### PR DESCRIPTION
Fixes #253.

`parseTableList` collapsed a list with no usable name to `undefined`, and `undefined` means "no filter at all" further down:

```sh
owlsql generate --url ./app.db --out schema.ts --table=
# Wrote schema.ts      <- every table in the database, no warning
```

In a CI job that scopes the schema from a variable (`--table=$TABLES`), an empty variable silently swaps a 3-table schema for a 200-table one. #240 already settled that a filter name matching no table is an error rather than a silent no-op — an empty list is the same class of mistake.

## The change

`parseTableList` now takes the flag name and throws `--table needs at least one table name.` when the flag was given but nothing usable survives the split. A flag that was never passed still returns `undefined`, so nothing changes for the normal path.

## Verification

- 187 runtime tests green (was 184), 4 tsconfigs green.
- The new cases were confirmed red against the pre-fix helper.
- CLI-only, no inference change: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
