### PR TITLE
fix(sqlite): bind numbered placeholders by number, not by position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ A second pass over the same ground, once those landed, found ten more; same rule
 - The editor plugin resolves table and column names case-insensitively, the way the type layer always has. `select id from USERS` type-checked fine and still drew a warning ([#250](https://github.com/tiagolauer/OwlSQL/issues/250)).
 - A password containing an unencoded `@` (`mysql://root:p@ss@host/db`, which every driver accepts) is redacted whole. The pattern stopped at the first `@` and printed the rest of the password ([#251](https://github.com/tiagolauer/OwlSQL/issues/251)).
 - A query holding two different kinds of whitespace no longer takes the compiler down with it. A tab beside a newline, or a single CRLF pair, exhausted the heap and killed the whole `tsc` run, so a tab-indented multi-line query or a checkout with CRLF endings could not be compiled at all ([#266](https://github.com/tiagolauer/OwlSQL/issues/266)).
+- The node:sqlite adapter binds `$1` by its number again. It read a numbered placeholder as a name that happened to be a digit and handed out values in the order the placeholders were written, so `where name = $2 and id = $1` bound them backwards: the same typed call returned the right rows on pg and the wrong ones on SQLite, and a write stored the swapped values without any error ([#267](https://github.com/tiagolauer/OwlSQL/issues/267)).
 
 ### Added
 

--- a/src/adapters/named-params.ts
+++ b/src/adapters/named-params.ts
@@ -85,7 +85,12 @@ function skipNonParameterRegion(sql: string, index: number): number {
   return -1;
 }
 
-type ParameterToken = { kind: 'positional' } | { kind: 'named'; name: string };
+const INDEXED_PARAM_BODY = /^[0-9]+$/;
+
+type ParameterToken =
+  | { kind: 'positional' }
+  | { kind: 'named'; name: string }
+  | { kind: 'indexed'; name: string; position: number };
 
 function scanParameters(
   sql: string,
@@ -117,7 +122,16 @@ function scanParameters(
 
       const body = NAMED_PARAM_BODY.exec(sql.slice(index + 1));
       if (body) {
-        visit({ kind: 'named', name: `${char}${body[0]}` });
+        const name = `${char}${body[0]}`;
+        // `$1` is Postgres numbering, not a name that happens to be a digit:
+        // the type layer sorts those slots by number and puts them ahead of
+        // the sequential ones, so binding them in the order they are written
+        // handed `$2` the value meant for `$1` (issue #267).
+        visit(
+          char === '$' && INDEXED_PARAM_BODY.test(body[0])
+            ? { kind: 'indexed', name, position: Number(body[0]) }
+            : { kind: 'named', name },
+        );
         index += 1 + body[0].length;
         continue;
       }
@@ -131,7 +145,7 @@ export function collectNamedParameters(sql: string, prefixes: ReadonlySet<string
   const names: string[] = [];
 
   scanParameters(sql, prefixes, (token) => {
-    if (token.kind === 'named' && !names.includes(token.name)) {
+    if (token.kind !== 'positional' && !names.includes(token.name)) {
       names.push(token.name);
     }
   });
@@ -144,12 +158,14 @@ export interface MixedParameters {
   positional: unknown[];
 }
 
-// Params<DB, Q> types one tuple slot per placeholder in first-occurrence
-// order, with repeated named placeholders (@id, $id, ...) deduped to their
-// first slot - matching collectNamedParameters' own dedup. A bare `?` is
-// never deduped: each occurrence consumes its own slot. This walks the SQL
-// once, in that same order, so `values` (built from that tuple) is
-// partitioned back into a named bag and an ordered positional list.
+// Params<DB, Q> lays the tuple out as the numbered slots followed by the
+// sequential ones. Numbered (`$1`) slots sit at their own position and a gap
+// still reserves one, so the block is as long as the highest number written.
+// Sequential slots - `@id`, `:id`, `$id`, `?` - come after it in
+// first-occurrence order, with repeated names deduped to their first slot,
+// matching collectNamedParameters. A bare `?` is never deduped. Reading the
+// highest number first is what lets the second walk resolve both kinds
+// against the same tuple the caller was typed against.
 export function resolveMixedParameters(
   sql: string,
   prefixes: ReadonlySet<string>,
@@ -158,9 +174,22 @@ export function resolveMixedParameters(
   const named: Record<string, unknown> = {};
   const bound = new Set<string>();
   const positional: unknown[] = [];
-  let valueIndex = 0;
+  let indexedCount = 0;
 
   scanParameters(sql, prefixes, (token) => {
+    if (token.kind === 'indexed' && token.position > indexedCount) {
+      indexedCount = token.position;
+    }
+  });
+
+  let valueIndex = indexedCount;
+
+  scanParameters(sql, prefixes, (token) => {
+    if (token.kind === 'indexed') {
+      named[token.name] = values[token.position - 1] ?? null;
+      return;
+    }
+
     if (token.kind === 'positional') {
       positional.push(values[valueIndex] ?? null);
       valueIndex += 1;

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -319,3 +319,50 @@ describe('createNodeSqliteExecutor column detection fallback', () => {
     expect(statement.run).not.toHaveBeenCalled();
   });
 });
+
+describe.skipIf(!sqliteAvailable)('numbered placeholders bind by index', () => {
+  it('gives $1 the first tuple slot even when $2 appears first', async () => {
+    const sqlite = seededDatabase();
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    await expect(
+      executor('select id, name from users where name = $2 and id = $1', [1, 'ada']),
+    ).resolves.toEqual([{ id: 1, name: 'ada' }]);
+  });
+
+  it('binds each numbered placeholder to its own slot, not its textual position', async () => {
+    const sqlite = seededDatabase();
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    await expect(
+      executor('select $2 as second, $1 as first', ['for-one', 'for-two']),
+    ).resolves.toEqual([{ second: 'for-two', first: 'for-one' }]);
+  });
+
+  it('places sequential placeholders after the numbered block', async () => {
+    const sqlite = seededDatabase();
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    await expect(
+      executor('select id, name from users where name = @who and id = $1', [1, 'ada']),
+    ).resolves.toEqual([{ id: 1, name: 'ada' }]);
+  });
+
+  it('reserves a slot for a gap in the numbering', async () => {
+    const sqlite = seededDatabase();
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    await expect(
+      executor('select $3 as third, $1 as first', ['for-one', 'unused', 'for-three']),
+    ).resolves.toEqual([{ third: 'for-three', first: 'for-one' }]);
+  });
+
+  it('repeats one value for a numbered placeholder used twice', async () => {
+    const sqlite = seededDatabase();
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    await expect(
+      executor('select id, name from users where id = $1 or id = $1', [2]),
+    ).resolves.toEqual([{ id: 2, name: 'grace' }]);
+  });
+});


### PR DESCRIPTION
Fixes #267.

## The bug

The parameter scanner's name pattern is `/^[A-Za-z0-9_]+/`, which accepts digits, so `$1` left it as a *named* token. `resolveMixedParameters` then walked the SQL and gave each token the next value in the order it appeared.

The type layer does the opposite. It sorts numbered slots by number and puts that whole block ahead of the sequential ones (`[...FinalIndexed, ...FinalSequential]`). So this query types as `[id, name]` and used to bind as `[name, id]`:

```ts
await db.query('select id, name from users where name = $2 and id = $1', 1, 'ada');
```

It returns `[]` on SQLite and the matching row on pg, from the same typed call. A probe shows the swap directly: `select $2 as second, $1 as first` with `['for-one', 'for-two']` came back as `{ second: 'for-one', first: 'for-two' }`.

Selects returned wrong rows and writes stored swapped values, both without an error, which is why this is worth a look even though the fix is small.

## The fix

A numbered token now carries its position and reads `values[position - 1]`. The sequential walk starts after the numbered block, whose length is the highest number written, so a gap reserves its slot exactly like the tuple does.

Only node:sqlite scans `$` (mssql scans `@` only), so mssql behaviour is unchanged. Its `collectNamedParameters` now collects numbered names too, which keeps today's behaviour if it ever gains the prefix.

## Versioning

Bug fix with no effect on inferred types: the tuple was always correct, only the binding was wrong. Nothing that was returning correct rows changes.

## Verification

Five cases added to `tests/adapter-node-sqlite.test.ts`, all against a real in-memory `node:sqlite`. Four of them fail on master and pass here; the fifth (`$1` used twice) passed already and is pinned so the dedup path does not regress:

- `$1` takes the first slot when `$2` is written first
- each numbered placeholder binds to its own slot, not its textual position
- sequential placeholders (`@who`) land after the numbered block
- a gap in the numbering still reserves its slot
- a numbered placeholder used twice reuses the one value

`tsc --noEmit` clean, 192 unit tests pass, type budget unchanged at 192,486 (this is runtime-only).

The bug came out of an audit pass over the adapters, and the fix and its tests were written with Claude Code.
