### PR TITLE
docs(comparison): stop quoting a parser line count that drifts

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -136,8 +136,8 @@ check the source link and open an issue.
   `defineSchema`, and the `Result` helpers — about 175 lines of source
   across [`src/index.ts`](src/index.ts) and [`src/result.ts`](src/result.ts)
   combined, most of which is type declarations erased at compile time. The
-  parser itself (~1,700 lines across `src/parse.ts`/`src/from.ts`/etc.) is
-  100% types — it ships zero bytes to any runtime.
+  parser itself (a few thousand lines across `src/parse.ts`/`src/from.ts`/
+  etc.) is 100% types — it ships zero bytes to any runtime.
 - **DX trade-off, stated plainly**: this is the smallest surface area of
   the five because it does the least. No migrations, no relation loading, no
   query builder ergonomics (autocomplete for chained methods) — you write


### PR DESCRIPTION
Fixes #308.

COMPARISON.md:140 said the type-level parser is "~1,700 lines". Counting the type-level sources today (`parse`, `from`, `case`, `cte`, `where`, `string`, `functions`, `params`) gives **2,653** — the number was true once and drifted.

The sentence exists to say the parser ships zero runtime bytes, which needs no exact figure, so it now reads "a few thousand lines" and stops being a maintenance item. The neighbouring "~175 lines of glue" claim was checked and is still accurate (`index.ts` + `result.ts` = 182), so it stays.

Docs only, no code change.