### PR TITLE
fix(cli): introspect SQLite generated columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- `owlsql generate` picks up SQLite generated columns. `PRAGMA table_info` omits them, so a `generated always as (...)` column, VIRTUAL or STORED, was missing from the schema while `select *` returned it — the generated `DB` disagreed with every read, and strict mode and the editor plugin flagged valid queries touching those columns ([#292](https://github.com/tiagolauer/OwlSQL/issues/292)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/cli/dialects/sqlite.ts
+++ b/src/cli/dialects/sqlite.ts
@@ -56,6 +56,16 @@ interface SqliteTableInfoRow {
   type: string;
   notnull: number;
   pk: number;
+  hidden: number;
+}
+
+// table_xinfo's `hidden` flag: 0 ordinary, 1 a virtual table's hidden column,
+// 2 a VIRTUAL generated column, 3 a STORED one. `select *` returns 0, 2 and 3
+// and skips 1, so this is the set that has to match the schema (issue #292).
+const VISIBLE_HIDDEN_FLAGS = new Set([0, 2, 3]);
+
+function isVisibleColumn(column: SqliteTableInfoRow): boolean {
+  return VISIBLE_HIDDEN_FLAGS.has(column.hidden);
 }
 
 function isRowidAlias(column: SqliteTableInfoRow, primaryKeyCount: number): boolean {
@@ -109,9 +119,15 @@ export async function introspectSqlite(connection: ConnectionInfo): Promise<Tabl
       .all() as { name: string }[];
 
     return tableRows.map((tableRow) => {
-      const columns = db
-        .prepare(`PRAGMA table_info(${quoteIdentifier(tableRow.name)})`)
-        .all() as unknown as SqliteTableInfoRow[];
+      // table_xinfo rather than table_info: the latter omits generated columns
+      // entirely, so a `total real generated always as (...)` column was missing
+      // from the schema while `select *` returned it, and strict mode plus the
+      // editor plugin flagged every valid query touching it (issue #292).
+      const columns = (
+        db
+          .prepare(`PRAGMA table_xinfo(${quoteIdentifier(tableRow.name)})`)
+          .all() as unknown as SqliteTableInfoRow[]
+      ).filter(isVisibleColumn);
 
       const primaryKeyCount = columns.filter((column) => column.pk > 0).length;
 

--- a/tests/cli-sqlite-introspect.test.ts
+++ b/tests/cli-sqlite-introspect.test.ts
@@ -62,6 +62,57 @@ describe.skipIf(!sqliteAvailable)('introspectSqlite', () => {
     }
   });
 
+  // Regression for #292: PRAGMA table_info omits generated columns, so the
+  // schema disagreed with `select *`, which returns all four.
+  it('includes VIRTUAL and STORED generated columns', async () => {
+    const file = withTempDatabase((db) => {
+      db.exec(`
+        create table products (
+          id integer primary key,
+          price real not null,
+          total_v real generated always as (price * 2) virtual,
+          total_s real generated always as (price * 3) stored
+        )
+      `);
+    });
+
+    try {
+      const tables = await introspectSqlite({ url: file });
+
+      expect(tables[0]?.columns.map((column) => column.name)).toEqual([
+        'id',
+        'price',
+        'total_v',
+        'total_s',
+      ]);
+      expect(tables[0]?.columns.map((column) => column.tsType)).toEqual([
+        'number',
+        'number',
+        'number',
+        'number',
+      ]);
+    } finally {
+      rmSync(join(file, '..'), { recursive: true, force: true });
+    }
+  });
+
+  // table_xinfo also exposes a virtual table's own hidden columns (hidden = 1),
+  // which `select *` does not return and the schema must not claim.
+  it('leaves a virtual table hidden column out', async () => {
+    const file = withTempDatabase((db) => {
+      db.exec("create virtual table docs using fts5(title, body)");
+    });
+
+    try {
+      const tables = await introspectSqlite({ url: file });
+      const docs = tables.find((table) => table.name === 'docs');
+
+      expect(docs?.columns.map((column) => column.name)).toEqual(['title', 'body']);
+    } finally {
+      rmSync(join(file, '..'), { recursive: true, force: true });
+    }
+  });
+
   it('introspects multiple tables', async () => {
     const file = withTempDatabase((db) => {
       db.exec('create table users (id integer primary key, name text not null)');


### PR DESCRIPTION
Fixes #292.

## The bug

```sql
create table products (
  id integer primary key,
  price real not null,
  total_v real generated always as (price * 2) virtual,
  total_s real generated always as (price * 3) stored
);
```

`introspectSqlite` returned only `id` and `price`. `select *` on node:sqlite returns all four, so the generated `DB` interface disagreed with every read, and strict mode plus the editor plugin flagged valid queries touching `total_v`/`total_s` as unknown columns.

## The fix

`PRAGMA table_info` → `PRAGMA table_xinfo`, filtered on the `hidden` flag.

Verified against a real database, which is also where the flag values come from:

```
table_info:  [{id,pk:1},{price}]
table_xinfo: [{id,hidden:0},{price,hidden:0},{total_v,hidden:2},{total_s,hidden:3}]
```

`hidden` is 0 for an ordinary column, 1 for a virtual table's own hidden column, 2 for VIRTUAL generated and 3 for STORED. Keeping `{0, 2, 3}` is exactly the set `select *` returns — 1 has to stay out, or an FTS5 table would gain a column no read ever produces.

## Verification

`tests/cli-sqlite-introspect.test.ts`, two new cases against real databases:

- the four-column `products` table above: all four names and types, red before the fix (only `id` and `price` came back)
- an `fts5` virtual table: still just `title` and `body`, pinning the `hidden = 1` exclusion

5 tests in the file pass; `tsc --noEmit` clean.