### PR TITLE
fix(ts-plugin): resolve table and column names case-insensitively

### DIFF
--- a/ts-plugin/src/schema.cts
+++ b/ts-plugin/src/schema.cts
@@ -1,5 +1,24 @@
 import type * as ts from 'typescript';
 
+// SQL identifiers are matched case-insensitively by the type layer
+// (ResolveKey/CaseInsensitiveKey in src/parse.ts), so the plugin has to
+// resolve them the same way or it reports a warning on a query tsc types
+// perfectly - `select id from USERS` against a `users` table (issue #250).
+// The exact lookup runs first: it is the cheap path and the common one.
+function findPropertySymbol(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  name: string,
+): ts.Symbol | undefined {
+  const exact = checker.getPropertyOfType(type, name);
+  if (exact) {
+    return exact;
+  }
+
+  const lowered = name.toLowerCase();
+  return type.getProperties().find((symbol) => symbol.getName().toLowerCase() === lowered);
+}
+
 function scopeToTable(
   tableSymbols: ts.Symbol[],
   onlyTable: string | string[] | null,
@@ -8,8 +27,10 @@ function scopeToTable(
     return tableSymbols;
   }
 
-  const wanted = new Set(Array.isArray(onlyTable) ? onlyTable : [onlyTable]);
-  return tableSymbols.filter((symbol) => wanted.has(symbol.getName()));
+  const wanted = new Set(
+    (Array.isArray(onlyTable) ? onlyTable : [onlyTable]).map((name) => name.toLowerCase()),
+  );
+  return tableSymbols.filter((symbol) => wanted.has(symbol.getName().toLowerCase()));
 }
 
 function tableExists(
@@ -18,7 +39,7 @@ function tableExists(
   dbType: ts.Type,
   tableName: string,
 ): boolean {
-  if (checker.getPropertyOfType(dbType, tableName)) {
+  if (findPropertySymbol(checker, dbType, tableName)) {
     return true;
   }
   // A Record<string, ...>-shaped schema (this library's own documented
@@ -42,7 +63,7 @@ function resolveTableRowTypes(
   onlyTable: string | string[] | null,
 ): ts.Type[] {
   const tableSymbols = scopeToTable(dbType.getProperties(), onlyTable);
-  const resolvedNames = new Set(tableSymbols.map((symbol) => symbol.getName()));
+  const resolvedNames = new Set(tableSymbols.map((symbol) => symbol.getName().toLowerCase()));
   const rowTypes = tableSymbols.map((symbol) =>
     checker.getNonNullableType(checker.getTypeOfSymbolAtLocation(symbol, node)),
   );
@@ -58,7 +79,7 @@ function resolveTableRowTypes(
 
   const requestedNames = Array.isArray(onlyTable) ? onlyTable : [onlyTable];
   for (const name of requestedNames) {
-    if (!resolvedNames.has(name)) {
+    if (!resolvedNames.has(name.toLowerCase())) {
       rowTypes.push(indexType);
     }
   }
@@ -73,7 +94,7 @@ function resolveColumnType(
   node: ts.Node,
   columnName: string,
 ): ts.Type | null {
-  const columnSymbol = checker.getPropertyOfType(rowType, columnName);
+  const columnSymbol = findPropertySymbol(checker, rowType, columnName);
   if (columnSymbol) {
     return checker.getTypeOfSymbolAtLocation(columnSymbol, node);
   }

--- a/ts-plugin/tests/diagnostics.test.ts
+++ b/ts-plugin/tests/diagnostics.test.ts
@@ -52,6 +52,14 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
     ]);
   });
 
+  // Regression for #250: `select id from USERS` compiles to { id: number }[],
+  // so a warning on it is a false positive the user cannot act on.
+  it('accepts a table and a column written in a different case', () => {
+    expect(diagnosticsFor('select id from USERS')).toEqual([]);
+    expect(diagnosticsFor('SELECT ID FROM users')).toEqual([]);
+    expect(diagnosticsFor('select id from users where NAME = $1')).toEqual([]);
+  });
+
   it('reports an unknown table in the FROM clause', () => {
     expect(diagnosticsFor('select id from ghosts')).toEqual([
       { message: 'unknown table: ghosts', text: 'ghosts' },

--- a/ts-plugin/tests/schema.test.ts
+++ b/ts-plugin/tests/schema.test.ts
@@ -49,6 +49,19 @@ describe('getColumnNames / getColumnType scoping', () => {
     expect(getColumnType(ts, checker, dbType, node, 'userz', 'title')).toBeNull();
   });
 
+  // Regression for #250: the type layer resolves identifiers
+  // case-insensitively, so the plugin has to as well - otherwise it scopes to
+  // nothing and offers no columns for a query tsc types fine.
+  it('scopes to a table named in a different case', () => {
+    const { checker, dbType, node } = buildDbType(`
+      interface DB { users: { id: number; name: string }; posts: { id: number; title: string } }
+      declare const dbValue: DB;
+    `);
+
+    expect(getColumnNames(ts, checker, dbType, node, 'USERS').sort()).toEqual(['id', 'name']);
+    expect(getColumnType(ts, checker, dbType, node, 'Users', 'NAME')).not.toBeNull();
+  });
+
   it('unions columns across all tables when no FROM table is given', () => {
     const { checker, dbType, node } = buildDbType(`
       interface DB { users: { id: number; name: string }; posts: { id: number; title: string } }


### PR DESCRIPTION
Fixes #250.

The core type layer matches identifiers case-insensitively (`ResolveKey`/`CaseInsensitiveKey` in `src/parse.ts`, covered by `tests/case-insensitive.test-d.ts`). `ts-plugin/src/schema.cts` matched them exactly, so the editor warned about queries `tsc` types perfectly:

| query | before | `tsc` |
| --- | --- | --- |
| `select id from USERS` | `unknown table: USERS` | `{ id: number }[]` |
| `SELECT ID FROM users` | `unknown column: ID` | `{ ID: number }[]` |

Uppercase keywords with lowercase identifiers is a common house style, so this fired a lot. `select U.id from users U` was already fine — `findSourceByAlias` lowercases both sides — which is what made the inconsistency visible.

## The change

One `findPropertySymbol` helper: exact `getPropertyOfType` first (the cheap and common path), then a lowercased scan of the type's own properties. `tableExists` and `resolveColumnType` go through it; `scopeToTable` and the `Record<string, ...>` index-signature fallback compare lowercased names the same way.

Completions still offer the schema's real casing — only *matching* is case-insensitive, not what gets displayed.

## Verification

- 155 plugin tests green (was 153), plugin type-check green.
- Both new cases were confirmed red against the pre-fix module.
- Plugin-only, no library inference change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
