### PR TITLE
fix(params): stop inventing a slot for a glued placeholder list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A glued placeholder list (`where id in ($1,$2)`) no longer invents a single phantom slot for two placeholders. `$1,$2` passed the placeholder test, failed the index read, and was registered as one sequential parameter named `$1,$2`, so `db.query(sql, 1)` compiled and pg rejected it at bind time. A glued list is now no placeholder at all, which is what the `?` spelling already did and what the documented "write the comma with a space" rule says ([#291](https://github.com/tiagolauer/OwlSQL/issues/291)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/params.ts
+++ b/src/params.ts
@@ -101,9 +101,20 @@ export type CleanColumnToken<S extends string> = StripLeadingParens<S> extends i
 // executor doesn't accept (issue #249). A bare `?` stays a placeholder -
 // that is exactly what it is in MySQL and SQLite, and no amount of text
 // alone can tell it apart from Postgres's jsonb existence operator.
-export type IsPlaceholder<Token extends string> = CleanScanToken<Token> extends '?'
-  ? true
-  : // MERGE's `$action` is a pseudo-column, not a placeholder - ResolveColumnType
+export type IsPlaceholder<Token extends string> = CleanScanToken<Token> extends `${string},${string}`
+  ? // Two placeholders glued into one space-delimited token (`in ($1,$2)`).
+    // CleanScanToken has already dropped a *trailing* comma, so a comma left
+    // inside the token means it holds more than one thing, and a one-token
+    // scan cannot hand out two slots. `$1,$2` used to pass the `$` body test
+    // (the body starts with a digit), fail DigitsToCounter, and fall through
+    // to the named branch as a single slot called `$1,$2` - one phantom
+    // parameter for two real ones, which pg rejects at bind time (issue
+    // #291). Not a placeholder, matching what the `?` spelling already did
+    // and the "write the comma with a space" rule the README states.
+    false
+  : CleanScanToken<Token> extends '?'
+    ? true
+    : // MERGE's `$action` is a pseudo-column, not a placeholder - ResolveColumnType
     // already types it as the branch that fired, so counting it here handed the
     // caller an extra parameter slot (issue #231).
     Lowercase<CleanScanToken<Token>> extends '$action'

--- a/tests/glued-placeholder-list.test-d.ts
+++ b/tests/glued-placeholder-list.test-d.ts
@@ -1,0 +1,62 @@
+import type { Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+// A glued list is one token to a space-splitting scan, and one token cannot
+// hand out two slots. It used to produce a single slot named `$1,$2`, so
+// `db.query(sql, 1)` compiled and pg rejected it at bind time with "bind
+// message supplies 1 parameters, but prepared statement requires 2" (#291).
+type GluedNumberedList = Expect<
+  Equal<Params<DB, 'select id from users where id in ($1,$2)'>, []>
+>;
+
+type GluedNamedList = Expect<
+  Equal<Params<DB, 'select id from users where id in (@a,@b)'>, []>
+>;
+
+// The `?` spelling already behaved this way; it is what the glued form is
+// documented to do.
+type GluedQuestionList = Expect<
+  Equal<Params<DB, 'select id from users where id in (?,?)'>, []>
+>;
+
+// Controls: written with the space the README asks for, both slots are typed.
+type SpacedNumberedList = Expect<
+  Equal<Params<DB, 'select id from users where id in ($1, $2)'>, [number, number]>
+>;
+
+type SpacedQuestionList = Expect<
+  Equal<Params<DB, 'select id from users where id in (?, ?)'>, [number, number]>
+>;
+
+// A placeholder inside a call still gets its slot (#244), including the one
+// whose argument list carries a comma written with a space.
+type PlaceholderInsideCall = Expect<
+  Equal<Params<DB, 'select id from users where id = coalesce($1, 0)'>, [number]>
+>;
+
+type ArrayComparison = Expect<
+  Equal<Params<DB, 'select id from users where id = any($1)'>, [number[]]>
+>;
+
+type PlainPlaceholder = Expect<
+  Equal<Params<DB, 'select id from users where id = $1'>, [number]>
+>;
+
+export type GluedPlaceholderListLock = [
+  GluedNumberedList,
+  GluedNamedList,
+  GluedQuestionList,
+  SpacedNumberedList,
+  SpacedQuestionList,
+  PlaceholderInsideCall,
+  ArrayComparison,
+  PlainPlaceholder,
+];


### PR DESCRIPTION
Fixes #291.

## The bug

```ts
Params<DB, 'select id from users where id in ($1,$2)'>
// [number] - db.query(sql, 1) compiles
```

pg then rejects the call at runtime with "bind message supplies 1 parameters, but prepared statement requires 2". The `?` twin gives `[]`, which at least matches the documented glued-token limitation; the `$` variant instead invented a single sequential param named `$1,$2` — the worst of both.

## The fix

`CleanScanToken` reduces the token to `$1,$2`. `IsPlaceholder` passed it (the body `1,$2` starts with an identifier character), `DigitsToCounter` then hit the comma and returned `never`, so `PlaceholderPosition` failed and the token fell into the named branch as one slot.

A comma left in a *cleaned* token means the token holds more than one thing, and a space-splitting scan cannot hand out two slots for one token — so it is not a placeholder. That is the `[]` outcome the issue lists as acceptable, and it matches both the `?` spelling and the README's "write the comma with a space" rule.

`CleanScanToken` already strips a *trailing* comma, so `$1,` and `coalesce($1,` are untouched — the `#244` placeholder-inside-a-call behaviour is pinned by a test here.

## Verification

`tests/glued-placeholder-list.test-d.ts`, eight cases. Two red on master:

```
tests/glued-placeholder-list.test-d.ts(17,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/glued-placeholder-list.test-d.ts(21,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

- `in ($1,$2)` and `in (@a,@b)` produce `[]`
- `in (?,?)` already did, and still does

Controls: `in ($1, $2)` and `in (?, ?)` still type both slots, `coalesce($1, 0)` still gets its slot, `= any($1)` still wraps, a plain `$1` is unchanged.

`tsc --noEmit` clean, 192 runtime tests pass, budget 192,774 (+288).