### PR TITLE
fix(parse): let a shadowing name replace the table it hides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A name that hides a real table now replaces it instead of merging with it. A CTE was only shadowed for the outer query, so a later CTE body still saw the real table's other columns ([#285](https://github.com/tiagolauer/OwlSQL/issues/285)), and a derived table whose alias reused a table name was intersected with it rather than hiding it ([#286](https://github.com/tiagolauer/OwlSQL/issues/286)). Strict mode accepted `select name from (select id from users) users` and typed a column the query cannot produce.
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/cte.ts
+++ b/src/cte.ts
@@ -6,7 +6,7 @@ import type {
   ExtractParenGroup,
   SplitColumnList,
 } from './string.js';
-import type { SchemaLike, Flatten, QueryTypeError, SelectColumnKeys } from './parse.js';
+import type { SchemaLike, Flatten, QueryTypeError, SelectColumnKeys, ShadowedBy } from './parse.js';
 import type { InferRowWith } from './parse.js';
 
 type CteEntry = [name: string, query: string, columns: string[] | null];
@@ -101,6 +101,6 @@ export type BuildCteMap<
       DB,
       Tail,
       Strict,
-      Accumulated & { [Key in Head[0]]: CteRow<DB & Accumulated, Head[1], Head[2], Strict> }
+      Accumulated & { [Key in Head[0]]: CteRow<ShadowedBy<DB, Accumulated>, Head[1], Head[2], Strict> }
     >
   : Accumulated;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -886,6 +886,19 @@ type EmptyRow = Record<string, never>;
 // selected. Omitting the shadowed keys first (case-insensitively, matching
 // how every other name lookup in this codebase already resolves) before
 // intersecting closes that gap.
+// Every place a name can hide a table of the same name needs the omit-then-
+// intersect pair, never a bare intersection: a CTE body seeing an earlier CTE
+// (issue #285), and a derived table whose alias reuses a real table name
+// (issue #286). Both used to intersect, which is additive, so the hidden
+// table's other columns stayed in scope and strict mode typed a column the
+// query cannot produce.
+// Gated on there being an overlay at all: OmitShadowedTables is a mapped type
+// over every table in the schema, and running it for the empty overlay a
+// plain query carries cost 10% of the whole type budget.
+export type ShadowedBy<DB, Overlay> = [keyof Overlay] extends [never]
+  ? DB
+  : OmitShadowedTables<DB, keyof Overlay & string> & Overlay;
+
 type OmitShadowedTables<DB, ShadowedNames extends string> = {
   [Key in keyof DB as Key extends string
     ? Lowercase<Key> extends Lowercase<ShadowedNames>
@@ -1001,7 +1014,7 @@ type InferRowWithChecked<
           whereText: infer WhereText extends string;
           fromText: infer FromText extends string;
         }
-    ? (CteDB & BuildDerivedSourceMap<CteDB, Sources, Strict>) extends infer EffectiveDB extends SchemaLike
+    ? ShadowedBy<CteDB, BuildDerivedSourceMap<CteDB, Sources, Strict>> extends infer EffectiveDB extends SchemaLike
       ? // The clause check wraps the empty row too: a write with no RETURNING
         // projects nothing, but its WHERE clause is still a set of column
         // references strict mode has to validate - and UPDATE/DELETE is where

--- a/tests/shadowing.test-d.ts
+++ b/tests/shadowing.test-d.ts
@@ -1,0 +1,87 @@
+import type { Query, StrictQuery, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+  };
+  orders: {
+    id: number;
+    user_id: number;
+  };
+}
+
+// Inside `t`, the name `users` is the CTE declared just before it, which
+// projects only `id`. `name` does not exist there.
+type CteShadowsInsideALaterCteBody = Expect<
+  Equal<
+    StrictQuery<DB, 'with users as (select id from users), t as (select name from users) select name from t'>,
+    QueryTypeError<'unknown column: name'>[]
+  >
+>;
+
+type CteShadowsInsideALaterCteBodyLoose = Expect<
+  Equal<
+    Query<DB, 'with users as (select id from users), t as (select id from users) select id from t'>,
+    { id: number }[]
+  >
+>;
+
+// A FROM alias hides the real table of the same name, so only `id` is in scope.
+type DerivedAliasShadowsTheRealTable = Expect<
+  Equal<
+    StrictQuery<DB, 'select name from (select id from users) users'>,
+    QueryTypeError<'unknown column: name'>[]
+  >
+>;
+
+type DerivedAliasStillExposesItsOwnColumns = Expect<
+  Equal<StrictQuery<DB, 'select id from (select id from users) users'>, { id: number }[]>
+>;
+
+// The outer query already shadowed correctly; pinned so it stays that way.
+type CteShadowsInTheOuterQuery = Expect<
+  Equal<
+    StrictQuery<DB, 'with users as (select id from users) select name from users'>,
+    QueryTypeError<'unknown column: name'>[]
+  >
+>;
+
+type CteReferringToAnEarlierCteUnchanged = Expect<
+  Equal<
+    Query<DB, 'with a as (select id from users), b as (select id from a) select id from b'>,
+    { id: number }[]
+  >
+>;
+
+type UnshadowedTableStillVisibleFromACteBody = Expect<
+  Equal<
+    Query<DB, 'with t as (select user_id from orders) select user_id from t'>,
+    { user_id: number }[]
+  >
+>;
+
+type DerivedTableWithAFreshAliasUnchanged = Expect<
+  Equal<Query<DB, 'select id from (select id from users) u'>, { id: number }[]>
+>;
+
+type PlainQueryUnchanged = Expect<
+  Equal<Query<DB, 'select id, name from users'>, { id: number; name: string }[]>
+>;
+
+export type {
+  CteShadowsInsideALaterCteBody,
+  CteShadowsInsideALaterCteBodyLoose,
+  DerivedAliasShadowsTheRealTable,
+  DerivedAliasStillExposesItsOwnColumns,
+  CteShadowsInTheOuterQuery,
+  CteReferringToAnEarlierCteUnchanged,
+  UnshadowedTableStillVisibleFromACteBody,
+  DerivedTableWithAFreshAliasUnchanged,
+  PlainQueryUnchanged,
+};


### PR DESCRIPTION
Fixes #285. Fixes #286.

Two issues, one root cause and one helper, which is why they are together here rather than in two PRs that would each need half of it.

## The bug

Object intersection is additive: `DB['users'] & { id: number }` still exposes `name`. Two places relied on it where SQL says the name is hidden.

A CTE was omitted from the schema only for the outer query, so a later CTE body still saw the real table:

```ts
StrictQuery<DB, 'with users as (select id from users), t as (select name from users) select name from t'>
// was: { name: string }[]   -- inside `t`, `users` is the CTE, which has no `name`
```

And a derived table whose alias reuses a real table name was intersected with it:

```ts
StrictQuery<DB, 'select name from (select id from users) users'>
// was: { name: string }[]   -- the alias hides the table; only `id` is in scope
```

Both cases have strict mode accepting a query the database rejects, and typing a column the query cannot produce. The comment at `ResolveCteContext` already described the first gap.

## The fix

`ShadowedBy` pairs the existing `OmitShadowedTables` with the intersection, and both sites use it.

It is gated on the overlay being non-empty. That matters: the omit is a mapped type over every table in the schema, and running it for the empty overlay a plain query carries measured **+18,744 instantiations, 10% of the whole budget** and blew the ceiling. With the gate the budget lands at 192,086, slightly *under* master's 192,486, because the intersection it replaces used to run on every query.

## Versioning

Minor: strict mode reports a mistake it previously let through.

## Verification

`tests/shadowing.test-d.ts`, two cases red on master (one per issue), seven controls green throughout:

- outer-query CTE shadowing still works (it always did)
- a CTE referring to an earlier CTE
- an unshadowed table still visible from a CTE body
- a derived table with a fresh alias
- a derived alias still exposing its own columns
- a plain query

`tsc --noEmit` clean, 192 unit tests pass.

Found during an audit pass; fix and tests written with Claude Code.
