### PR TITLE
fix(parse): accept a column list glued to the INSERT target

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -270,8 +270,17 @@ type ZipIntersectIndexed<A extends unknown[], B extends unknown[]> = A extends [
     : A
   : B;
 
+// The column list starts right after the target name, which is not always a
+// word boundary: `insert into users(id, name)` glues it to the table, so
+// dropping the first word ate the first column too (issue #245).
+type RestAfterTarget<S extends string> = FirstWord<Trim<S>> extends `${string}(${string}`
+  ? Trim<S> extends `${string}(${infer AfterOpen}`
+    ? `(${AfterOpen}`
+    : Trim<DropFirstWord<Trim<S>>>
+  : Trim<DropFirstWord<Trim<S>>>;
+
 type InsertColumnList<S extends string> = AfterKeyword<S, 'into'> extends infer AfterInto extends string
-  ? Trim<DropFirstWord<AfterInto>> extends `(${infer AfterOpen}`
+  ? RestAfterTarget<AfterInto> extends `(${infer AfterOpen}`
     ? ExtractParenGroup<AfterOpen> extends { inner: infer Cols extends string; rest: infer Rest extends string }
       ? { columns: SplitColumnList<Cols>; rest: Trim<Rest> }
       : never

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -4,6 +4,7 @@ import type {
   FirstWord,
   DropFirstWord,
   StripQualifier,
+  BeforeParen,
   Qualifier,
   IsKeyword,
   Unquote,
@@ -179,7 +180,7 @@ type ReturningOrOutputColumns<S extends string, StopKeyword extends string> = Re
   ? StripPseudoTableQualifiers<OutputClauseColumns<S, StopKeyword>>
   : ReturningColumns<S>;
 
-type CleanTargetIdentifier<Raw extends string> = Unquote<StripQualifier<Raw>>;
+type CleanTargetIdentifier<Raw extends string> = Unquote<StripQualifier<BeforeParen<Raw>>>;
 
 type SingleSource<Table extends string> = [
   { table: CleanTargetIdentifier<Table>; alias: CleanTargetIdentifier<Table>; nullable: false },

--- a/src/string.ts
+++ b/src/string.ts
@@ -218,6 +218,11 @@ export type FirstWord<S extends string> = S extends `${infer Head} ${string}`
   ? Head
   : S;
 
+// `insert into users(id, name)` is as legal as `insert into users (id, name)`,
+// and the target is a space-delimited word either way - so the name has to be
+// cut at the paren too, or the table is read as `users(id,` (issue #245).
+export type BeforeParen<S extends string> = S extends `${infer Before}(${string}` ? Before : S;
+
 export type StripQualifier<S extends string> = S extends `${string}.${infer Rest}`
   ? StripQualifier<Rest>
   : S;

--- a/tests/insert-target.test-d.ts
+++ b/tests/insert-target.test-d.ts
@@ -1,0 +1,54 @@
+import type { Params, StrictRow, Row } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+// Regression for #245: the target is a space-delimited word, so a column list
+// glued to it (`users(id, name)`) was read as part of the table name - the
+// statement's source became `users(id,` and the column list was never found.
+type GluedColumnListStillTypesParams = Expect<
+  Equal<Params<DB, 'insert into users(id, name) values ($1, $2)'>, [number, string]>
+>;
+
+type GluedColumnListStillResolvesTheTarget = Expect<
+  Equal<StrictRow<DB, 'insert into users(id, name) values ($1, $2) returning id'>, { id: number }>
+>;
+
+type GluedColumnListWithSchemaQualifiedTarget = Expect<
+  Equal<Params<DB, 'insert into public.users(id, name) values ($1, $2)'>, [number, string]>
+>;
+
+type GluedColumnListWithQuotedTarget = Expect<
+  Equal<Params<DB, 'insert into "users"(id, name) values ($1, $2)'>, [number, string]>
+>;
+
+type SpacedColumnListStillWorks = Expect<
+  Equal<Params<DB, 'insert into users (id, name) values ($1, $2)'>, [number, string]>
+>;
+
+type GluedMultiRowValues = Expect<
+  Equal<
+    Params<DB, 'insert into users(id, name) values ($1, $2), ($3, $4)'>,
+    [number, string, number, string]
+  >
+>;
+
+type GluedColumnListLooseRow = Expect<
+  Equal<Row<DB, 'insert into users(id, name) values ($1, $2) returning name'>, { name: string }>
+>;
+
+export type Assertions = [
+  GluedColumnListStillTypesParams,
+  GluedColumnListStillResolvesTheTarget,
+  GluedColumnListWithSchemaQualifiedTarget,
+  GluedColumnListWithQuotedTarget,
+  SpacedColumnListStillWorks,
+  GluedMultiRowValues,
+  GluedColumnListLooseRow,
+];


### PR DESCRIPTION
Fixes #245.

`insert into users (id, name) ...` worked; `insert into users(id, name) ...` was parsed as if the table were named `users(id,`.

```ts
Params<DB, 'insert into users(id, name) values ($1, $2)'>
// before: unknown[]                                   after: [number, string]

StrictRow<DB, 'insert into users(id, name) values ($1, $2) returning id'>
// before: QueryTypeError<'unknown table: users(id,'>  after: { id: number }
```

`WordAfterKeyword<S, 'into'>` takes the first space-delimited word, and `CleanTargetIdentifier` didn't split on `(`. `InsertColumnList` then dropped that same word and looked for a `(` in `name) values ...`, found none, and fell through to the untyped parameter fallback.

## The change

- `BeforeParen` in `src/string.ts` cuts an identifier at its first `(`; `CleanTargetIdentifier` runs it before de-qualifying and unquoting, so `public.users(id,` and `"users"(id,` resolve too.
- `RestAfterTarget` in `src/params.ts` starts the column-list scan at that paren when the target has one glued on, instead of dropping the first word. The spaced form takes the same path it always did.

## Verification

- 4 tsconfigs green with 7 new type assertions (`tests/insert-target.test-d.ts`), 187 runtime tests green.
- Every new assertion was confirmed red against the pre-fix parser.
- Type budget: 170,219 instantiations, 92% of 185,000 (was 170,045). Ceiling unchanged.
- Under VERSIONING.md this is *a query that failed to parse now parses and types correctly* → **minor**. Worth calling out in the release notes: a call site that was passing arbitrary values through the old `unknown[]` tuple now gets the real parameter types checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
