### PR TITLE
fix(cte): accept the MATERIALIZED hint on a CTE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- `WITH t AS MATERIALIZED (...)` and its `NOT MATERIALIZED` twin parse again. The parser wanted the body's opening paren directly after `as`, so the Postgres 12 planner hint took the whole WITH clause down with it and the query degraded into an index signature row instead of reporting anything ([#283](https://github.com/tiagolauer/OwlSQL/issues/283)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/cte.ts
+++ b/src/cte.ts
@@ -22,13 +22,26 @@ type CteNameAndRest<S extends string> = S extends `${infer NamePart}(${infer Aft
       : never
   : { name: FirstWord<S>; columns: null; rest: Trim<DropFirstWord<S>> };
 
+// `AS MATERIALIZED (...)` and `AS NOT MATERIALIZED (...)` are Postgres 12+
+// planner hints sitting between `as` and the body. Requiring the paren to
+// follow `as` directly rejected the whole WITH clause over them (issue #283).
+// Nothing else reads the hint: it changes how the CTE is executed, not what
+// it returns.
+type SkipMaterializedKeyword<S extends string> = IsKeyword<FirstWord<S>, 'materialized'> extends true
+  ? Trim<DropFirstWord<S>>
+  : IsKeyword<FirstWord<S>, 'not'> extends true
+    ? IsKeyword<FirstWord<Trim<DropFirstWord<S>>>, 'materialized'> extends true
+      ? Trim<DropFirstWord<Trim<DropFirstWord<S>>>>
+      : S
+    : S;
+
 type ParseCteEntry<S extends string> = CteNameAndRest<Trim<S>> extends {
   name: infer Name extends string;
   columns: infer Columns extends string[] | null;
   rest: infer Rest extends string;
 }
   ? IsKeyword<FirstWord<Rest>, 'as'> extends true
-    ? Trim<DropFirstWord<Rest>> extends `(${infer AfterOpen}`
+    ? SkipMaterializedKeyword<Trim<DropFirstWord<Rest>>> extends `(${infer AfterOpen}`
       ? ExtractParenGroup<AfterOpen> extends { inner: infer SubQuery extends string; rest: infer AfterQuery extends string }
         ? { name: Name; columns: Columns; query: Trim<SubQuery>; rest: Trim<AfterQuery> }
         : never
@@ -52,13 +65,21 @@ type SkipRecursiveKeyword<S extends string> = IsKeyword<FirstWord<S>, 'recursive
   ? Trim<DropFirstWord<S>>
   : S;
 
+// The [never] guard is load-bearing: ParseCteList resolves to never for a WITH
+// clause it cannot read, and `never extends { ctes: infer C extends
+// CteEntry[]; rest: infer R extends string }` passes with both infers falling
+// back to their constraints. That handed ResolveCteContext a `rest` of
+// `string` instead of a clean failure, and the query degraded into an index
+// signature row rather than reporting anything (issue #283).
 export type ParseWithClause<S extends string> = IsKeyword<FirstWord<S>, 'with'> extends true
-  ? ParseCteList<SkipRecursiveKeyword<Trim<DropFirstWord<S>>>> extends {
-      ctes: infer Ctes extends CteEntry[];
-      rest: infer Rest extends string;
-    }
-    ? { ctes: Ctes; rest: Rest }
-    : never
+  ? [ParseCteList<SkipRecursiveKeyword<Trim<DropFirstWord<S>>>>] extends [never]
+    ? never
+    : ParseCteList<SkipRecursiveKeyword<Trim<DropFirstWord<S>>>> extends {
+          ctes: infer Ctes extends CteEntry[];
+          rest: infer Rest extends string;
+        }
+      ? { ctes: Ctes; rest: Rest }
+      : never
   : never;
 
 type RenameKeys<Row, Keys extends string[], NewNames extends string[]> = NewNames extends [

--- a/tests/cte-materialized.test-d.ts
+++ b/tests/cte-materialized.test-d.ts
@@ -1,0 +1,88 @@
+import type { Query, StrictQuery, Params, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+  };
+  orders: {
+    id: number;
+    user_id: number;
+    total: number;
+  };
+}
+
+type Materialized = Expect<
+  Equal<Query<DB, 'with t as materialized (select id from users) select id from t'>, { id: number }[]>
+>;
+
+type NotMaterialized = Expect<
+  Equal<
+    Query<DB, 'with t as not materialized (select id, name from users) select id, name from t'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type MaterializedInStrictMode = Expect<
+  Equal<
+    StrictQuery<DB, 'with t as materialized (select id from users) select id from t'>,
+    { id: number }[]
+  >
+>;
+
+type StrictStillCatchesATypoInsideAMaterializedCte = Expect<
+  Equal<
+    StrictQuery<DB, 'with t as materialized (select naem from users) select naem from t'>,
+    QueryTypeError<'unknown column: naem'>[]
+  >
+>;
+
+type MaterializedAlongsideAPlainCte = Expect<
+  Equal<
+    Query<
+      DB,
+      'with a as (select id from users), b as materialized (select user_id from orders) select id from a'
+    >,
+    { id: number }[]
+  >
+>;
+
+type MaterializedKeepsParamInference = Expect<
+  Equal<
+    Params<DB, 'with t as materialized (select id from users where id = $1) select id from t'>,
+    [number]
+  >
+>;
+
+type RecursiveAndMaterializedTogether = Expect<
+  Equal<
+    Query<DB, 'with recursive t as materialized (select id from users) select id from t'>,
+    { id: number }[]
+  >
+>;
+
+type PlainCteUnchanged = Expect<
+  Equal<Query<DB, 'with t as (select id from users) select id from t'>, { id: number }[]>
+>;
+
+// A column named `materialized` is still a column, not the hint.
+type ColumnCalledMaterializedUnchanged = Expect<
+  Equal<Query<{ t: { materialized: number } }, 'select materialized from t'>, { materialized: number }[]>
+>;
+
+export type {
+  Materialized,
+  NotMaterialized,
+  MaterializedInStrictMode,
+  StrictStillCatchesATypoInsideAMaterializedCte,
+  MaterializedAlongsideAPlainCte,
+  MaterializedKeepsParamInference,
+  RecursiveAndMaterializedTogether,
+  PlainCteUnchanged,
+  ColumnCalledMaterializedUnchanged,
+};


### PR DESCRIPTION
Fixes #283.

## The bug

```ts
Query<DB, 'with t as materialized (select id from users) select id from t'>
// was: { [x: string]: unknown }[]
// strict: QueryTypeError<'unknown table: '>
```

`AS MATERIALIZED (...)` and `AS NOT MATERIALIZED (...)` are Postgres 12+ planner hints that sit between `as` and the body. `ParseCteEntry` wanted the opening paren directly after `as`, so either spelling failed the match and took the whole WITH clause with it.

The failure was quiet rather than loud, which is the second half of this. `ParseWithClause` had no `[never]` guard, so `never extends { ctes: infer C extends CteEntry[]; rest: infer R extends string }` passed with both infers falling back to their constraints. `ResolveCteContext` then got a `rest` of `string`, and the query degraded into an index signature row instead of reporting anything.

## The fix

Skip the hint, and add the guard. Skipping is enough on its own because the hint changes how the CTE is executed, not what it returns. The guard is the same `[never]` pattern `ExtraSourcesAfterKeyword` carries from #229, and it means the next unparseable WITH clause fails cleanly instead of degrading.

## Versioning

Minor: a query that failed to parse now parses and types correctly.

## Verification

`tests/cte-materialized.test-d.ts`, seven cases red on master:

- `materialized` and `not materialized`
- both in strict mode, including a typo inside the CTE still being caught
- a materialized CTE alongside a plain one
- param inference through a materialized body
- `with recursive` and the hint together

Two controls stay pinned: a plain CTE is unchanged, and a column actually named `materialized` is still read as a column rather than the hint.

`tsc --noEmit` clean, 192 unit tests pass, budget 192,881 (+395 over master).

Found during an audit pass; fix and tests written with Claude Code.
