### PR TITLE
fix(cli): redact credentials in the SQLite missing-file error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- The CLI no longer echoes a password when a connection URL is malformed in a way the blocklist misses. `jdbc:postgresql://user:pw@host/db` and `postgres//user:pw@host/db` (missing colon) match neither the scheme detector nor the credential patterns, so both fell through to sqlite and the "database file not found" error printed the raw string, password included, into terminal scrollback and CI logs. The echo is redacted at the point it is written, which covers the next gap too ([#278](https://github.com/tiagolauer/OwlSQL/issues/278)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import type { ConnectionInfo, TableSchema } from '../types.js';
+import { redactCredentials } from '../redact.js';
 
 export function mapSqliteType(declaredType: string): string {
   const type = declaredType.toUpperCase().trim();
@@ -97,8 +98,14 @@ export async function introspectSqlite(connection: ConnectionInfo): Promise<Tabl
     ? connection.url
     : normalizeSqlitePath(connection.url);
 
+  // Redacted because sqlite is where every string detectDialect does not
+  // recognize ends up, and some of those carry credentials: `jdbc:postgresql://
+  // user:pw@host/db` and `postgres//user:pw@host/db` match neither the scheme
+  // detector nor the credential blocklist, so the password reached stderr - and
+  // CI logs - intact (issue #278). Redacting at the echo covers the next
+  // blocklist gap without another pattern.
   if (!isMemoryDatabase(path) && !existsSync(path)) {
-    throw new Error(`SQLite database file not found: "${path}".`);
+    throw new Error(`SQLite database file not found: "${redactCredentials(path)}".`);
   }
 
   const db = new DatabaseSyncCtor(path, { readOnly: !isMemoryDatabase(path) });

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -5,6 +5,7 @@ import { introspectPostgres } from './dialects/postgres.js';
 import { introspectMysql } from './dialects/mysql.js';
 import { introspectSqlite } from './dialects/sqlite.js';
 import { introspectMssql } from './dialects/mssql.js';
+import { redactCredentials } from './redact.js';
 
 export interface GenerateOptions {
   url: string;
@@ -37,29 +38,7 @@ const MISTYPED_URL_CREDENTIALS_PATTERN = /^(?![a-z]:[/\\])[a-z][a-z0-9+.-]*:\/{1
 const ADO_CREDENTIALS_PATTERN =
   /(^|;)\s*(uid|user id|pwd|password|database|initial catalog|trusted_connection|integrated security|driver|dsn)\s*=/i;
 
-// URL userinfo ("//user:pass@" or a mistyped single-slash ":/user:pass@"). The
-// single-slash form requires a multi-character scheme before the ":/" so that
-// Windows drive-letter paths ("C:/app@prod.db") are not treated as URL userinfo.
-//
-// The userinfo run is greedy up to the *last* "@" of the authority, because
-// that is the one a URL parser splits on: an unencoded "@" inside a password
-// ("root:p@ss@host") is accepted by `new URL` and by the drivers, and a
-// non-greedy match stopped at the first one and printed the rest of the
-// password (issue #251). "/", "?" and "#" end the authority, so a later "@"
-// in a path or query is never mistaken for userinfo.
-const URL_CREDENTIALS_PATTERN = /(\/\/|(?<=[a-z][a-z0-9+.-]):\/)[^/?#]*@/i;
-
-// The password value of an ADO / DSN "Pwd="/"Password=" pair. The value may be
-// wrapped in double quotes, braces, or single quotes (so an embedded ";" does
-// not terminate it); an unquoted value runs to the next ";" delimiter.
-const DSN_PASSWORD_PATTERN =
-  /((?:^|;)\s*(?:pwd|password)\s*=)("[^"]*"|\{[^}]*\}|'[^']*'|[^;]*)/gi;
-
-export function redactCredentials(url: string): string {
-  return url
-    .replace(URL_CREDENTIALS_PATTERN, (_match, separator: string) => `${separator}***@`)
-    .replace(DSN_PASSWORD_PATTERN, '$1***');
-}
+export { redactCredentials } from './redact.js';
 
 function unrecognizedUrlError(url: string): Error {
   return new Error(

--- a/src/cli/redact.ts
+++ b/src/cli/redact.ts
@@ -1,0 +1,25 @@
+// URL userinfo ("//user:pass@" or a mistyped single-slash ":/user:pass@"). The
+// single-slash form requires a multi-character scheme before the ":/" so that
+// Windows drive-letter paths ("C:/app@prod.db") are not treated as URL userinfo.
+//
+// The userinfo run is greedy up to the *last* "@" of the authority, because
+// that is the one a URL parser splits on: an unencoded "@" inside a password
+// ("root:p@ss@host") is accepted by `new URL` and by the drivers, and a
+// non-greedy match stopped at the first one and printed the rest of the
+// password (issue #251). "/", "?" and "#" end the authority, so a later "@"
+// in a path or query is never mistaken for userinfo.
+const URL_CREDENTIALS_PATTERN = /(\/\/|(?<=[a-z][a-z0-9+.-]):\/)[^/?#]*@/i;
+
+// The password value of an ADO / DSN "Pwd="/"Password=" pair. The value may be
+// wrapped in double quotes, braces, or single quotes (so an embedded ";" does
+// not terminate it); an unquoted value runs to the next ";" delimiter.
+const DSN_PASSWORD_PATTERN =
+  /((?:^|;)\s*(?:pwd|password)\s*=)("[^"]*"|\{[^}]*\}|'[^']*'|[^;]*)/gi;
+
+// Lives here rather than in generate.ts so the dialect modules can call it
+// without importing the module that imports them (issue #278).
+export function redactCredentials(url: string): string {
+  return url
+    .replace(URL_CREDENTIALS_PATTERN, (_match, separator: string) => `${separator}***@`)
+    .replace(DSN_PASSWORD_PATTERN, '$1***');
+}

--- a/tests/cli-redact.test.ts
+++ b/tests/cli-redact.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { detectDialect, redactCredentials } from '../src/cli/generate.js';
+import { introspectSqlite } from '../src/cli/dialects/sqlite.js';
+import { sqliteAvailable } from './sqlite-availability.js';
 
 describe('redactCredentials', () => {
   it('replaces the user:password segment with ***', () => {
@@ -56,5 +58,39 @@ describe('detectDialect error redaction', () => {
     expect(message).toContain('postgress://***@host/db');
     expect(message).not.toContain('S3cret');
     expect(message).not.toContain('user:');
+  });
+});
+
+// Regression for #278: a second scheme token ("jdbc:postgresql://") and a
+// missing colon ("postgres//") match neither SCHEME_PATTERN nor the credential
+// blocklist, so both land in the sqlite fallback, which echoed the raw string.
+describe.skipIf(!sqliteAvailable)('sqlite missing-file error redaction', () => {
+  it.each([
+    'jdbc:postgresql://user:S3cret@host/db',
+    'postgres//user:S3cret@host/db',
+  ])('does not echo the password for %s', async (url) => {
+    expect(detectDialect(url)).toBe('sqlite');
+
+    let message = '';
+    try {
+      await introspectSqlite({ url });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('SQLite database file not found');
+    expect(message).toContain('***@host/db');
+    expect(message).not.toContain('S3cret');
+  });
+
+  it('still names an ordinary missing path in full', async () => {
+    let message = '';
+    try {
+      await introspectSqlite({ url: './no-such-database.db' });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('"./no-such-database.db"');
   });
 });


### PR DESCRIPTION
Fixes #278.

## The bug

```
owlsql generate --url "jdbc:postgresql://user:S3cret@host/db" --out x.ts
# Error: SQLite database file not found: "jdbc:postgresql://user:S3cret@host/db".
```

Same for a missing colon (`postgres//user:S3cret@host/db`). `detectDialect` returns `'sqlite'` for both, and the sqlite error prints the raw string — password included — on stderr, so terminal scrollback and CI logs end up holding the secret.

## The fix

`MISTYPED_URL_CREDENTIALS_PATTERN` expects the credentials right after the first `scheme:/`, so a second scheme token or a colonless `postgres//` matches neither it nor `SCHEME_PATTERN` and reaches the sqlite fallback.

Redacting at the echo (`src/cli/dialects/sqlite.ts`) rather than adding a third detection pattern, which is what the issue recommends and for the reason it gives: sqlite is where *every* unrecognized string ends up, so this covers the next blocklist gap at once. `redactCredentials()` already handled both strings correctly — the error site just never called it.

One structural change to make that possible: `redactCredentials` and its two patterns move to `src/cli/redact.ts`, because `generate.ts` imports the dialect modules and a dialect importing `generate.ts` back would be a cycle. `generate.ts` re-exports it, so the name it is imported under everywhere else (including `tests/cli-redact.test.ts`) does not change.

## Verification

`tests/cli-redact.test.ts`, three new cases:

- both reported URLs: `detectDialect` still returns `'sqlite'`, the error contains `***@host/db`, and `S3cret` appears nowhere — **red before the fix**:
  ```
  AssertionError: expected 'SQLite database file not found: "post…' to contain '***@host/db'
  ```
- a control that an ordinary missing path is still named in full (`"./no-such-database.db"`), since redaction must not make a real file-not-found unreadable

40 tests across `cli-redact`, `cli-ux` and `cli-generate` pass; `tsc --noEmit` clean.