### PR TITLE
fix(cli): accept a file:/// SQLite URL on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- `owlsql generate --url "file:///C:/data/app.db"` finds the database on Windows. The RFC 8089 form carries an empty authority, so stripping `file://` left that slash glued to the drive letter and the file was reported missing under `/C:/data/app.db`, a path nobody wrote ([#305](https://github.com/tiagolauer/OwlSQL/issues/305)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -70,10 +70,18 @@ function isRowidAlias(column: SqliteTableInfoRow, primaryKeyCount: number): bool
 // name nobody wrote (issue #236).
 const SQLITE_URL_PREFIXES = ['sqlite://', 'sqlite:', 'file://', 'file:'];
 
+// RFC 8089 puts an empty authority before an absolute path, so a Windows file
+// URL reads `file:///C:/data/app.db` and stripping `file://` leaves the
+// authority's slash glued to the drive letter. existsSync then tests
+// `/C:/data/app.db` and reports a path nobody wrote (issue #305). On POSIX the
+// same strip is already correct, and there is no drive letter to match.
+const AUTHORITY_SLASH_BEFORE_DRIVE = /^\/[a-zA-Z]:[/\\]/;
+
 export function normalizeSqlitePath(url: string): string {
   for (const prefix of SQLITE_URL_PREFIXES) {
     if (url.startsWith(prefix)) {
-      return url.slice(prefix.length);
+      const path = url.slice(prefix.length);
+      return AUTHORITY_SLASH_BEFORE_DRIVE.test(path) ? path.slice(1) : path;
     }
   }
   return url;

--- a/tests/cli-ux.test.ts
+++ b/tests/cli-ux.test.ts
@@ -34,6 +34,25 @@ describe('sqlite URL forms', () => {
     expect(normalizeSqlitePath('./app.db')).toBe('./app.db');
   });
 
+  // Regression for #305: the RFC 8089 form carries an empty authority, so
+  // stripping `file://` left its slash glued to the drive letter and the
+  // missing-file error named `/C:/data/app.db`.
+  it('drops the authority slash in front of a Windows drive letter', () => {
+    expect(normalizeSqlitePath('file:///C:/data/app.db')).toBe('C:/data/app.db');
+    expect(normalizeSqlitePath('file:///c:\\data\\app.db')).toBe('c:\\data\\app.db');
+    expect(normalizeSqlitePath('sqlite:///C:/data/app.db')).toBe('C:/data/app.db');
+  });
+
+  it('keeps a POSIX absolute path absolute', () => {
+    expect(normalizeSqlitePath('file:///var/data/app.db')).toBe('/var/data/app.db');
+    expect(normalizeSqlitePath('sqlite:///var/data/app.db')).toBe('/var/data/app.db');
+  });
+
+  it('leaves the two nonstandard Windows spellings alone', () => {
+    expect(normalizeSqlitePath('file://C:/data/app.db')).toBe('C:/data/app.db');
+    expect(normalizeSqlitePath('file:C:/data/app.db')).toBe('C:/data/app.db');
+  });
+
   it.skipIf(!sqliteAvailable)('introspects through a file: URL', async () => {
     const { dir, file } = createDatabase();
     try {


### PR DESCRIPTION
Fixes #305.

## The bug

```
owlsql generate --url "file:///C:/data/app.db" --out x.ts
# Error: SQLite database file not found: "/C:/data/app.db".
```

`file://C:/data/app.db` and `file:C:/data/app.db` both work. The triple-slash form is the one RFC 8089 mandates and the one most tools put on the clipboard, and the error names a path the user never wrote, so it reads like a phantom missing file.

## The fix

RFC 8089 puts an *empty authority* between the scheme and an absolute path — that is the third slash. `normalizeSqlitePath` strips `file://` literally, so the authority's slash stayed glued to the drive path.

One rule: drop a leading `/` when a drive letter follows it. On POSIX there is no drive letter, so `file:///var/data/app.db` still normalizes to `/var/data/app.db` and stays absolute.

**Not `url.fileURLToPath`**, which the issue offers as the alternative: it rejects `file://C:/data/app.db` (a bare `C` reads as the authority), and that spelling works today and is one of the two the issue explicitly reports as working.

Percent-decoding is left alone deliberately — it would change how the two nonstandard spellings treat a literal `%` in a filename, which is beyond what is broken here.

## Verification

`tests/cli-ux.test.ts`, three new cases red before the fix:

- `file:///C:/data/app.db` → `C:/data/app.db` (was `/C:/data/app.db`), plus the backslash and `sqlite:///` spellings
- controls: `file:///var/data/app.db` stays `/var/data/app.db`, and both nonstandard Windows spellings are untouched

17 tests in the file pass.