### PR TITLE
docs(roadmap): list mssql among the shipped adapters

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ the editor tooling, not a promise of dates.
 - Official multi-database support: PostgreSQL, MySQL, SQLite, SQL Server
   (named `@params`, backtick identifiers, `TOP`, `OUTPUT`).
 - Ready-made driver adapters (`pg`, `mysql2`, `postgres.js`, `node:sqlite`,
-  Kysely) and a documented Drizzle recipe.
+  `mssql`, Kysely) and a documented Drizzle recipe.
 - `npx @owlsql/core generate` — schema introspection CLI for all four
   databases.
 - `@owlsql/ts-plugin` — in-editor column-name autocomplete and hover


### PR DESCRIPTION
Fixes #309.

ROADMAP.md's Shipped section listed the driver adapters as `pg`, `mysql2`, `postgres.js`, `node:sqlite` and Kysely. `mssql` was missing, even though `src/adapters/mssql.ts` ships `createMssqlExecutor` and `createMssqlTransaction` and the README documents both.

The document describes itself as reflecting the current state, so one name goes back in the list. Docs only, no code change.