### PR TITLE
fix(params): strip $action as a whole token, not a substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A named placeholder whose name starts with `action` (`$actionType`, `$action_id`, `$actionable`) is checked against the dialect again. MERGE's `$action` pseudo-column was stripped as a substring rather than as a whole token, so those names left no dollar placeholder behind, the query reported no placeholder style at all, and it passed the brand check against a mysql or sqlite client that can never bind a `$name` - while the parameter tuple still demanded a value for it ([#298](https://github.com/tiagolauer/OwlSQL/issues/298)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/params.ts
+++ b/src/params.ts
@@ -475,8 +475,17 @@ type StripDoubledAt<S extends string> = S extends `${infer Before}@@${infer Afte
   ? StripDoubledAt<`${Before}${After}`>
   : S;
 
+// Whole-token, because `$actionType` is a name that merely starts with the
+// pseudo-column's letters. Stripping the substring turned it into `type`, the
+// dollar scan then found nothing, and the query reported no placeholder style
+// at all - so it passed the brand check for every dialect while Params still
+// demanded a value for it, which is the guaranteed runtime failure the brand
+// exists to prevent (issue #298). IsPlaceholder already excluded only the
+// exact token; this is the same rule on the other side.
 type StripDollarAction<S extends string> = S extends `${infer Before}$action${infer After}`
-  ? StripDollarAction<`${Before}${After}`>
+  ? StartsWithIdentifierChar<After> extends true
+    ? `${Before}$action${StripDollarAction<After>}`
+    : `${Before}${StripDollarAction<After>}`
   : S;
 
 // A prefix only counts when a name or an index follows it, the same rule

--- a/tests/dialect-brand.test-d.ts
+++ b/tests/dialect-brand.test-d.ts
@@ -50,6 +50,22 @@ export async function placeholderStyleCallSites() {
   // @ts-expect-error a question-style client rejects @name placeholders
   await mysqlDb.query('select id from users where id = @id', 1);
 
+  // Regression for #298: `$action` used to be stripped as a substring, so a
+  // name that merely starts with it left no dollar token behind, the query
+  // reported no placeholder style at all, and it passed the brand check for
+  // every dialect - while Params still demanded a value for it. No driver but
+  // Postgres can bind a `$name`.
+  // @ts-expect-error a question-style client rejects a $actionType placeholder
+  await mysqlDb.query('select id from users where name = $actionType', 'x');
+
+  // @ts-expect-error the underscore spelling is a name too
+  await mysqlDb.query('select id from users where name = $action_id', 'x');
+
+  // @ts-expect-error and so is a plain suffix
+  await mysqlDb.query('select id from users where name = $actionable', 'x');
+
+  await pgDb.query('select id from users where name = $actionType', 'x');
+
   await uncheckedDb.query('select id from users where id = $1', 1);
   await uncheckedDb.query('select id from users where id = ?', 1);
 


### PR DESCRIPTION
Fixes #298.

## The bug

```ts
const db = createTypedDb<DB, { placeholders: 'question' }>(executor);
db.query('select id from users where kind = $actionType', 'x'); // compiles
```

`UsedPlaceholderStyles` came back `never` for that query, so the brand check passed for any dialect, while `Params` still assigned the token a `[string]` slot. A mysql or sqlite driver can never bind a `$name`, so this is exactly the guaranteed runtime failure the brand exists to prevent. Same for `$action_id`, `$actionable`, and friends.

## The fix

The two layers disagreed about what `$action` means. `StripDollarAction` removed the *substring* anywhere, so `$actiontype` became `type` before the dollar scan ran; `IsPlaceholder` excludes only the *exact* token. The strip now follows `IsPlaceholder`'s rule: keep `$action` when an identifier character follows it.

MERGE is unaffected — a real `output $action, inserted.id` has a comma after it, and `tests/dialect-mssql.test-d.ts` pins that (the pseudo-column takes no parameter slot and does not make the statement look dollar-styled).

## Verification

`tests/dialect-brand.test-d.ts`, four new cases. The three `@ts-expect-error` ones are red on master, which `tsc` reports precisely because the directive is *unused* there:

```
tests/dialect-brand.test-d.ts(58,3): error TS2578: Unused '@ts-expect-error' directive.
tests/dialect-brand.test-d.ts(61,3): error TS2578: Unused '@ts-expect-error' directive.
tests/dialect-brand.test-d.ts(64,3): error TS2578: Unused '@ts-expect-error' directive.
```

- a question-style client rejects `$actionType`, `$action_id` and `$actionable`
- a control: a dollar-style client still accepts `$actionType`

`tsc --noEmit` clean, budget 192,568 (+82).