### PR TITLE
fix(params): name the placeholder whose types conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A placeholder reused against columns of different types says so. `where id = $1 or name = $1` intersected `number` with `string`, collapsed the tuple to `[never]` and made every call - including the zero-argument one - fail with an opaque "not assignable to never" chain. The query is still rejected, since pg refuses inconsistent deduced parameter types too, but now as `QueryTypeError<'conflicting types for $1'>` ([#302](https://github.com/tiagolauer/OwlSQL/issues/302)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/params.ts
+++ b/src/params.ts
@@ -20,6 +20,7 @@ import type {
   AfterKeyword,
   SplitColumnList,
   MultipleStatementsError,
+  QueryTypeError,
 } from './parse.js';
 import type { ParseWithClause } from './cte.js';
 import type { FunctionName } from './functions.js';
@@ -186,16 +187,30 @@ type FindNameIndex<
     : FindNameIndex<Tail, Name, [...Position, unknown]>
   : never;
 
+// A repeated placeholder intersects the two types it was read with, and
+// `number & string` is `never`: the tuple became uncallable with any argument
+// list at all, including the empty one, behind an opaque "not assignable to
+// never" chain (issue #302). Rejecting the query is right - pg refuses
+// inconsistent deduced parameter types too - so this keeps the rejection and
+// adds the diagnosis. An earlier conflict is kept as it is rather than
+// intersected again, so the first placeholder that conflicts is the one named.
+type MergeSlot<Head, Type, Label extends string> = Head extends QueryTypeError<string>
+  ? Head
+  : [Head & Type] extends [never]
+    ? QueryTypeError<`conflicting types for ${Label}`>
+    : Head & Type;
+
 type SetSlot<
   Tuple extends unknown[],
   Position extends unknown[],
   Type,
+  Label extends string,
 > = Position extends [unknown, ...infer PositionRest extends unknown[]]
   ? Tuple extends [infer Head, ...infer TupleRest extends unknown[]]
-    ? [Head, ...SetSlot<TupleRest, PositionRest, Type>]
-    : [unknown, ...SetSlot<[], PositionRest, Type>]
+    ? [Head, ...SetSlot<TupleRest, PositionRest, Type, Label>]
+    : [unknown, ...SetSlot<[], PositionRest, Type, Label>]
   : Tuple extends [infer Head, ...infer TupleRest extends unknown[]]
-    ? [Head & Type, ...TupleRest]
+    ? [MergeSlot<Head, Type, Label>, ...TupleRest]
     : [Type];
 
 // `= any($1)` / `= all($1)` compare the column against a whole array, so the
@@ -248,14 +263,14 @@ type AddParam<
           : Existing extends unknown[]
             ? {
                 indexed: Indexed;
-                sequential: SetSlot<Sequential, Existing, Type>;
+                sequential: SetSlot<Sequential, Existing, Type, CleanScanToken<Token>>;
                 sequentialNames: SequentialNames;
               }
             : never
         : never
     : Position extends unknown[]
       ? {
-          indexed: SetSlot<Indexed, Position, Type>;
+          indexed: SetSlot<Indexed, Position, Type, CleanScanToken<Token>>;
           sequential: Sequential;
           sequentialNames: SequentialNames;
         }

--- a/tests/conflicting-params.test-d.ts
+++ b/tests/conflicting-params.test-d.ts
@@ -1,0 +1,79 @@
+import type { Params, QueryTypeError } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; email: string | null };
+  posts: { id: number; user_id: number; title: string };
+}
+
+// Reusing one placeholder against columns of different types has to be
+// rejected - pg refuses inconsistent deduced parameter types too - but the
+// bare `never` the intersection produced made every call fail, including the
+// zero-argument one, with nothing pointing at the cause (issue #302).
+type ConflictingNumberedPlaceholder = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = $1 or name = $1'>,
+    [QueryTypeError<'conflicting types for $1'>]
+  >
+>;
+
+type ConflictingNamedPlaceholder = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = @v or name = @v'>,
+    [QueryTypeError<'conflicting types for @v'>]
+  >
+>;
+
+type ConflictingColonPlaceholder = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = :v or name = :v'>,
+    [QueryTypeError<'conflicting types for :v'>]
+  >
+>;
+
+// The conflicting slot does not swallow the ones beside it.
+type ConflictKeepsTheOtherSlots = Expect<
+  Equal<
+    Params<DB, 'select id from users where id = $1 or name = $1 and email = $2'>,
+    [QueryTypeError<'conflicting types for $1'>, string | null]
+  >
+>;
+
+// Controls: repeating a placeholder against the same type is the documented
+// behaviour and still collapses to one slot.
+type RepeatedPlaceholderSameType = Expect<
+  Equal<Params<DB, 'select id from users where id = $1 or id = $1'>, [number]>
+>;
+
+type RepeatedNamedSameType = Expect<
+  Equal<Params<DB, 'select id from users where id = @id or id = @id'>, [number]>
+>;
+
+type RepeatedAcrossTablesSameType = Expect<
+  Equal<
+    Params<
+      DB,
+      'select u.id from users u join posts p on u.id = p.user_id where u.id = $1 or p.user_id = $1'
+    >,
+    [number]
+  >
+>;
+
+type DistinctPlaceholdersAreUnaffected = Expect<
+  Equal<Params<DB, 'select id from users where id = $1 or name = $2'>, [number, string]>
+>;
+
+export type ConflictingParamsLock = [
+  ConflictingNumberedPlaceholder,
+  ConflictingNamedPlaceholder,
+  ConflictingColonPlaceholder,
+  ConflictKeepsTheOtherSlots,
+  RepeatedPlaceholderSameType,
+  RepeatedNamedSameType,
+  RepeatedAcrossTablesSameType,
+  DistinctPlaceholdersAreUnaffected,
+];


### PR DESCRIPTION
Fixes #302.

## The bug

```ts
Params<DB, 'select id from users where id = $1 or name = $1'>
// [never]
```

Every call is rejected, including the zero-argument one, behind an opaque "not assignable to never" chain. Rejecting the query is defensible — pg refuses inconsistent deduced parameter types too — but nothing told the user what went wrong or where. #230 treated a `never` tuple as a bug for exactly this reason: the failure mode is invisible.

## The fix

`SetSlot` intersects on repeat (`Head & Type`), and `number & string` is `never`. The merge step now checks for that and produces `QueryTypeError<'conflicting types for $1'>`, naming the token as written — `$1`, `@v`, `:v`.

An already-conflicting slot is kept rather than intersected again, so a third occurrence does not rename the error.

## Verification

`tests/conflicting-params.test-d.ts`, eight cases. Four red on master:

```
tests/conflicting-params.test-d.ts(18,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/conflicting-params.test-d.ts(25,3): ...
tests/conflicting-params.test-d.ts(32,3): ...
tests/conflicting-params.test-d.ts(40,3): ...
```

- the numbered, `@name` and `:name` spellings each report their own token
- the conflicting slot does not swallow the one beside it (`[QueryTypeError<...>, string | null]`)

Four controls stay pinned: a repeat against the same type still collapses to one slot (numbered, named, and across a join), and two distinct placeholders are unaffected.

`tsc --noEmit` clean. Budget 193,953, up 1,467 from master's 192,486 (97% of 200,000) — the cost of one extra conditional in the merge step.