### PR TITLE
docs(ts-plugin): describe an install that works today

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,7 +769,20 @@ library: everything else works by *type-checking* a finished query string;
 this works by hooking into the editor's completion request for a string
 that isn't even valid SQL yet.
 
-**Setup** — it ships as its own package, so install it first:
+**Setup** — it ships as its own package, so install it first.
+
+> **Not on npm yet.** `@owlsql/ts-plugin` has not been published; the
+> command below will be the install once it is. Until then, build it from a
+> clone of this repository and install that folder:
+>
+> ```bash
+> git clone https://github.com/tiagolauer/OwlSQL
+> cd OwlSQL && npm install && npm run build --workspace @owlsql/ts-plugin
+> cd /path/to/your/project
+> npm install --save-dev /path/to/OwlSQL/ts-plugin
+> ```
+>
+> Everything below this box is the same either way.
 
 ```bash
 npm install --save-dev @owlsql/ts-plugin

--- a/examples/ts-plugin-demo/README.md
+++ b/examples/ts-plugin-demo/README.md
@@ -8,9 +8,16 @@ StackBlitz.
 
 ## Setup
 
-1. In this folder: `npm install` (`@owlsql/core` is on npm; to test
-   unpublished changes instead, run `npm install && npm run build` at the
-   repo root and then `npm install ../.. typescript --no-save` here).
+1. Build the plugin, then install it here. `@owlsql/ts-plugin` is not on npm
+   yet, so it is not a dependency of this example — it comes from the
+   workspace:
+   ```bash
+   npm install && npm run build --workspace @owlsql/ts-plugin   # at the repo root
+   cd examples/ts-plugin-demo && npm install && npm install ../../ts-plugin --no-save
+   ```
+   (`@owlsql/core` does come from npm. To test unpublished changes to it as
+   well, run `npm run build` at the repo root too and add `../..` to that
+   last install.)
 2. Open **this folder** (`examples/ts-plugin-demo`) in VSCode — not the
    monorepo root, so the workspace TypeScript version resolves correctly.
 3. Command Palette → **"TypeScript: Select TypeScript Version" → "Use

--- a/examples/ts-plugin-demo/package.json
+++ b/examples/ts-plugin-demo/package.json
@@ -6,7 +6,6 @@
     "@owlsql/core": "^0.1.4"
   },
   "devDependencies": {
-    "@owlsql/ts-plugin": "^0.1.0",
     "typescript": "^5.6.0"
   }
 }

--- a/ts-plugin/README.md
+++ b/ts-plugin/README.md
@@ -8,6 +8,15 @@ A TypeScript Language Service Plugin: it runs inside `tsserver`, the process tha
 npm install --save-dev @owlsql/ts-plugin
 ```
 
+> **Not on npm yet.** Until this package is published, build it from a clone
+> and install the folder instead:
+>
+> ```bash
+> git clone https://github.com/tiagolauer/OwlSQL
+> cd OwlSQL && npm install && npm run build --workspace @owlsql/ts-plugin
+> npm install --save-dev /path/to/OwlSQL/ts-plugin   # from your project
+> ```
+
 ```json
 {
   "compilerOptions": {


### PR DESCRIPTION
Fixes #279.

## The bug

```
npm view @owlsql/ts-plugin
# npm error 404 '@owlsql/ts-plugin' is not in this registry
```

The README told users to run `npm install --save-dev @owlsql/ts-plugin` (line 775), and `examples/ts-plugin-demo` listed it as a devDependency. `npm install` in a fresh copy of the demo aborts on the 404, which also means `@owlsql/core` never installs — the demo is dead on arrival, not just missing the plugin.

## The fix

The issue offers two routes; this is the second (rewrite the install story until it ships), because publishing is not something a commit can do.

- **README.md** and **ts-plugin/README.md** keep the npm command — it is the install once the package ships — with a callout next to it giving the clone → `npm run build --workspace @owlsql/ts-plugin` → `npm install --save-dev /path/to/OwlSQL/ts-plugin` route that works today.
- **examples/ts-plugin-demo/package.json** drops the `@owlsql/ts-plugin` devDependency, so `npm install` there resolves again (`@owlsql/core` is on npm, `typescript` is on npm).
- **examples/ts-plugin-demo/README.md** step 1 now builds the workspace and installs that folder — which is what the step already hinted at for testing unpublished changes to the core.

Docs plus one dependency removal; no code change. The publishing half of the issue stays open to whoever runs the release.