### PR TITLE
fix(parse): parse a parenthesized branch of a set operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ A second pass over the same ground, once those landed, found ten more; same rule
 - A password containing an unencoded `@` (`mysql://root:p@ss@host/db`, which every driver accepts) is redacted whole. The pattern stopped at the first `@` and printed the rest of the password ([#251](https://github.com/tiagolauer/OwlSQL/issues/251)).
 - A query holding two different kinds of whitespace no longer takes the compiler down with it. A tab beside a newline, or a single CRLF pair, exhausted the heap and killed the whole `tsc` run, so a tab-indented multi-line query or a checkout with CRLF endings could not be compiled at all ([#266](https://github.com/tiagolauer/OwlSQL/issues/266)).
 - The node:sqlite adapter binds `$1` by its number again. It read a numbered placeholder as a name that happened to be a digit and handed out values in the order the placeholders were written, so `where name = $2 and id = $1` bound them backwards: the same typed call returned the right rows on pg and the wrong ones on SQLite, and a write stored the swapped values without any error ([#267](https://github.com/tiagolauer/OwlSQL/issues/267)).
+- A parenthesized branch of a set operation parses again. `(select id from users) union (select id from archived_users)` opens with `(` rather than a keyword, which the statement parser matched to nothing, and the row came back as a bare index signature instead of failing; wrapping branches in parentheses is how a set operation gives one its own ORDER BY or LIMIT ([#275](https://github.com/tiagolauer/OwlSQL/issues/275)).
 
 ### Added
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -303,7 +303,17 @@ type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer B
     : never
   : never;
 
-type ParseStatementNormalized<S extends string> = FirstWord<S> extends infer Keyword extends string
+// A branch of a set operation may be parenthesized - that is the standard way
+// to give one its own ORDER BY or LIMIT - and the statement then opens with
+// `(` instead of a keyword, which matched nothing (issue #275). Unwrapping and
+// parsing what is inside keeps the documented rule that the row shape comes
+// from the first branch: whatever follows the group is another branch, and
+// branches have to be column-compatible.
+type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string }
+    ? ParseStatementNormalized<Trim<Inner>>
+    : never
+  : FirstWord<S> extends infer Keyword extends string
   ? IsKeyword<Keyword, 'select'> extends true
     ? ParseSelectBody<S>
     : IsKeyword<Keyword, 'insert'> extends true
@@ -962,12 +972,20 @@ type InferRowWithChecked<
   db: infer CteDB extends SchemaLike;
   query: infer EffectiveQuery extends string;
 }
-  ? ParseStatementNormalized<EffectiveQuery> extends {
-      columns: infer Columns extends string;
-      sources: infer Sources extends Source[];
-      whereText: infer WhereText extends string;
-      fromText: infer FromText extends string;
-    }
+  ? // The [never] guard is load-bearing, the same way it is in
+    // ExtraSourcesAfterKeyword: ParseStatementNormalized resolves to never for
+    // a statement it does not recognize, and `never extends { columns: infer C
+    // extends string, ... }` passes with every infer position resolving to its
+    // constraint, which built a row out of `string` keys instead of failing
+    // (issue #275).
+    [ParseStatementNormalized<EffectiveQuery>] extends [never]
+    ? never
+    : ParseStatementNormalized<EffectiveQuery> extends {
+          columns: infer Columns extends string;
+          sources: infer Sources extends Source[];
+          whereText: infer WhereText extends string;
+          fromText: infer FromText extends string;
+        }
     ? (CteDB & BuildDerivedSourceMap<CteDB, Sources, Strict>) extends infer EffectiveDB extends SchemaLike
       ? // The clause check wraps the empty row too: a write with no RETURNING
         // projects nothing, but its WHERE clause is still a set of column

--- a/tests/parenthesized-set-ops.test-d.ts
+++ b/tests/parenthesized-set-ops.test-d.ts
@@ -1,0 +1,70 @@
+import type { Query, StrictQuery, Row, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+  };
+  archived_users: {
+    id: number;
+    name: string;
+  };
+}
+
+type ParenthesizedUnion = Expect<
+  Equal<Query<DB, '(select id from users) union (select id from archived_users)'>, { id: number }[]>
+>;
+
+type ParenthesizedUnionAll = Expect<
+  Equal<
+    Query<DB, '(select id, name from users) union all (select id, name from archived_users)'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type ParenthesizedBranchWithOrderAndLimit = Expect<
+  Equal<
+    Query<DB, '(select id from users order by id limit 5) union (select id from archived_users limit 5)'>,
+    { id: number }[]
+  >
+>;
+
+type SingleParenthesizedSelect = Expect<
+  Equal<Query<DB, '(select id from users)'>, { id: number }[]>
+>;
+
+type ParenthesizedUnionInStrictMode = Expect<
+  Equal<
+    StrictQuery<DB, '(select id from users) union (select id from archived_users)'>,
+    { id: number }[]
+  >
+>;
+
+type StrictStillCatchesATypoInAParenthesizedBranch = Expect<
+  Equal<
+    StrictQuery<DB, '(select naem from users) union (select name from archived_users)'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+type UnparenthesizedUnionUnchanged = Expect<
+  Equal<Query<DB, 'select id from users union select id from archived_users'>, { id: number }[]>
+>;
+
+type PlainSelectUnchanged = Expect<Equal<Row<DB, 'select id, name from users'>, { id: number; name: string }>>;
+
+export type {
+  ParenthesizedUnion,
+  ParenthesizedUnionAll,
+  ParenthesizedBranchWithOrderAndLimit,
+  SingleParenthesizedSelect,
+  ParenthesizedUnionInStrictMode,
+  StrictStillCatchesATypoInAParenthesizedBranch,
+  UnparenthesizedUnionUnchanged,
+  PlainSelectUnchanged,
+};


### PR DESCRIPTION
Fixes #275.

## The bug

Wrapping set-op branches in parentheses is how you give one its own ORDER BY or LIMIT, and it is valid everywhere:

```ts
Query<DB, '(select id from users) union (select id from archived_users)'>
// was: { [x: string]: unknown }[]
// strict: QueryTypeError<'unknown table: '>   <- empty name
```

Two things went wrong in sequence. The statement parser reads the first word to choose a branch, so `(select` matched nothing and the parse resolved to `never`. That `never` then reached `InferRowWithChecked`, which had no guard for it: `never extends { columns: infer C extends string, ... }` passes with every infer position falling back to its constraint, so the failure turned into a row built from `string` keys instead of an error.

## The fix

Both halves:

- the statement parser unwraps a leading paren group and parses what is inside
- the `[never]` guard is in place for anything else it cannot recognize, the same pattern `ExtraSourcesAfterKeyword` already carries from #229

Unwrapping preserves the documented rule that the row shape comes from the first branch: whatever follows the group is another branch, and branches must be column-compatible.

## Versioning

Minor: a query that failed to parse now parses and types correctly. Nothing that already typed changes shape.

## Verification

`tests/parenthesized-set-ops.test-d.ts`, six cases red on master:

- parenthesized UNION and UNION ALL
- a branch carrying its own ORDER BY / LIMIT
- a single parenthesized SELECT
- the same in strict mode
- strict still catching a typo inside a parenthesized branch

Two controls stay pinned: unparenthesized UNION and a plain SELECT are unchanged.

`tsc --noEmit` clean, 192 unit tests pass, budget 192,545 (+59).

Found during an audit pass; fix and tests written with Claude Code.
