### PR TITLE
fix(examples): declare console in the playground typecheck

### DIFF
--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -9,6 +9,7 @@
     "@owlsql/core": "^0.1.4"
   },
   "devDependencies": {
+    "@types/node": "^26.1.1",
     "typescript": "^5.6.0"
   }
 }


### PR DESCRIPTION
Fixes #295.

## The bug

The playground fails its own documented typecheck step, and it is the StackBlitz playground the README links from line 38, so it is the first thing a curious visitor runs:

```
examples/playground/index.ts(36,3): error TS2584: Cannot find name 'console'.
```

`index.ts:36` logs from the fake executor, but the example's tsconfig sets `lib: ["ES2022"]` with no DOM and the package declares no `@types/node`, so `console` exists nowhere.

## The fix

`@types/node` in the example's devDependencies, rather than adding `DOM` to `lib`. The file logs from a Node process and touches no browser API, so the Node types are the honest description of what it needs; `DOM` would declare `document` and `fetch` to make `console` appear.

## Verification

The error only reproduces in isolation — running `tsc` from the repo root resolves `@types/node` by walking up into the root `node_modules/@types`, which is why this never showed up in CI:

```
npx tsc --noEmit -p examples/playground/tsconfig.json --typeRoots ./no-such-dir
# index.ts(36,3): error TS2584: Cannot find name 'console'.   <- reproduced

npx tsc --noEmit -p examples/playground/tsconfig.json
# no TS2584                                                    <- with node types present
```

(The `Cannot find module '@owlsql/core'` and two `implicitly has an 'any'` errors in both runs are the uninstalled workspace dependency, not this bug — they disappear after `npm install` in the example.)

Aside from this, every query in the playground type-checks.