### PR TITLE
docs(readme): state the real TypeScript peer range

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ lives in the `.d.ts` types.
 npm install @owlsql/core
 ```
 
-`typescript` is a peer dependency (**>= 5.0, < 8** — template literal type
-recursion needs 5.0; the ts-plugin does not load on TS 7). You almost
+`typescript` is a peer dependency (**>= 5.4, < 8** — 5.4 is the oldest
+version CI tests; the ts-plugin does not load on TS 7). You almost
 certainly already have it.
 
 The package is **ESM-only** (`import` only — `require()` is not supported).


### PR DESCRIPTION
Fixes #297.

README.md:128 said `typescript` is a peer dependency at **">= 5.0, < 8"**. The declared constraint is `">=5.4.0 <8"` (package.json:69) and the oldest version CI runs is 5.4 (.github/workflows/ci.yml:18, matrix `['5.4', '5.6', '6.0']`).

Someone on 5.0–5.3 following the README gets an unmet peer dependency warning, against a range nothing here has ever verified. One number, plus the parenthetical that justified the old floor ("template literal type recursion needs 5.0") now pointing at the real reason.

Docs only, no code change.