### PR TITLE
fix(parse): keep a quoted identifier holding a space in one piece

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,7 +926,7 @@ this.**
 | Joins | `select u.name, p.title from users u join posts p on u.id = p.user_id` |
 | `LEFT`/`RIGHT`/`FULL` nullability | outer-joined side(s) become `T \| null` |
 | Qualified / mixed star | `select u.*, p.title from ...`, `select *, extra from ...` |
-| Quoted / schema-qualified ids | `select "id" from public."users"` |
+| Quoted / schema-qualified ids | `select "id" from public."users"`, `select "first name" from [Order Details]` |
 | Trailing semicolon | `select id from users;` |
 | Typed parameters | `where id = $1` → `query(sql, id: number)` |
 | Strict mode | `{ strict: true }` → unknown column becomes a `QueryTypeError` (`SELECT` list, `WHERE`, and `JOIN ... ON`) |
@@ -998,8 +998,10 @@ This is a focused tool for the common read path, not a full SQL grammar:
   a repeated `$n` occupies a single slot.
 - **Quoted identifiers** use `"..."` (standard), `[...]` (SQL Server), or
   `` `...` `` (MySQL — escape the backtick with `\`` inside the template
-  literal). Schema-qualified tables (`public.users`) resolve by their final
-  segment (`users`).
+  literal). A quoted name may contain spaces (`"first name"`,
+  `[Order Details]`) — which is what quoting is for, and what `owlsql
+  generate` writes when a real column is named that way. Schema-qualified
+  tables (`public.users`) resolve by their final segment (`users`).
 - **`TOP` supports a plain count, `TOP N PERCENT`, `TOP N WITH TIES`, and
   `TOP N PERCENT WITH TIES`** (`PERCENT` before `WITH TIES`, the only order
   T-SQL accepts) — none of

--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -7,7 +7,13 @@ const TABLE_COUNT = 100;
 const FILLER_COLUMNS = 6;
 const SHAPE_REPEATS = 4;
 
-const MAX_INSTANTIATIONS = 185_000;
+// Raised from 185,000 for #247: a quoted identifier may hold a space, and
+// finding out whether one does costs a full-string scan per query - roughly
+// 4% on every query, quoted or not, since the only way to skip the rewrite is
+// to look for a quote first. The alternative was leaving `"first name"` and
+// `[Order Details]` unusable, including in schemas `owlsql generate` writes
+// itself.
+const MAX_INSTANTIATIONS = 195_000;
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PERF_DIR = join(ROOT, 'tests', 'perf');

--- a/src/string.ts
+++ b/src/string.ts
@@ -171,9 +171,50 @@ export type StripCommentsAndMaskLiterals<
               ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${Head}`>
               : Accumulated;
 
+// Everything downstream splits the query on spaces, so a quoted identifier
+// holding one - `"first name"`, `[Order Details]` - was torn in half: the
+// column key came out as `name"`, the table as `[Order`, and strict mode
+// reported both as unknown (issue #247). Quoting exists precisely for those
+// names, and `owlsql generate` emits them itself.
+//
+// The space is swapped for a character SQL text cannot contain, so the
+// identifier survives every splitter as one token, and Unquote - the single
+// place a quoted name is finally read - puts it back.
+type QuotedSpace = '\u0000';
+
+type ReplaceSpaces<S extends string> = S extends `${infer Before} ${infer After}`
+  ? ReplaceSpaces<`${Before}${QuotedSpace}${After}`>
+  : S;
+
+type EscapeQuotedSpacesWith<
+  S extends string,
+  Open extends string,
+  Close extends string,
+> = S extends `${infer Before}${Open}${infer AfterOpen}`
+  ? AfterOpen extends `${infer Body}${Close}${infer Rest}`
+    ? `${Before}${Open}${ReplaceSpaces<Body>}${Close}${EscapeQuotedSpacesWith<Rest, Open, Close>}`
+    : S
+  : S;
+
+// Gated on the one cheap check, since most queries quote nothing: without it
+// every query pays three template splits for a rewrite that cannot apply.
+type EscapeQuotedSpaces<S extends string> = HasQuoteChar<S> extends false
+  ? S
+  : EscapeQuotedSpacesWith<
+      EscapeQuotedSpacesWith<EscapeQuotedSpacesWith<S, '[', ']'>, '`', '`'>,
+      '"',
+      '"'
+    >;
+
 export type Normalize<S extends string> = Trim<
-  CollapseSpaces<WhitespaceToSpace<RemoveTrailingSemicolons<StripCommentsAndMaskLiterals<S>>>>
+  CollapseSpaces<
+    EscapeQuotedSpaces<WhitespaceToSpace<RemoveTrailingSemicolons<StripCommentsAndMaskLiterals<S>>>>
+  >
 >;
+
+type UnescapeSpaces<S extends string> = S extends `${infer Before}${QuotedSpace}${infer After}`
+  ? UnescapeSpaces<`${Before} ${After}`>
+  : S;
 
 type HasQuoteChar<S extends string> = S extends
   | `${string}"${string}`
@@ -216,11 +257,11 @@ export type HasNonTrailingSemicolon<S extends string> =
     : false;
 
 export type Unquote<S extends string> = S extends `"${infer Inner}"`
-  ? Inner
+  ? UnescapeSpaces<Inner>
   : S extends `[${infer Inner}]`
-    ? Inner
+    ? UnescapeSpaces<Inner>
     : S extends `\`${infer Inner}\``
-      ? Inner
+      ? UnescapeSpaces<Inner>
       : S;
 
 export type FirstWord<S extends string> = S extends `${infer Head} ${string}`

--- a/tests/quoted-identifier-spaces.test-d.ts
+++ b/tests/quoted-identifier-spaces.test-d.ts
@@ -1,0 +1,96 @@
+import type { Params, QueryTypeError, Row, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; 'first name': string };
+  'Order Details': { id: number; qty: number; 'unit price': number };
+}
+
+// Regression for #247: every splitter in the parser works on spaces, so a
+// quoted identifier holding one was torn in half - the row key came out as
+// `name"` and strict mode reported `unknown column: "first`.
+type QuotedColumnWithASpaceProjects = Expect<
+  Equal<Row<DB, 'select "first name" from users'>, { 'first name': string }>
+>;
+
+type QuotedColumnWithASpaceIsKnownInStrictMode = Expect<
+  Equal<StrictRow<DB, 'select "first name" from users'>, { 'first name': string }>
+>;
+
+type QuotedColumnWithASpaceInWhere = Expect<
+  Equal<StrictRow<DB, 'select id from users where "first name" = $1'>, { id: number }>
+>;
+
+type QuotedColumnWithASpaceTypesItsParameter = Expect<
+  Equal<Params<DB, 'select id from users where "first name" = $1'>, [string]>
+>;
+
+type QuotedTableWithASpace = Expect<
+  Equal<StrictRow<DB, 'select qty from [Order Details]'>, { qty: number }>
+>;
+
+type QuotedTableWithASpaceAndAnAlias = Expect<
+  Equal<StrictRow<DB, 'select d.qty from [Order Details] d'>, { qty: number }>
+>;
+
+type QualifiedQuotedColumnWithASpace = Expect<
+  Equal<
+    StrictRow<DB, 'select d."unit price" from [Order Details] d'>,
+    { 'unit price': number }
+  >
+>;
+
+type QuotedAliasWithASpace = Expect<
+  Equal<Row<DB, 'select id as "user id" from users'>, { 'user id': number }>
+>;
+
+type BacktickColumnWithASpace = Expect<
+  Equal<Row<DB, 'select `first name` from users'>, { 'first name': string }>
+>;
+
+type StarStillMergesTheQuotedTable = Expect<
+  Equal<
+    StrictRow<DB, 'select * from [Order Details]'>,
+    { id: number; qty: number; 'unit price': number }
+  >
+>;
+
+type QuotedColumnWithASpaceInAJoin = Expect<
+  Equal<
+    StrictRow<DB, 'select u."first name", d.qty from users u join [Order Details] d on d.id = u.id'>,
+    { 'first name': string; qty: number }
+  >
+>;
+
+// A quoted name without a space keeps behaving exactly as before, and a
+// misspelled one is still reported.
+type SingleWordQuotedIdentifierIsUnchanged = Expect<
+  Equal<StrictRow<DB, 'select "id" from "users"'>, { id: number }>
+>;
+
+type UnknownQuotedColumnStillErrors = Expect<
+  Equal<
+    StrictRow<DB, 'select "last name" from users'>,
+    QueryTypeError<'unknown column: last name'>
+  >
+>;
+
+export type Assertions = [
+  QuotedColumnWithASpaceProjects,
+  QuotedColumnWithASpaceIsKnownInStrictMode,
+  QuotedColumnWithASpaceInWhere,
+  QuotedColumnWithASpaceTypesItsParameter,
+  QuotedTableWithASpace,
+  QuotedTableWithASpaceAndAnAlias,
+  QualifiedQuotedColumnWithASpace,
+  QuotedAliasWithASpace,
+  BacktickColumnWithASpace,
+  StarStillMergesTheQuotedTable,
+  QuotedColumnWithASpaceInAJoin,
+  SingleWordQuotedIdentifierIsUnchanged,
+  UnknownQuotedColumnStillErrors,
+];


### PR DESCRIPTION
Fixes #247.

Every splitter in the parser works on spaces, so a quoted identifier containing one was torn in half:

```ts
Row<DB, 'select "first name" from users'>              // { 'name"': unknown }  →  { 'first name': string }
StrictRow<DB, 'select "first name" from users'>        // unknown column: "first
StrictRow<DB, 'select id from users where "first name" = $1'>  // unknown column: name"
StrictRow<DB, 'select qty from [Order Details]'>       // unknown table: [Order
Params<DB, 'select id from users where "first name" = $1'>     // [unknown]  →  [string]
```

Quoting exists precisely for those names, and this isn't hypothetical: `renderKey` in the CLI's codegen JSON-quotes any name that isn't a plain identifier, so `owlsql generate` against Northwind or any legacy schema wrote a `DB` type its own parser couldn't query.

## The change

`Normalize` swaps the spaces *inside* a quoted identifier for a character SQL text cannot contain, so the name survives every splitter as a single token. `Unquote` — the one place a quoted name is finally read — puts them back, so schema lookups and `QueryTypeError` messages both carry the real name. All three quoting styles are handled (`"…"`, `[…]`, `` `…` ``).

## The cost

The rewrite is gated on one "is there a quote at all" test, and that test *is* the cost: you cannot know whether a query quotes anything without scanning it. Every query pays about 4% more instantiations, quoted or not.

- Before this PR: 173,726 (94% of 185,000)
- After: **181,194**, and the budget moves to **195,000** with the reasoning recorded beside it in `scripts/type-budget.mjs` (93% used, ~7% headroom restored).

I looked at paying only inside the affected splitters instead. `ParseColumnEntry` and the FROM segment scanner could each check locally, but the `WHERE` scan and the parameter scan split the *whole* query, so they'd need the same full-string knowledge anyway — more total work, in more places, for the same answer.

## Verification

- 4 tsconfigs green with 13 new assertions (`tests/quoted-identifier-spaces.test-d.ts`): projection, strict mode, `WHERE`, params, a quoted table with and without an alias, a qualified quoted column, a quoted alias, backticks, `select *`, a join across both, plus locks that a single-word quoted identifier is unchanged and that a misspelled quoted column still errors — with the real spelling in the message. 187 runtime tests green.
- Every new assertion was confirmed red against the pre-fix parser.
- Under VERSIONING.md: *a query that failed to parse now parses and types correctly* → **minor**. A row that used to carry a junk key (`name"`) now carries the real one, which is the point.
- README: the subset table and the quoted-identifier limitation both say spaces are fine now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
