### PR TITLE
fix(params): give a placeholder inside a call its parameter slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,7 +981,12 @@ This is a focused tool for the common read path, not a full SQL grammar:
   column name (e.g. both have `id`), the types are intersected rather than kept
   separate. Alias the columns to keep them distinct.
 - **Typed parameters need spaced operators.** `where id = $1` is typed;
-  `where id=$1` is not. `INSERT ... VALUES` parameters are matched
+  `where id=$1` is not. A placeholder inside a call is typed
+  (`lower($1)`, `coalesce($1, 0)`), but two placeholders glued into one
+  space-delimited token (`coalesce($1,$2)`) are not — write the comma with a
+  space. `= any($1)` and `= all($1)` compare against the whole list, so their
+  slot is an array of the column's type (`number[]`, not `number`).
+  `INSERT ... VALUES` parameters are matched
   positionally against the INSERT's column list — `insert into t (a, b)
   values ($1, $2)` types `$1`/`$2` as `a`/`b`; without an explicit column
   list they fall back to a flexible `unknown[]`. Placeholders inside a

--- a/src/params.ts
+++ b/src/params.ts
@@ -20,6 +20,7 @@ import type {
   MultipleStatementsError,
 } from './parse.js';
 import type { ParseWithClause } from './cte.js';
+import type { FunctionName } from './functions.js';
 
 type Operator = '=' | '<>' | '!=' | '<' | '>' | '<=' | '>=';
 
@@ -54,8 +55,32 @@ type StripTrailingListPunctuation<S extends string> = S extends `${infer Rest})`
 // binding by position (issue #228).
 type StripCast<S extends string> = S extends `${infer Before}::${string}` ? Before : S;
 
+type AfterLastOpenParen<S extends string> = S extends `${string}(${infer After}`
+  ? After extends `${string}(${string}`
+    ? AfterLastOpenParen<After>
+    : After
+  : S;
+
+// A placeholder is routinely written inside a call - `lower($1)`, `any($1)`,
+// `coalesce($1, 0)`. The scan splits on spaces, so the call is one token and
+// stripping only the trailing `)` left `lower($1`, which matches nothing: the
+// placeholder vanished and the tuple had no slot for a value the driver still
+// demands (issue #244).
+//
+// Two placeholders inside a single token (`f($1,$2)`, written without the
+// space) cannot both get a slot from a one-token scan, so that token is left
+// alone rather than handed a made-up single slot - the same "write it with
+// spaces" rule the README already states for `where id=$1`.
+type StripCallWrapper<S extends string> = S extends `${string}(${string}`
+  ? AfterLastOpenParen<S> extends infer Inner extends string
+    ? Inner extends `${string},${string}`
+      ? S
+      : Inner
+    : S
+  : S;
+
 export type CleanScanToken<S extends string> = StripCast<
-  StripTrailingListPunctuation<StripLeadingParens<S>>
+  StripCallWrapper<StripTrailingListPunctuation<StripLeadingParens<S>>>
 >;
 
 export type CleanColumnToken<S extends string> = StripLeadingParens<S> extends infer Stripped extends string
@@ -161,15 +186,28 @@ type SetSlot<
     ? [Head & Type, ...TupleRest]
     : [Type];
 
+// `= any($1)` / `= all($1)` compare the column against a whole array, so the
+// bound value is an array of the column's type, not one of them. Without this
+// the fix for #244 would hand the caller a confidently wrong element type for
+// the idiomatic Postgres way to bind a list.
+type ArrayWrappingFunction = 'any' | 'all' | 'some';
+
+type WrapArrayArgument<T, Token extends string> = Token extends `${string}(${string}`
+  ? Lowercase<FunctionName<Token>> extends ArrayWrappingFunction
+    ? T[]
+    : T
+  : T;
+
 type ParamType<
   DB extends SchemaLike,
   Sources extends Source[],
   Column extends string,
   Op extends string,
+  Token extends string = '',
 > = Lowercase<Op> extends ForcedNumberKeyword
   ? number
   : IsOperator<Op> extends true
-    ? ResolveColumnLoose<DB, Sources, Column>
+    ? WrapArrayArgument<ResolveColumnLoose<DB, Sources, Column>, Token>
     : unknown;
 
 type AddParam<
@@ -225,7 +263,7 @@ type ScanParamsRaw<
   ? IsPlaceholder<Head> extends true
     ? AddParam<
         Head,
-        ParamType<DB, Sources, PrevPrev, Prev>,
+        ParamType<DB, Sources, PrevPrev, Prev, Head>,
         Indexed,
         Sequential,
         SequentialNames
@@ -242,7 +280,7 @@ type ScanParamsRaw<
   : S extends ''
     ? { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames }
     : IsPlaceholder<S> extends true
-      ? AddParam<S, ParamType<DB, Sources, PrevPrev, Prev>, Indexed, Sequential, SequentialNames>
+      ? AddParam<S, ParamType<DB, Sources, PrevPrev, Prev, S>, Indexed, Sequential, SequentialNames>
       : { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames };
 
 type ScanParams<

--- a/tests/params-in-call.test-d.ts
+++ b/tests/params-in-call.test-d.ts
@@ -1,0 +1,87 @@
+import type { Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; created_at: Date };
+}
+
+// Regression for #244: the scan splits on spaces, so a placeholder written
+// inside a call was part of one unrecognized token and got no tuple slot -
+// the query could not be called with the value the driver demands.
+type PlaceholderInsideAFunctionCall = Expect<
+  Equal<Params<DB, 'select id from users where lower(name) = lower($1)'>, [string]>
+>;
+
+type PlaceholderInsideANestedCall = Expect<
+  Equal<Params<DB, 'select id from users where name = lower(trim($1))'>, [string]>
+>;
+
+type PlaceholderInsideCoalesce = Expect<
+  Equal<Params<DB, 'select id from users where id = coalesce($1, 0)'>, [number]>
+>;
+
+type NamedPlaceholderInsideACall = Expect<
+  Equal<Params<DB, 'select id from users where id = coalesce(@id, 0)'>, [number]>
+>;
+
+type QuestionMarkInsideACall = Expect<
+  Equal<Params<DB, 'select id from users where name = lower(?)'>, [string]>
+>;
+
+// `= any($1)` binds the whole list, so the slot is an array of the column's
+// type rather than one element of it.
+type AnyBindsAnArray = Expect<
+  Equal<Params<DB, 'select id from users where id = any($1)'>, [number[]]>
+>;
+
+type AnyWithACastBindsAnArray = Expect<
+  Equal<Params<DB, 'select id from users where id = any($1::int[])'>, [number[]]>
+>;
+
+type AllBindsAnArray = Expect<
+  Equal<Params<DB, 'select id from users where id = all($1)'>, [number[]]>
+>;
+
+// A call is not an array wrapper just because it holds the placeholder.
+type OtherCallsKeepTheColumnType = Expect<
+  Equal<Params<DB, 'select id from users where created_at = date_trunc($1)'>, [Date]>
+>;
+
+// Two placeholders glued into one token stay outside the typed set, matching
+// the documented "write it with spaces" rule.
+type TwoPlaceholdersInOneTokenAreLeftAlone = Expect<
+  Equal<Params<DB, 'select id from users where id = coalesce($1,$2)'>, []>
+>;
+
+// Shapes that already worked keep working.
+type ParenthesizedListStillBinds = Expect<
+  Equal<Params<DB, 'select id from users where id in ($1, $2)'>, [number, number]>
+>;
+
+type StarArgumentIsNotAPlaceholder = Expect<
+  Equal<Params<DB, 'select count(*) as total from users where id = $1'>, [number]>
+>;
+
+type PlainCallWithoutAPlaceholder = Expect<
+  Equal<Params<DB, 'select id from users where lower(name) = lower(name)'>, []>
+>;
+
+export type Assertions = [
+  PlaceholderInsideAFunctionCall,
+  PlaceholderInsideANestedCall,
+  PlaceholderInsideCoalesce,
+  NamedPlaceholderInsideACall,
+  QuestionMarkInsideACall,
+  AnyBindsAnArray,
+  AnyWithACastBindsAnArray,
+  AllBindsAnArray,
+  OtherCallsKeepTheColumnType,
+  TwoPlaceholdersInOneTokenAreLeftAlone,
+  ParenthesizedListStillBinds,
+  StarArgumentIsNotAPlaceholder,
+  PlainCallWithoutAPlaceholder,
+];


### PR DESCRIPTION
Fixes #244.

`ScanParamsRaw` splits the query on spaces, so `lower($1)` is a single token, and `CleanScanToken` only stripped the trailing `)` — leaving `lower($1`, which matches no placeholder shape. The slot disappeared while the driver still demanded the value, so the correct call stopped compiling:

```ts
Params<DB, 'select id from users where lower(name) = lower($1)'>  // [] → [string]
Params<DB, 'select id from users where id = coalesce($1, 0)'>     // [] → [number]
Params<DB, 'select id from users where id = any($1)'>             // [] → [number[]]
```

`= any($1)` is the idiomatic Postgres way to bind an array, and it could not be written at all — `db.query(sql, ids)` reported *Expected 1 arguments, but got 2*.

## The change

- `CleanScanToken` unwraps a call token down to the text after its **last** open paren, so `lower($1)`, `coalesce($1, 0)` and `lower(trim($1))` all reach the placeholder branch. A token with no paren takes the same path as before.
- Two placeholders glued into one token (`coalesce($1,$2)`, no space) are left alone instead of getting one invented slot — the same "write it with spaces" rule the README already states for `where id=$1`. The README limitation now says so explicitly.
- `= any($1)` / `= all($1)` / `= some($1)` compare the column against the whole list, so their slot is `T[]`. Without that, this fix would have swapped an uncallable query for a confidently wrong argument type.

## Verification

- 4 tsconfigs green with 13 new assertions (`tests/params-in-call.test-d.ts`), including the array wrappers, a cast inside one (`any($1::int[])`), a non-wrapper call keeping the column type, and the shapes that already worked. 187 runtime tests green.
- Every new assertion was confirmed red against the pre-fix scanner.
- Type budget: 173,059 instantiations, **94%** of 185,000 (was 171,154 / 93%). Under budget, ceiling unchanged.
- Under VERSIONING.md: *a query that failed to parse now parses and types correctly* → **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
