### PR TITLE
fix(params): stop accepting null for a comparison parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A parameter compared against a nullable column no longer accepts null. `where email = $1` typed its slot `string | null`, and passing null compiles into a query that matches nothing, since `= NULL` is never true. The `| null` belongs to the result side - most visibly with a LEFT JOIN, where it means a missing match, not a value to compare against. `is distinct from` keeps null, and so do SET assignments and INSERT values, where storing null is ordinary ([#299](https://github.com/tiagolauer/OwlSQL/issues/299)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1008,7 +1008,10 @@ This is a focused tool for the common read path, not a full SQL grammar:
   query, ahead of placeholders in the outer query that follows the `WITH`
   clause. Numbered placeholders bind by
   their index (`$2` fills the second tuple slot even when it appears first);
-  a repeated `$n` occupies a single slot.
+  a repeated `$n` occupies a single slot. A parameter compared against a
+  nullable column is typed without the `null` (`= NULL` never matches a row);
+  `is distinct from` keeps it, and so do `SET` assignments and `INSERT`
+  values, where storing null is ordinary.
 - **Quoted identifiers** use `"..."` (standard), `[...]` (SQL Server), or
   `` `...` `` (MySQL — escape the backtick with `\`` inside the template
   literal). A quoted name may contain spaces (`"first name"`,

--- a/src/params.ts
+++ b/src/params.ts
@@ -210,16 +210,41 @@ type WrapArrayArgument<T, Token extends string> = Token extends `${string}(${str
     : T
   : T;
 
+// `= NULL` never matches a row, so a comparison parameter that accepts null
+// types a query that silently returns nothing (issue #299). The `| null` on a
+// column belongs to the result side - it says a row can come back with that
+// column empty, including the one a LEFT JOIN invents - not to the value you
+// compare against.
+//
+// `is distinct from` is the exception, and the reason this is keyed on the
+// operator: comparing against null is the entire point of it.
+type NullTolerantOperator = 'distinct';
+
+// `unknown extends T` holds only for `unknown` itself, and the guard matters:
+// NonNullable<unknown> is `{}`, which would quietly reject the null a column
+// this scan could not resolve is still allowed to take.
+type ComparisonValue<T, Op extends string> = Lowercase<Op> extends NullTolerantOperator
+  ? T
+  : unknown extends T
+    ? T
+    : NonNullable<T>;
+
 type ParamType<
   DB extends SchemaLike,
   Sources extends Source[],
   Column extends string,
   Op extends string,
   Token extends string = '',
+  InAssignment extends boolean = false,
 > = Lowercase<Op> extends ForcedNumberKeyword
   ? number
   : IsOperator<Op> extends true
-    ? WrapArrayArgument<ResolveColumnLoose<DB, Sources, Column>, Token>
+    ? WrapArrayArgument<
+        InAssignment extends true
+          ? ResolveColumnLoose<DB, Sources, Column>
+          : ComparisonValue<ResolveColumnLoose<DB, Sources, Column>, Op>,
+        Token
+      >
     : unknown;
 
 type AddParam<
@@ -262,6 +287,23 @@ type AddParam<
       : never
   : never;
 
+// Which side of the statement the scan is on. A `=` in a SET assignment or a
+// VALUES tuple is a write, where null is a legitimate value to bind; a `=` in
+// a WHERE or an ON is a comparison, where it can never match. The scan is
+// linear and keeps only the two previous tokens, so the region has to be
+// carried along - `set a = $1, b = $2` gives the second placeholder no local
+// hint that it is still inside the SET clause.
+type AssignmentKeyword = 'set' | 'values';
+
+type ComparisonKeyword = 'where' | 'on' | 'having' | 'using' | 'join' | 'returning' | 'output';
+
+type NextAssignmentRegion<Token extends string, Current extends boolean> =
+  Lowercase<Token> extends AssignmentKeyword
+    ? true
+    : Lowercase<Token> extends ComparisonKeyword
+      ? false
+      : Current;
+
 type ScanParamsRaw<
   S extends string,
   DB extends SchemaLike,
@@ -271,11 +313,12 @@ type ScanParamsRaw<
   Indexed extends unknown[] = [],
   Sequential extends unknown[] = [],
   SequentialNames extends string[] = [],
+  InAssignment extends boolean = false,
 > = S extends `${infer Head} ${infer Tail}`
   ? IsPlaceholder<Head> extends true
     ? AddParam<
         Head,
-        ParamType<DB, Sources, PrevPrev, Prev, Head>,
+        ParamType<DB, Sources, PrevPrev, Prev, Head, InAssignment>,
         Indexed,
         Sequential,
         SequentialNames
@@ -284,15 +327,51 @@ type ScanParamsRaw<
         sequential: infer NextSequential extends unknown[];
         sequentialNames: infer NextSequentialNames extends string[];
       }
-      ? ScanParamsRaw<Tail, DB, Sources, PrevPrev, Prev, NextIndexed, NextSequential, NextSequentialNames>
+      ? ScanParamsRaw<
+          Tail,
+          DB,
+          Sources,
+          PrevPrev,
+          Prev,
+          NextIndexed,
+          NextSequential,
+          NextSequentialNames,
+          InAssignment
+        >
       : never
     : IsTransparentToken<Head> extends true
-      ? ScanParamsRaw<Tail, DB, Sources, PrevPrev, Prev, Indexed, Sequential, SequentialNames>
-      : ScanParamsRaw<Tail, DB, Sources, Prev, CleanColumnToken<Head>, Indexed, Sequential, SequentialNames>
+      ? ScanParamsRaw<
+          Tail,
+          DB,
+          Sources,
+          PrevPrev,
+          Prev,
+          Indexed,
+          Sequential,
+          SequentialNames,
+          InAssignment
+        >
+      : ScanParamsRaw<
+          Tail,
+          DB,
+          Sources,
+          Prev,
+          CleanColumnToken<Head>,
+          Indexed,
+          Sequential,
+          SequentialNames,
+          NextAssignmentRegion<Head, InAssignment>
+        >
   : S extends ''
     ? { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames }
     : IsPlaceholder<S> extends true
-      ? AddParam<S, ParamType<DB, Sources, PrevPrev, Prev, S>, Indexed, Sequential, SequentialNames>
+      ? AddParam<
+          S,
+          ParamType<DB, Sources, PrevPrev, Prev, S, InAssignment>,
+          Indexed,
+          Sequential,
+          SequentialNames
+        >
       : { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames };
 
 type ScanParams<

--- a/tests/nullable-params.test-d.ts
+++ b/tests/nullable-params.test-d.ts
@@ -1,0 +1,84 @@
+import type { Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; email: string | null };
+  posts: { id: number; user_id: number; title: string; views: number | null };
+}
+
+// `= NULL` never matches a row, so accepting null here typed a query that
+// silently returns nothing (issue #299).
+type ComparisonAgainstNullableColumn = Expect<
+  Equal<Params<DB, 'select id from users where email = $1'>, [string]>
+>;
+
+type LikeAgainstNullableColumn = Expect<
+  Equal<Params<DB, 'select id from users where email like $1'>, [string]>
+>;
+
+// Join-induced nullability is the clearest case: the `| null` belongs to the
+// result side, since a missing match makes the column null in the output.
+type ComparisonAgainstJoinNullableColumn = Expect<
+  Equal<
+    Params<
+      DB,
+      'select u.id from users u left join posts p on u.id = p.user_id where p.views = $1'
+    >,
+    [number]
+  >
+>;
+
+type InListAgainstNullableColumn = Expect<
+  Equal<Params<DB, 'select id from posts where views in $1'>, [number]>
+>;
+
+// `is distinct from` exists to compare against null, so it keeps it.
+type IsDistinctFromKeepsNull = Expect<
+  Equal<Params<DB, 'select id from users where email is distinct from $1'>, [string | null]>
+>;
+
+// Writes are not comparisons: storing null in a nullable column is ordinary.
+type UpdateSetKeepsNull = Expect<
+  Equal<Params<DB, 'update users set email = $1 where id = $2'>, [string | null, number]>
+>;
+
+type UpdateSetKeepsNullForEveryAssignment = Expect<
+  Equal<
+    Params<DB, 'update posts set title = $1, views = $2 where id = $3'>,
+    [string, number | null, number]
+  >
+>;
+
+type InsertValuesKeepsNull = Expect<
+  Equal<Params<DB, 'insert into users (name, email) values ($1, $2)'>, [string, string | null]>
+>;
+
+// Controls: a non-nullable column is unchanged, and an array-wrapping call
+// still wraps the element type.
+type NonNullableColumnIsUnchanged = Expect<
+  Equal<Params<DB, 'select id from users where name = $1'>, [string]>
+>;
+
+type AnyArrayStillWraps = Expect<
+  Equal<Params<DB, 'select id from users where id = any($1)'>, [number[]]>
+>;
+
+type LimitIsStillNumber = Expect<Equal<Params<DB, 'select id from users limit $1'>, [number]>>;
+
+export type NullableParamsLock = [
+  ComparisonAgainstNullableColumn,
+  LikeAgainstNullableColumn,
+  ComparisonAgainstJoinNullableColumn,
+  InListAgainstNullableColumn,
+  IsDistinctFromKeepsNull,
+  UpdateSetKeepsNull,
+  UpdateSetKeepsNullForEveryAssignment,
+  InsertValuesKeepsNull,
+  NonNullableColumnIsUnchanged,
+  AnyArrayStillWraps,
+  LimitIsStillNumber,
+];


### PR DESCRIPTION
Fixes #299.

## The bug

```ts
// schema: email: string | null
Params<DB, 'select id from users where email = $1'>  // [string | null]
db.query('select id from users where email = $1', null); // compiles, matches nothing
```

Join-induced nullability leaks the same way, and shows the mechanism plainly — the `| null` belongs to the *result* side (a missing match makes the column null in the output), not to the value you compare against:

```ts
Params<DB, 'select u.id from users u left join posts p on u.id = p.user_id where p.views = $1'>
// [number | null]
```

## The fix

`ParamType` resolves through `ResolveColumnLoose`, which reuses result-column resolution verbatim. Comparison parameters are now `NonNullable`, with three carve-outs where null is meaningful:

- **`is distinct from`** — comparing against null is the entire point of it.
- **`SET` assignments and `VALUES` tuples** — storing null is ordinary. The scan keeps only the two previous tokens, so `set a = $1, b = $2` gives the second placeholder no local hint that it is still a write; the region is carried along the scan instead.
- **an unresolved column** — stays `unknown`. `NonNullable<unknown>` is `{}`, which would have rejected the null such a slot is still allowed to take. This one was caught by an existing test (`tests/update-where-subquery.test-d.ts`) going red mid-change, not by foresight.

## Verification

`tests/nullable-params.test-d.ts`, eleven cases. Four red on master:

```
tests/nullable-params.test-d.ts(16,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/nullable-params.test-d.ts(20,3): ...
tests/nullable-params.test-d.ts(26,3): ...
tests/nullable-params.test-d.ts(36,3): ...
```

- `=`, `like`, `in`, and the LEFT JOIN column all drop the null
- carve-outs pinned: `is distinct from`, `update ... set`, every assignment in a multi-column SET, and `insert ... values`
- controls: a non-nullable column is unchanged, `= any($1)` still wraps to `number[]`, `limit $1` is still `number`

`tsc --noEmit` clean, 192 runtime tests pass. Budget 193,992 (+1,506).