### PR TITLE
chore(examples): let the version pin reach 0.2.0

### DIFF
--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -6,7 +6,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@owlsql/core": "^0.1.4"
+    "@owlsql/core": "^0.1.4 || ^0.2.0"
   },
   "devDependencies": {
     "typescript": "^5.6.0"

--- a/examples/ts-plugin-demo/package.json
+++ b/examples/ts-plugin-demo/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@owlsql/core": "^0.1.4"
+    "@owlsql/core": "^0.1.4 || ^0.2.0"
   },
   "devDependencies": {
     "@owlsql/ts-plugin": "^0.1.0",


### PR DESCRIPTION
Fixes #307.

## The bug

Both examples pin `@owlsql/core: ^0.1.4` (`examples/playground/package.json`, `examples/ts-plugin-demo/package.json`). `^0.1.4` means `>=0.1.4 <0.2.0`, so once 0.2.0 is on npm the examples keep resolving 0.1.8 forever — and everything documented as new in 0.2.0 (typed `:name` params, `= any($1)` arrays, quoted names with spaces) looks broken to anyone trying it in the playground.

## The fix

`^0.1.4 || ^0.2.0` in both, rather than the flat `^0.2.0` the issue suggests.

The reason is ordering: 0.2.0 is tagged but **not published** — `npm view @owlsql/core versions` gives `['0.1.4', '0.1.6', '0.1.7', '0.1.8']` today. A flat `^0.2.0` would resolve to nothing and break `npm install` in both examples right now, trading a stale install for a dead one. This range installs 0.1.8 today and 0.2.0 the moment it lands, with no follow-up commit to remember.

No code change.