### PR TITLE
fix(sqlite): reject a numbered ? placeholder by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A SQLite `?NNN` placeholder is rejected with an explanation instead of the driver's "column index out of range". The type layer gives `?1` no slot at all, the parameter scanner read it as a bare `?` and pushed a value node:sqlite could not place, and the error that came back pointed nowhere useful. Write a bare `?`, a `$1`, or a `:name` ([#304](https://github.com/tiagolauer/OwlSQL/issues/304)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1008,7 +1008,9 @@ This is a focused tool for the common read path, not a full SQL grammar:
   query, ahead of placeholders in the outer query that follows the `WITH`
   clause. Numbered placeholders bind by
   their index (`$2` fills the second tuple slot even when it appears first);
-  a repeated `$n` occupies a single slot.
+  a repeated `$n` occupies a single slot. SQLite's numbered `?NNN` form is
+  not typed and is rejected by the adapters with an explanation — write a
+  bare `?`, a `$n`, or a `:name` instead.
 - **Quoted identifiers** use `"..."` (standard), `[...]` (SQL Server), or
   `` `...` `` (MySQL — escape the backtick with `\`` inside the template
   literal). A quoted name may contain spaces (`"first name"`,

--- a/src/adapters/named-params.ts
+++ b/src/adapters/named-params.ts
@@ -87,6 +87,8 @@ function skipNonParameterRegion(sql: string, index: number): number {
 
 const INDEXED_PARAM_BODY = /^[0-9]+$/;
 
+const NUMBERED_POSITIONAL_BODY = /^[0-9]+/;
+
 type ParameterToken =
   | { kind: 'positional' }
   | { kind: 'named'; name: string }
@@ -109,6 +111,18 @@ function scanParameters(
     const char = sql[index] as string;
 
     if (char === '?') {
+      // SQLite's `?NNN` binds by number, but nothing above here knows that: the
+      // type layer gives it no slot, so the caller is typed as passing nothing,
+      // and this scanner used to read it as a bare `?` and push a positional
+      // value the driver could not place, which surfaced as node:sqlite's
+      // "column index out of range" (issue #304). Saying so beats that.
+      const digits = NUMBERED_POSITIONAL_BODY.exec(sql.slice(index + 1));
+      if (digits) {
+        throw new Error(
+          `Unsupported placeholder "?${digits[0]}": numbered ? placeholders are not typed by OwlSQL. Use a bare "?", or a numbered "$${digits[0]}", or a named ":name" placeholder.`,
+        );
+      }
+
       visit({ kind: 'positional' });
       index += 1;
       continue;

--- a/tests/adapter-node-sqlite.test.ts
+++ b/tests/adapter-node-sqlite.test.ts
@@ -365,4 +365,15 @@ describe.skipIf(!sqliteAvailable)('numbered placeholders bind by index', () => {
       executor('select id, name from users where id = $1 or id = $1', [2]),
     ).resolves.toEqual([{ id: 2, name: 'grace' }]);
   });
+
+  // Regression for #304: node:sqlite's anonymous-args API cannot bind a
+  // numbered slot, so this used to surface as "column index out of range".
+  it('rejects a ?NNN placeholder by name instead of by driver error', async () => {
+    const sqlite = seededDatabase();
+    const executor = createNodeSqliteExecutor(sqlite);
+
+    await expect(executor('select id from users where id = ?1', [])).rejects.toThrow(
+      /Unsupported placeholder "\?1"/,
+    );
+  });
 });

--- a/tests/named-params.test.ts
+++ b/tests/named-params.test.ts
@@ -127,3 +127,34 @@ describe('resolveMixedParameters', () => {
     });
   });
 });
+
+// Regression for #304: the type layer gives `?NNN` no slot at all, so the
+// caller passes nothing, and this scanner used to read it as a bare `?` and
+// push a positional value node:sqlite could not place - "column index out of
+// range", which points nowhere useful.
+describe('numbered ? placeholders', () => {
+  it('rejects ?1 with a message that names the alternatives', () => {
+    expect(() => resolveMixedParameters('select id from t where id = ?1', AT_DOLLAR_COLON, [])).toThrow(
+      /Unsupported placeholder "\?1".*\$1.*:name/s,
+    );
+  });
+
+  it('rejects a multi-digit ?12', () => {
+    expect(() => resolveMixedParameters('select id from t where id = ?12', AT_DOLLAR_COLON, [])).toThrow(
+      /Unsupported placeholder "\?12"/,
+    );
+  });
+
+  it('leaves a bare ? alone', () => {
+    expect(resolveMixedParameters('select id from t where id = ?', AT_DOLLAR_COLON, [7])).toEqual({
+      named: {},
+      positional: [7],
+    });
+  });
+
+  it('does not fire on a ?NNN inside a literal or a comment', () => {
+    expect(
+      resolveMixedParameters("select '?1' from t where a = ? -- ?2\n", AT_DOLLAR_COLON, [7]),
+    ).toEqual({ named: {}, positional: [7] });
+  });
+});


### PR DESCRIPTION
Fixes #304.

## The bug

```ts
Params<DB, 'select id from users where id = ?1'>  // [] - zero slots
await executor('select id from users where id = ?1', []);
// Error: column index out of range   (surfaced as EXECUTOR_FAILED)
```

Three layers disagree about `?NNN`. The type layer's `IsPlaceholder` does not recognize it, so the tuple is empty and the caller is typed as passing nothing. `scanParameters` read the `?` as a bare positional and left the digits in the SQL, pushing a value node:sqlite's anonymous-args API cannot place. The driver's error names neither the placeholder nor anything actionable.

## The fix

The issue offers two routes — bind `?NNN` by its number, or reject it upfront with a clear message. This is the second.

The reason is scope: the query already always fails (no silent corruption), so the message *is* the bug. Typing `?NNN` end to end would mean teaching `IsPlaceholder`, `DigitsToCounter` and the dialect brand a fourth placeholder style — a feature, and one that only one of the four engines has.

`scanParameters` now throws when digits follow a `?`:

```
Unsupported placeholder "?1": numbered ? placeholders are not typed by OwlSQL.
Use a bare "?", or a numbered "$1", or a named ":name" placeholder.
```

It sits in the shared scanner, so the mssql adapter gets the same treatment, and it is behind the existing literal/comment/quoted-identifier skipping — `'?1'` in a string is still a string.

README's typed-parameter limitation gains one sentence saying so.

## Verification

`tests/named-params.test.ts`, four cases: `?1` and `?12` rejected with that message, a bare `?` untouched, and `?1` inside a literal or a comment not firing. `tests/adapter-node-sqlite.test.ts`, one end-to-end case against a real in-memory database, red before the fix with `column index out of range`.

25 + 20 tests in those files pass; `tsc --noEmit` clean.