### PR TITLE
ci: publish from a workflow with npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+# Publishes @owlsql/core to npm without a token: the OIDC identity of this
+# workflow is what the registry trusts, configured once on npmjs.com under the
+# package's "Trusted publisher" settings. That is also what makes a token
+# unnecessary here - npm is restricting 2FA-bypassing tokens for direct
+# publishing, and there is no secret in this repository to leak.
+#
+# Run it from the Actions tab (or let a published GitHub Release trigger it)
+# once the version bump is on master. `npm publish` runs prepublishOnly, so
+# the type tests, the runtime tests and the build all have to pass first.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required for trusted publishing: the job mints a short-lived OIDC token
+  # that npm verifies against the publisher configured for the package.
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      # Trusted publishing needs npm 11.5.1 or newer; Node 22 still ships an
+      # older npm, so the runner's npm is upgraded rather than the toolchain.
+      - run: npm install -g npm@latest
+
+      - run: npm ci
+
+      - run: npm publish --provenance --access public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,11 +107,23 @@ If your change legitimately costs more, raise the budget in the same commit rath
 
 ## Publishing
 
-Both packages ship compiled JavaScript and declarations from their own `dist/`, wired into `prepublishOnly`:
+Both packages ship compiled JavaScript and declarations from their own `dist/`, wired into `prepublishOnly`.
+
+The library is published by the [Release workflow](.github/workflows/release.yml) rather than from a laptop, using npm's trusted publishing: the workflow's OIDC identity is what the registry trusts, so there is no npm token in this repository to leak or rotate. npm is restricting tokens that bypass 2FA for direct publishing, which is the other half of the reason.
 
 ```bash
 npm version <patch|minor|major>
-npm publish            # runs test:types, then build, then publishes dist/
+git push --follow-tags origin master
+```
+
+Then run **Actions → Release → Run workflow**, or publish a GitHub Release for the tag — either triggers it. The workflow runs `npm publish --provenance`, and `prepublishOnly` puts the type tests, the runtime tests and the build in front of that, so a red build cannot reach the registry.
+
+This needs the package's *Trusted publisher* to be configured once on npmjs.com (package → Settings → Trusted publisher → GitHub Actions, repository `tiagolauer/OwlSQL`, workflow `release.yml`).
+
+Publishing by hand still works if you own the package and pass a real one-time password, which npm now requires for a direct publish:
+
+```bash
+npm publish --otp=<code from your authenticator>
 ```
 
 The editor plugin publishes separately, on its own version, from its own directory:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@owlsql/core",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@owlsql/core",
-      "version": "0.1.8",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "ts-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owlsql/core",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "Parse SQL in TypeScript template literal types and infer the result shape from your schema — no codegen, no ORM.",
   "type": "module",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "types": "./dist/index.d.ts",
   "bin": {
-    "owlsql": "./dist/cli/index.js"
+    "owlsql": "dist/cli/index.js"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Publishing 0.2.0 from a laptop is currently impossible, and not for a reason a retry fixes:

- `npm owner ls @owlsql/core` → `tiagolauer`; `npm access list collaborators` → `read-write`; `npm org ls owlsql` → `tiagolauer - owner`; email verified.
- A granular token, a replacement granular token, and a fresh `npm login` web session all return the same bare `403 Forbidden - PUT /@owlsql%2fcore`.
- `npm login` itself prints the reason: *npm tokens that bypass 2FA are being restricted for account changes and direct publishing*.

Trusted publishing takes the credential out of the loop: the workflow's OIDC identity is what the registry verifies, so there is no token in this repository to leak, rotate, or have refused.

## What this adds

`.github/workflows/release.yml` — manual (`workflow_dispatch`) or triggered by publishing a GitHub Release:

- `permissions: id-token: write` for the OIDC mint, `contents: read` otherwise.
- npm upgraded to latest on the runner, since trusted publishing needs npm ≥ 11.5.1 and Node 22 ships older.
- `npm publish --provenance --access public`. `prepublishOnly` still runs the type tests, the runtime tests and the build, so a red build cannot reach the registry — and provenance means the tarball is linked to the commit and workflow that built it.

CONTRIBUTING's Publishing section is rewritten around it, including the one-time setup on npmjs.com and the `npm publish --otp=<code>` form for a hand publish.

## One-time setup before this can run

npmjs.com → `@owlsql/core` → Settings → **Trusted publisher** → GitHub Actions:

| field | value |
| --- | --- |
| Organization or user | `tiagolauer` |
| Repository | `OwlSQL` |
| Workflow filename | `release.yml` |
| Environment | *(leave empty)* |

## Also here

`bin.owlsql` loses its leading `./` — npm rewrote it on every publish and warned about it each time (`"bin[owlsql]" script name was cleaned`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
