### PR TITLE
fix(parse): keep the alias of an UPDATE/DELETE/MERGE target

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ this.**
 | Trailing clauses (ignored) | `... where active = true order by id limit 10` |
 | Aggregates / functions | `select count(*) as total, lower(name) from users` |
 | `RETURNING` | `insert into users (name) values ($1) returning id` |
+| Aliased write target | `update users u set name = $1 where u.id = $2 returning u.name` |
 | Nullable columns | `bio: string \| null` → `{ bio: string \| null }` |
 | Joins | `select u.name, p.title from users u join posts p on u.id = p.user_id` |
 | `LEFT`/`RIGHT`/`FULL` nullability | outer-joined side(s) become `T \| null` |

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -122,13 +122,6 @@ export type AfterKeyword<S extends string, Keyword extends string> =
       : AfterKeyword<Tail, Keyword>
     : never;
 
-type WordAfterKeyword<S extends string, Keyword extends string> =
-  AfterKeyword<S, Keyword> extends infer Rest
-    ? Rest extends string
-      ? FirstWord<Rest>
-      : ''
-    : '';
-
 type ReturningColumns<S extends string> = AfterKeyword<S, 'returning'> extends infer Rest
   ? Rest extends string
     ? Rest
@@ -182,9 +175,70 @@ type ReturningOrOutputColumns<S extends string, StopKeyword extends string> = Re
 
 type CleanTargetIdentifier<Raw extends string> = Unquote<StripQualifier<BeforeParen<Raw>>>;
 
-type SingleSource<Table extends string> = [
-  { table: CleanTargetIdentifier<Table>; alias: CleanTargetIdentifier<Table>; nullable: false },
-];
+// The word after a write target is an alias unless it opens the next clause.
+// `UPDATE t alias`, `DELETE FROM t AS alias` and `MERGE INTO t AS alias` are
+// all legal - the README's own MERGE example uses `as target` - and the alias
+// used to be dropped, so every reference through it failed to resolve
+// (issue #246).
+type WriteTargetBoundary =
+  | 'set'
+  | 'where'
+  | 'values'
+  | 'value'
+  | 'returning'
+  | 'output'
+  | 'using'
+  | 'from'
+  | 'select'
+  | 'on'
+  | 'default'
+  | 'with'
+  | 'union'
+  | 'order'
+  | 'group'
+  | 'having'
+  | 'limit'
+  | 'offset'
+  | 'when';
+
+type IsWriteTargetBoundary<Word extends string> = Lowercase<Word> extends WriteTargetBoundary
+  ? true
+  : false;
+
+// CleanTargetIdentifier resolves a token that opens a column list (`(id,`) to
+// the empty string, which is exactly the "no alias here" answer this needs.
+type AliasAfterTarget<Rest extends string> = Trim<Rest> extends ''
+  ? ''
+  : FirstWord<Trim<Rest>> extends infer Next extends string
+    ? IsKeyword<Next, 'as'> extends true
+      ? CleanTargetIdentifier<FirstWord<Trim<DropFirstWord<Trim<Rest>>>>>
+      : IsWriteTargetBoundary<Next> extends true
+        ? ''
+        : CleanTargetIdentifier<Next>
+    : '';
+
+type SingleSource<After extends string> = CleanTargetIdentifier<
+  FirstWord<Trim<After>>
+> extends infer Table extends string
+  ? FirstWord<Trim<After>> extends `${string}(${string}`
+    ? // A column list glued to the target (`users(id, name)`) leaves no room
+      // for an alias: Postgres spells that form `insert into t AS u (id)`.
+      [{ table: Table; alias: Table; nullable: false }]
+    : AliasAfterTarget<DropFirstWord<Trim<After>>> extends infer Alias extends string
+      ? [{ table: Table; alias: Alias extends '' ? Table : Alias; nullable: false }]
+      : [{ table: Table; alias: Table; nullable: false }]
+  : never;
+
+// AfterKeyword resolves to never when the keyword is absent; SingleSource
+// needs a string either way.
+type RestAfterKeyword<S extends string, Keyword extends string> = AfterKeyword<
+  S,
+  Keyword
+> extends infer Rest
+  ? Rest extends string
+    ? Rest
+    : ''
+  : '';
 
 // Postgres/SQLite's `UPDATE t SET ... FROM other WHERE ...` and Postgres's
 // `DELETE FROM t USING other WHERE ...` both introduce an extra table that
@@ -255,7 +309,7 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
     : IsKeyword<Keyword, 'insert'> extends true
       ? {
           columns: ReturningOrOutputColumns<S, 'values'>;
-          sources: SingleSource<WordAfterKeyword<S, 'into'>>;
+          sources: SingleSource<RestAfterKeyword<S, 'into'>>;
           whereText: '';
           fromText: '';
         }
@@ -263,7 +317,7 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
         ? {
             columns: ReturningOrOutputColumns<S, 'where'>;
             sources: [
-              ...SingleSource<WordAfterKeyword<S, 'update'>>,
+              ...SingleSource<RestAfterKeyword<S, 'update'>>,
               ...ExtraSourcesAfterKeyword<S, 'from'>,
             ];
             whereText: ExtractUpdateDeleteWhereText<S>;
@@ -273,7 +327,7 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
           ? {
               columns: ReturningOrOutputColumns<S, 'where'>;
               sources: [
-                ...SingleSource<WordAfterKeyword<S, 'from'>>,
+                ...SingleSource<RestAfterKeyword<S, 'from'>>,
                 ...ExtraSourcesAfterKeyword<S, 'using'>,
               ];
               whereText: ExtractUpdateDeleteWhereText<S>;
@@ -287,7 +341,7 @@ type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Key
                 // for INSERT/UPDATE/DELETE. Requires an explicit INTO; MERGE
                 // without it (legal but rare in practice) isn't recognized.
                 columns: StripPseudoTableQualifiers<OutputClauseColumnsToEnd<S>>;
-                sources: SingleSource<WordAfterKeyword<S, 'into'>>;
+                sources: SingleSource<RestAfterKeyword<S, 'into'>>;
                 whereText: '';
                 fromText: '';
               }

--- a/tests/dml-alias.test-d.ts
+++ b/tests/dml-alias.test-d.ts
@@ -1,0 +1,104 @@
+import type { Params, Row, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  orders: { id: number; user_id: number; total: number };
+}
+
+// Regression for #246: the alias of a write target was replaced by the table
+// name, so every reference through it failed to resolve.
+type UpdateAliasResolves = Expect<
+  Equal<StrictRow<DB, 'update users u set name = $1 where u.id = $2 returning u.id'>, { id: number }>
+>;
+
+type UpdateAsAliasResolves = Expect<
+  Equal<
+    StrictRow<DB, 'update users as u set name = $1 where u.id = $2 returning u.name'>,
+    { name: string }
+  >
+>;
+
+type UpdateAliasTypesItsParams = Expect<
+  Equal<Params<DB, 'update users as u set name = $1 where u.id = $2'>, [string, number]>
+>;
+
+type UpdateAliasLooseRow = Expect<
+  Equal<Row<DB, 'update users u set name = $1 returning u.name'>, { name: string }>
+>;
+
+type DeleteAliasResolves = Expect<
+  Equal<StrictRow<DB, 'delete from users as u where u.id = $1 returning u.id'>, { id: number }>
+>;
+
+type DeleteBareAliasResolves = Expect<
+  Equal<StrictRow<DB, 'delete from users u where u.id = $1 returning u.id'>, { id: number }>
+>;
+
+type MergeAliasResolves = Expect<
+  Equal<
+    StrictRow<
+      DB,
+      'merge into users as target using orders o on o.user_id = target.id when matched then update set name = $1 output inserted.id, target.name'
+    >,
+    { id: number; name: string }
+  >
+>;
+
+type InsertAliasResolves = Expect<
+  Equal<
+    StrictRow<DB, 'insert into users as u (id, name) values ($1, $2) returning u.id'>,
+    { id: number }
+  >
+>;
+
+// The table name keeps resolving whether or not an alias was written, and a
+// target with no alias is unchanged.
+type TableNameStillResolvesAlongsideTheAlias = Expect<
+  Equal<
+    StrictRow<DB, 'update users u set name = $1 where users.id = $2 returning users.name'>,
+    { name: string }
+  >
+>;
+
+type NoAliasIsUnchanged = Expect<
+  Equal<StrictRow<DB, 'update users set name = $1 where id = $2 returning id'>, { id: number }>
+>;
+
+type NoAliasDeleteIsUnchanged = Expect<
+  Equal<StrictRow<DB, 'delete from users where id = $1 returning name'>, { name: string }>
+>;
+
+type GluedColumnListIsNotAnAlias = Expect<
+  Equal<StrictRow<DB, 'insert into users(id, name) values ($1, $2) returning id'>, { id: number }>
+>;
+
+type UpdateFromKeepsTheExtraSource = Expect<
+  Equal<
+    StrictRow<
+      DB,
+      'update users u set name = $1 from orders o where o.user_id = u.id returning u.id, o.total'
+    >,
+    { id: number; total: number }
+  >
+>;
+
+export type Assertions = [
+  UpdateAliasResolves,
+  UpdateAsAliasResolves,
+  UpdateAliasTypesItsParams,
+  UpdateAliasLooseRow,
+  DeleteAliasResolves,
+  DeleteBareAliasResolves,
+  MergeAliasResolves,
+  InsertAliasResolves,
+  TableNameStillResolvesAlongsideTheAlias,
+  NoAliasIsUnchanged,
+  NoAliasDeleteIsUnchanged,
+  GluedColumnListIsNotAnAlias,
+  UpdateFromKeepsTheExtraSource,
+];


### PR DESCRIPTION
Fixes #246.

`SingleSource` set `alias` to the table name, so an aliased write target lost its alias:

```ts
StrictRow<DB, 'update users u set name = $1 where u.id = $2 returning u.id'>
// before: QueryTypeError<'unknown alias: u'>   after: { id: number }

Row<DB, 'update users u set name = $1 returning u.name'>
// before: { name: unknown }                    after: { name: string }

Params<DB, 'update users as u set name = $1 where u.id = $2'>
// before: [string, unknown]                    after: [string, number]
```

`UPDATE t alias`, `DELETE FROM t AS alias` and `MERGE INTO t AS alias` are all legal — the README's MERGE example uses `as target` — and non-strict mode was the worse half: no error, just `unknown` where the real type belonged.

## The change

The word after the target is read as the alias unless it opens the next clause (`set`, `where`, `using`, `values`, `returning`, `output`, `select`, `on`, `default`, …). The `AS` form is handled like SELECT sources already handle it, and a column list glued to the target (`users(id, name)`) leaves no room for an alias — which is what Postgres's own `insert into t AS u (id)` ordering says too.

`FindSourceByName` matches on either the alias or the table name, so `update users u ... where users.id = $1` keeps resolving through the table name as well. `WordAfterKeyword` had no callers left and is gone.

## Verification

- 4 tsconfigs green with 13 new assertions (`tests/dml-alias.test-d.ts`), covering UPDATE/DELETE/MERGE/INSERT aliases, the unaliased forms, the glued column list, and `UPDATE ... FROM` with an alias on both sides. 187 runtime tests green.
- Every new assertion was confirmed red against the pre-fix parser.
- Type budget: 171,154 instantiations, **93%** of 185,000 (was 170,219 / 92%). Still under; the ceiling is left where it is.
- Under VERSIONING.md: *a query that failed to parse now parses and types correctly* and *a column that resolved to `unknown` now resolves to a concrete type* → **minor**.
- README: the supported-subset table gains the aliased write target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
