### PR TITLE
fix(parse): normalize whitespace one character at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ A second pass over the same ground, once those landed, found ten more; same rule
 - Postgres's `@>`, `<@`, `?|` and `?&` are operators, not placeholders. `where tags @> $1` used to demand an extra argument and fail the placeholder-style check against a dollar executor ([#249](https://github.com/tiagolauer/OwlSQL/issues/249)).
 - The editor plugin resolves table and column names case-insensitively, the way the type layer always has. `select id from USERS` type-checked fine and still drew a warning ([#250](https://github.com/tiagolauer/OwlSQL/issues/250)).
 - A password containing an unencoded `@` (`mysql://root:p@ss@host/db`, which every driver accepts) is redacted whole. The pattern stopped at the first `@` and printed the rest of the password ([#251](https://github.com/tiagolauer/OwlSQL/issues/251)).
+- A query holding two different kinds of whitespace no longer takes the compiler down with it. A tab beside a newline, or a single CRLF pair, exhausted the heap and killed the whole `tsc` run, so a tab-indented multi-line query or a checkout with CRLF endings could not be compiled at all ([#266](https://github.com/tiagolauer/OwlSQL/issues/266)).
 
 ### Added
 

--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -13,7 +13,13 @@ const SHAPE_REPEATS = 4;
 // to look for a quote first. The alternative was leaving `"first name"` and
 // `[Order Details]` unusable, including in schemas `owlsql generate` writes
 // itself.
-const MAX_INSTANTIATIONS = 195_000;
+//
+// Raised again from 195,000 for #266: normalizing whitespace now runs one pass
+// per character rather than one union match, which costs about 6% (five template
+// splits per query instead of one) and buys back a compiler crash - a tab beside
+// a newline, or any CRLF, used to exhaust the heap outright. Gating the passes
+// was measured and came out worse, see the note in src/string.ts.
+const MAX_INSTANTIATIONS = 200_000;
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PERF_DIR = join(ROOT, 'tests', 'perf');

--- a/src/string.ts
+++ b/src/string.ts
@@ -12,10 +12,26 @@ export type TrimRight<S extends string> = S extends `${infer Rest}${Whitespace}`
 
 export type Trim<S extends string> = TrimLeft<TrimRight<S>>;
 
-type WhitespaceToSpace<S extends string> =
-  S extends `${infer Before}${NonSpaceWhitespace}${infer After}`
-    ? WhitespaceToSpace<`${Before} ${After}`>
+type ReplaceWhitespace<S extends string, W extends NonSpaceWhitespace> =
+  S extends `${infer Before}${W}${infer After}`
+    ? ReplaceWhitespace<`${Before} ${After}`, W>
     : S;
+
+// One pass per character instead of a union in the match position. A union
+// there makes TypeScript infer Before and After as one candidate per member
+// and the rebuilt string cross-products them, so any query holding two
+// distinct whitespace kinds - a tab plus a newline, or a single CRLF pair -
+// exhausted the compiler heap (issue #266). Gating the passes behind a
+// HasQuoteChar-style check costs more than it saves here: that test needs the
+// union back in match position, which measured 3k instantiations worse than
+// letting all five passes miss.
+type WhitespaceToSpace<S extends string> = ReplaceWhitespace<
+  ReplaceWhitespace<
+    ReplaceWhitespace<ReplaceWhitespace<ReplaceWhitespace<S, '\t'>, '\n'>, '\r'>,
+    '\f'
+  >,
+  '\v'
+>;
 
 type CollapseSpaces<S extends string> = S extends `${infer Before}  ${infer After}`
   ? CollapseSpaces<`${Before} ${After}`>

--- a/tests/whitespace.test-d.ts
+++ b/tests/whitespace.test-d.ts
@@ -1,0 +1,83 @@
+import type { Query, Row, StrictRow, Params, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    amount: number;
+  };
+  orders: {
+    id: number;
+    user_id: number;
+  };
+}
+
+interface Spaced {
+  reports: {
+    'first name': string;
+    id: number;
+  };
+}
+
+type TabAndNewline = Expect<Equal<Query<DB, 'select\tid\nfrom users'>, { id: number }[]>>;
+
+type Crlf = Expect<Equal<Query<DB, 'select id\r\nfrom users'>, { id: number }[]>>;
+
+type TabIndentedBlock = Expect<
+  Equal<Query<DB, 'select\tid,\n\tname\nfrom users'>, { id: number; name: string }[]>
+>;
+
+type CrlfThroughout = Expect<
+  Equal<
+    Row<DB, 'select id,\r\n\tname\r\nfrom users\r\nwhere id = 1'>,
+    { id: number; name: string }
+  >
+>;
+
+type EveryWhitespaceKind = Expect<
+  Equal<Query<DB, 'select\f\vid\t\r\nfrom\tusers'>, { id: number }[]>
+>;
+
+type CrlfKeepsStrictChecking = Expect<
+  Equal<StrictRow<DB, 'select naem\r\nfrom users'>, QueryTypeError<'unknown column: naem'>>
+>;
+
+type CrlfKeepsParamInference = Expect<
+  Equal<Params<DB, 'select id\r\nfrom users\r\nwhere amount = $1'>, [number]>
+>;
+
+type CrlfAcrossJoin = Expect<
+  Equal<
+    Row<DB, 'select u.id,\r\n\to.id as order_id\r\nfrom users u\r\njoin orders o on o.user_id = u.id'>,
+    { id: number; order_id: number }
+  >
+>;
+
+type QuotedSpaceSurvivesCrlf = Expect<
+  Equal<Query<Spaced, 'select "first name"\r\nfrom reports'>, { 'first name': string }[]>
+>;
+
+type PlainNewlineStillWorks = Expect<Equal<Query<DB, 'select id\nfrom users'>, { id: number }[]>>;
+
+type RepeatedSpacesStillCollapse = Expect<
+  Equal<Query<DB, 'select  id   from users'>, { id: number }[]>
+>;
+
+export type {
+  TabAndNewline,
+  Crlf,
+  TabIndentedBlock,
+  CrlfThroughout,
+  EveryWhitespaceKind,
+  CrlfKeepsStrictChecking,
+  CrlfKeepsParamInference,
+  CrlfAcrossJoin,
+  QuotedSpaceSurvivesCrlf,
+  PlainNewlineStillWorks,
+  RepeatedSpacesStillCollapse,
+};


### PR DESCRIPTION
Fixes #266.

## The bug

`WhitespaceToSpace` matched on a union:

```ts
S extends `${infer Before}${NonSpaceWhitespace}${infer After}`
```

With a union in the match position TypeScript infers `Before` and `After` as one candidate per member, and the rebuilt `` `${Before} ${After}` `` cross-products them. One whitespace kind is fine; two distinct ones compound the recursion until the compiler dies:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

A tab beside a newline triggers it, and so does a single CRLF pair. In practice that means a tab-indented multi-line query, or any query at all on a checkout with CRLF line endings, could not be compiled. Raising the heap to 12GB does not help. The existing tests only ever mix newline with space, which is why the suite stayed green.

## The fix

One pass per character, so every split stays single-candidate. Same shape `EscapeQuotedSpaces` already uses just below it.

## Versioning

Minor, by the VERSIONING.md row *a query that failed to parse now parses and types correctly*. Nothing that already typed changes shape: the regression test pins plain newlines, repeated spaces, quoted identifiers holding a space, param inference and strict diagnostics as they were.

## Cost

The budget goes from 181,194 to 192,486 instantiations, about 6%, and `MAX_INSTANTIATIONS` rises to 200,000 in this commit as the script asks.

I tried gating the passes behind a `HasQuoteChar`-style check to buy that back. It came out worse, 195,235, because the gate needs the union back in match position and every budget query is single-line, so the gate never pays for itself. The measurement is recorded in the comment next to the code so the next person does not repeat it.

## Verification

- `tests/whitespace.test-d.ts` covers CRLF, tab plus newline, tab-indented blocks, all five whitespace kinds at once, and CRLF across a join. It also pins the things that must not regress: strict checking still reports `unknown column: naem` through CRLF, params still infer, quoted identifiers holding a space survive, plain newlines and repeated spaces still collapse.
- `tsc --noEmit` clean, 187 unit tests pass, 155 ts-plugin tests pass.

The bug was found by an audit pass over the library, and the fix and its measurements were done with Claude Code.
