### PR TITLE
fix(plugin): resolve a qualified CTE reference instead of flagging it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- The editor plugin stops flagging every qualified reference to a CTE as an unknown alias. `with recent as (...) select r.id from recent r`, the same reference by the CTE's own name, and the same in a WHERE clause all resolve cleanly in the type layer; the plugin dropped CTE names from its source list and had nothing left to match the qualifier against ([#293](https://github.com/tiagolauer/OwlSQL/issues/293)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/ts-plugin/src/diagnostics.cts
+++ b/ts-plugin/src/diagnostics.cts
@@ -2,7 +2,8 @@ import type * as ts from 'typescript';
 import sqlContext = require('./sql-context.cjs');
 import schemaModule = require('./schema.cjs');
 
-const { findSources, findSourceByAlias, stripStringLiterals, stripWithClause } = sqlContext;
+const { findSources, findCteQualifiers, findSourceByAlias, stripStringLiterals, stripWithClause } =
+  sqlContext;
 const { tableExists, columnExists } = schemaModule;
 
 const SELECT_KEYWORD = /^\s*select\b/i;
@@ -151,6 +152,7 @@ function whereTokenDiagnostics(
   dbType: ts.Type,
   literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral,
   sources: ReturnType<typeof findSources>,
+  cteQualifiers: Set<string>,
   token: { text: string; start: number },
 ): DiagnosticSpan[] {
   if (
@@ -167,6 +169,13 @@ function whereTokenDiagnostics(
   const columnStart = token.start + (dotIndex === -1 ? 0 : dotIndex + 1);
 
   if (qualifier) {
+    // A qualifier naming a CTE, or the alias a FROM/JOIN gave one, resolves in
+    // the type layer; findSources leaves CTEs out because their projected
+    // columns are not something this scanner can compute, so the reference has
+    // to be skipped rather than reported (issue #293).
+    if (cteQualifiers.has(qualifier.toLowerCase())) {
+      return [];
+    }
     const matchedSource = findSourceByAlias(sources, qualifier);
     if (!matchedSource) {
       return [{ start: token.start, length: qualifier.length, message: `unknown alias: ${qualifier}` }];
@@ -211,6 +220,7 @@ function findWhereDiagnostics(
   dbType: ts.Type,
   literal: ts.StringLiteral | ts.NoSubstitutionTemplateLiteral,
   sources: ReturnType<typeof findSources>,
+  cteQualifiers: Set<string>,
   stripped: string,
   literalStart: number,
 ): DiagnosticSpan[] {
@@ -229,7 +239,7 @@ function findWhereDiagnostics(
       return;
     }
     diagnostics.push(
-      ...whereTokenDiagnostics(typescript, checker, dbType, literal, sources, {
+      ...whereTokenDiagnostics(typescript, checker, dbType, literal, sources, cteQualifiers, {
         text: prevToken.text,
         start: literalStart + prevToken.start,
       }),
@@ -312,6 +322,7 @@ function getQueryDiagnostics(
   }
 
   const sources = findSources(text);
+  const cteQualifiers = findCteQualifiers(text);
   const diagnostics: DiagnosticSpan[] = [];
 
   for (const source of sources) {
@@ -346,6 +357,9 @@ function getQueryDiagnostics(
     const columnStart = tokenStart + (dotIndex === -1 ? 0 : dotIndex + 1);
 
     if (qualifier) {
+      if (cteQualifiers.has(qualifier.toLowerCase())) {
+        continue;
+      }
       const matchedSource = findSourceByAlias(sources, qualifier);
       if (!matchedSource) {
         diagnostics.push({ start: tokenStart, length: qualifier.length, message: `unknown alias: ${qualifier}` });
@@ -377,7 +391,16 @@ function getQueryDiagnostics(
   }
 
   diagnostics.push(
-    ...findWhereDiagnostics(typescript, checker, dbType, literal, sources, stripped, literalStart),
+    ...findWhereDiagnostics(
+      typescript,
+      checker,
+      dbType,
+      literal,
+      sources,
+      cteQualifiers,
+      stripped,
+      literalStart,
+    ),
   );
 
   return diagnostics;

--- a/ts-plugin/src/sql-context.cts
+++ b/ts-plugin/src/sql-context.cts
@@ -345,7 +345,24 @@ function findFromTable(fullLiteralText: string): string | null {
   return match?.[1] ?? null;
 }
 
+// The qualifiers a CTE can be referenced through: its own name, plus whatever
+// alias the FROM/JOIN entry gives it. findSources drops those entries, so the
+// qualified checks in diagnostics.cts had nothing to match them against and
+// reported a plain `unknown alias` on a reference the type layer resolves
+// (issue #293). Under the plugin's "not reported on, instead of reported
+// wrongly" policy, a qualifier in this set is skipped rather than flagged.
+function findCteQualifiers(fullLiteralText: string): Set<string> {
+  return scanSources(fullLiteralText).cteQualifiers;
+}
+
 function findSources(fullLiteralText: string): QuerySource[] {
+  return scanSources(fullLiteralText).sources;
+}
+
+function scanSources(fullLiteralText: string): {
+  sources: QuerySource[];
+  cteQualifiers: Set<string>;
+} {
   const { stripped } = stripStringLiterals(fullLiteralText);
   // A CTE's inner query is its own private scope: its FROM/JOIN sources
   // belong to it, not to the outer statement, so scan only what follows the
@@ -355,6 +372,7 @@ function findSources(fullLiteralText: string): QuerySource[] {
   // heuristic scanner can compute anyway.
   const { remainder, remainderStart, cteNames } = stripWithClause(stripped);
   const cteNameSet = new Set(cteNames.map((name) => name.toLowerCase()));
+  const cteQualifiers = new Set(cteNameSet);
   const fromClause = fromClauseRange(remainder);
   const sources: QuerySource[] = [];
 
@@ -369,7 +387,14 @@ function findSources(fullLiteralText: string): QuerySource[] {
     ).indices?.groups;
     const table = groups?.['table'];
     const tableSpan = spans?.['table'];
-    if (!table || !tableSpan || cteNameSet.has(table.toLowerCase())) {
+    if (!table || !tableSpan) {
+      continue;
+    }
+    if (cteNameSet.has(table.toLowerCase())) {
+      const cteAlias = groups?.['alias'] ?? null;
+      if (cteAlias && !RESERVED_AFTER_SOURCE.has(cteAlias.toLowerCase())) {
+        cteQualifiers.add(cteAlias.toLowerCase());
+      }
       continue;
     }
     if (
@@ -388,7 +413,7 @@ function findSources(fullLiteralText: string): QuerySource[] {
     });
   }
 
-  return sources;
+  return { sources, cteQualifiers };
 }
 
 function fromClauseRange(text: string): { start: number; end: number } {
@@ -464,6 +489,7 @@ export = {
   getFromClauseContext,
   findFromTable,
   findSources,
+  findCteQualifiers,
   findSourceByAlias,
   getQualifierBefore,
   getWordAtOffset,

--- a/ts-plugin/tests/diagnostics.test.ts
+++ b/ts-plugin/tests/diagnostics.test.ts
@@ -284,4 +284,43 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
       diagnosticsFor('select posts.titel from users join posts on users.id = posts.user_id'),
     ).toEqual([{ message: 'unknown column: titel', text: 'titel' }]);
   });
+
+  // Regression for #293: findSources drops CTE names, so every alias- or
+  // name-qualified reference to a CTE was reported as an unknown alias while
+  // the core type layer resolves all of them.
+  describe('CTE-qualified references', () => {
+    it('does not report an alias given to a CTE', () => {
+      expect(
+        diagnosticsFor('with recent as (select id from users) select r.id from recent r'),
+      ).toEqual([]);
+    });
+
+    it('does not report a CTE referenced by its own name', () => {
+      expect(diagnosticsFor('with recent as (select id from users) select recent.id from recent')).toEqual(
+        [],
+      );
+    });
+
+    it('does not report a CTE alias in the WHERE clause', () => {
+      expect(
+        diagnosticsFor(
+          'with recent as (select id from users) select r.id from recent r where r.id = 1',
+        ),
+      ).toEqual([]);
+    });
+
+    it('does not report the query type-locked in tests/cte.test-d.ts', () => {
+      expect(
+        diagnosticsFor(
+          'with popular as (select id, title from posts) select u.name, p.title from users u join popular p on u.id = p.id',
+        ),
+      ).toEqual([]);
+    });
+
+    it('still reports a qualifier that is neither a source nor a CTE', () => {
+      expect(
+        diagnosticsFor('with recent as (select id from users) select z.id from recent r'),
+      ).toEqual([{ message: 'unknown alias: z', text: 'z' }]);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #293.

## The bug

```
with recent as (select id from users) select r.id from recent r
                                             ^^^^ unknown alias: r
select recent.id from recent          -> unknown alias: recent
... from recent r where r.id = 1      -> unknown alias: r
```

The core type layer resolves all of these. The strongest form is the query type-locked in `tests/cte.test-d.ts` — a CTE joined to a real table — which gets an `unknown alias: p` squiggle in the editor while `tsc` is perfectly happy.

## The fix

`findSources` drops CTE names on purpose: a CTE is not a schema table and its projected columns are not something this heuristic scanner can compute. That left the qualified checks in `diagnostics.cts` (SELECT list and WHERE) with a qualifier matching no source, which they report as an unknown alias.

The source scan now also collects the qualifiers a CTE can be referenced through — its own name, plus whatever alias the FROM/JOIN entry gives it — and both checks skip those. That is the plugin's own stated policy: not reported on, instead of reported wrongly.

`findSources` and the new `findCteQualifiers` share one internal walk, so there is no second scan and no duplicated regex logic.

## Verification

`ts-plugin/tests/diagnostics.test.ts`, five new cases. Four are red on master (`PASS (41) FAIL (4)` with the src change stashed):

- an alias given to a CTE, the CTE referenced by its own name, a CTE alias in a WHERE clause, and the `tests/cte.test-d.ts` query
- a control that stays red-flagged: `select z.id from recent r` still reports `unknown alias: z`

Full plugin suite: 160 tests pass; `tsc --noEmit -p ts-plugin/tsconfig.json` clean.