### PR TITLE
fix(cli): explain a malformed percent-escape in an mssql URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A raw `%` in an mssql connection URL explains itself instead of dying with a bare `URI malformed`. `new URL` accepts a broken percent sequence, so the throw came out of `decodeURIComponent` afterwards, outside the try/catch built to explain malformed URLs — and passwords with special characters are exactly where a stray `%` shows up ([#306](https://github.com/tiagolauer/OwlSQL/issues/306)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/cli/dialects/mssql.ts
+++ b/src/cli/dialects/mssql.ts
@@ -74,11 +74,26 @@ function parseMssqlUrl(url: string): URL {
   }
 }
 
+// `new URL` accepts a broken percent sequence and keeps it verbatim, so the
+// throw lands here instead, as a bare URIError with no hint of which input
+// caused it (#306). A raw `%` in a password is the likely reason, and the
+// decoded value never reaches the message: this is the credential half of the
+// URL.
+function decodeUrlPart(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new Error(
+      'Invalid SQL Server connection URL: it contains an incomplete percent-escape. A literal % in a user, password or database name has to be written as %25. Expected mssql://user:password@host[\\INSTANCE][:port]/database, or an ADO string such as "Server=host;Database=db;User Id=user;Password=password".',
+    );
+  }
+}
+
 export function mssqlUrlToConfig(url: string): MssqlConnectionConfig {
   const parsed = parseMssqlUrl(url);
   const flags = parsed.searchParams;
 
-  const host = decodeURIComponent(parsed.hostname);
+  const host = decodeUrlPart(parsed.hostname);
   const separatorIndex = host.indexOf(INSTANCE_SEPARATOR);
   const instanceName = separatorIndex === -1 ? '' : host.slice(separatorIndex + 1);
 
@@ -95,14 +110,14 @@ export function mssqlUrlToConfig(url: string): MssqlConnectionConfig {
   }
 
   if (parsed.username) {
-    config.user = decodeURIComponent(parsed.username);
+    config.user = decodeUrlPart(parsed.username);
   }
   if (parsed.password) {
-    config.password = decodeURIComponent(parsed.password);
+    config.password = decodeUrlPart(parsed.password);
   }
   const database = parsed.pathname.replace(/^\//, '');
   if (database) {
-    config.database = decodeURIComponent(database);
+    config.database = decodeUrlPart(database);
   }
   if (parsed.port) {
     config.port = Number(parsed.port);

--- a/tests/cli-mssql-url.test.ts
+++ b/tests/cli-mssql-url.test.ts
@@ -55,6 +55,26 @@ describe('mssqlUrlToConfig', () => {
   it('does not leak the password when the URL cannot be parsed', () => {
     expect(() => mssqlUrlToConfig('mssql://sa:S3cret@host:notaport/db')).not.toThrow(/S3cret/);
   });
+
+  // Regression for #306: `new URL` keeps a broken percent sequence verbatim, so
+  // the throw came out of decodeURIComponent as a bare "URI malformed".
+  it('explains an incomplete percent-escape instead of throwing "URI malformed"', () => {
+    expect(() => mssqlUrlToConfig('mssql://sa:p%ss@host/db')).toThrow(
+      /Invalid SQL Server connection URL.*%25/s,
+    );
+  });
+
+  it.each([
+    ['user', 'mssql://p%ss:S3cret@host/db'],
+    ['host', 'mssql://sa:S3cret@ho%st/db'],
+    ['database', 'mssql://sa:S3cret@host/d%b'],
+  ])('explains an incomplete percent-escape in the %s', (_part, url) => {
+    expect(() => mssqlUrlToConfig(url)).toThrow(/incomplete percent-escape/);
+  });
+
+  it('does not leak the password when a percent-escape is incomplete', () => {
+    expect(() => mssqlUrlToConfig('mssql://sa:S3cret%@host/db')).not.toThrow(/S3cret/);
+  });
 });
 
 describe('detectDialect for SQL Server inputs', () => {


### PR DESCRIPTION
Fixes #306.

## The bug

```
owlsql generate --url "mssql://sa:p%ss@host/db" --out x.ts
# Error: URI malformed
```

Compare `mssql://host:notaport/db`, which gets the deliberate explanation ("Invalid SQL Server connection URL... Expected mssql://user:password@host..."). Passwords with special characters are the ones most likely to carry a stray `%`, so the users who hit this are exactly the ones who need the hint about percent-encoding.

## The fix

`parseMssqlUrl`'s try/catch wraps only `new URL`, which tolerates a broken percent sequence and keeps it verbatim. The throw happens later, in the four `decodeURIComponent` calls that sit outside any catch.

All four now go through one `decodeUrlPart` helper that turns the `URIError` into a message in the same shape as the existing one, plus the actionable part: a literal `%` has to be written `%25`.

**The value stays out of the message.** Three of the four decodes are user, password and database — echoing the input here would have reintroduced the credential leak that #251 and #278 are about.

## Verification

`tests/cli-mssql-url.test.ts`, five new cases:

- `mssql://sa:p%ss@host/db` matches `/Invalid SQL Server connection URL.*%25/` (red before: it threw `URIError: URI malformed`)
- the same broken escape in the user, the host and the database name
- a control that the password is not in the message

15 tests in the file pass; `tsc --noEmit` clean.