### PR TITLE
fix(params): dedupe a named parameter across the CTE boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A named parameter written in a CTE body and again in the outer query binds once, the way the adapters have always bound it. The type layer scanned the two halves with separate name registries and demanded a value per occurrence, so the caller passed one value too many and every parameter after the duplicate shifted by one: on mssql the next `@name` silently received the duplicated value and its own was dropped, on node:sqlite the query returned no rows ([#268](https://github.com/tiagolauer/OwlSQL/issues/268)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/params.ts
+++ b/src/params.ts
@@ -311,15 +311,6 @@ type ScanParams<
   ? [...FinalIndexed, ...FinalSequential]
   : never;
 
-type ZipIntersectIndexed<A extends unknown[], B extends unknown[]> = A extends [
-  infer AHead,
-  ...infer ATail extends unknown[],
-]
-  ? B extends [infer BHead, ...infer BTail extends unknown[]]
-    ? [AHead & BHead, ...ZipIntersectIndexed<ATail, BTail>]
-    : A
-  : B;
-
 // The column list starts right after the target name, which is not always a
 // word boundary: `insert into users(id, name)` glues it to the table, so
 // dropping the first word ate the first column too (issue #245).
@@ -450,26 +441,33 @@ type InsertParamTypes<DB extends SchemaLike, Q extends string> = ParseStatement<
 
 type CteScanEntry = [name: string, query: string, columns: string[] | null];
 
-type CteBodyParamScan<DB extends SchemaLike, Ctes extends CteScanEntry[]> = Ctes extends [
-  infer Head extends CteScanEntry,
-  ...infer Tail extends CteScanEntry[],
-]
+// The registry threads through every CTE body and on into the outer query,
+// rather than each scan starting a fresh one and the results being
+// concatenated. A name registry is what dedups a repeated placeholder to one
+// slot, so a `@since` written in a CTE body and again outside it used to get
+// two slots while the adapters - which dedupe by name over the whole
+// statement - bound one value. Every parameter after the duplicate then
+// shifted by one: on mssql the next `@name` silently received the duplicated
+// value, on node:sqlite the query matched nothing (issue #268).
+type CteBodyParamScan<
+  DB extends SchemaLike,
+  Ctes extends CteScanEntry[],
+  Indexed extends unknown[] = [],
+  Sequential extends unknown[] = [],
+  SequentialNames extends string[] = [],
+> = Ctes extends [infer Head extends CteScanEntry, ...infer Tail extends CteScanEntry[]]
   ? [ParseStatement<Head[1]>] extends [never]
-    ? CteBodyParamScan<DB, Tail>
+    ? CteBodyParamScan<DB, Tail, Indexed, Sequential, SequentialNames>
     : ParseStatement<Head[1]> extends { sources: infer Sources extends Source[] }
-      ? ScanParamsRaw<Head[1], DB, Sources> extends {
-          indexed: infer HeadIndexed extends unknown[];
-          sequential: infer HeadSequential extends unknown[];
+      ? ScanParamsRaw<Head[1], DB, Sources, '', '', Indexed, Sequential, SequentialNames> extends {
+          indexed: infer NextIndexed extends unknown[];
+          sequential: infer NextSequential extends unknown[];
+          sequentialNames: infer NextSequentialNames extends string[];
         }
-        ? CteBodyParamScan<DB, Tail> extends {
-            indexed: infer TailIndexed extends unknown[];
-            sequential: infer TailSequential extends unknown[];
-          }
-          ? { indexed: ZipIntersectIndexed<HeadIndexed, TailIndexed>; sequential: [...HeadSequential, ...TailSequential] }
-          : never
+        ? CteBodyParamScan<DB, Tail, NextIndexed, NextSequential, NextSequentialNames>
         : never
-      : CteBodyParamScan<DB, Tail>
-  : { indexed: []; sequential: [] };
+      : CteBodyParamScan<DB, Tail, Indexed, Sequential, SequentialNames>
+  : { indexed: Indexed; sequential: Sequential; sequentialNames: SequentialNames };
 
 type StripDoubledAt<S extends string> = S extends `${infer Before}@@${infer After}`
   ? StripDoubledAt<`${Before}${After}`>
@@ -521,21 +519,31 @@ type OuterAndCteParams<
   CteDB extends SchemaLike,
   EffectiveQuery extends string,
   Sources extends Source[],
-> = ScanParamsRaw<EffectiveQuery, CteDB, Sources> extends {
-  indexed: infer OuterIndexed extends unknown[];
-  sequential: infer OuterSequential extends unknown[];
-}
-  ? [ParseWithClause<Normalize<Q>>] extends [never]
-    ? [...OuterIndexed, ...OuterSequential]
-    : ParseWithClause<Normalize<Q>> extends { ctes: infer Ctes extends CteScanEntry[] }
-      ? CteBodyParamScan<CteDB, Ctes> extends {
-          indexed: infer CteIndexed extends unknown[];
-          sequential: infer CteSequential extends unknown[];
-        }
-        ? [...ZipIntersectIndexed<CteIndexed, OuterIndexed>, ...CteSequential, ...OuterSequential]
-        : unknown[]
+> = [ParseWithClause<Normalize<Q>>] extends [never]
+  ? ScanParams<EffectiveQuery, CteDB, Sources>
+  : ParseWithClause<Normalize<Q>> extends { ctes: infer Ctes extends CteScanEntry[] }
+    ? CteBodyParamScan<CteDB, Ctes> extends {
+        indexed: infer CteIndexed extends unknown[];
+        sequential: infer CteSequential extends unknown[];
+        sequentialNames: infer CteSequentialNames extends string[];
+      }
+      ? // Seeding the outer scan with what the CTE bodies produced replaces the
+        // old concatenation: the numbered slots merge at their own positions
+        // the way SetSlot already merges a repeat, the sequential ones come
+        // out CTE-first in textual order, and a name already registered by a
+        // CTE body now resolves to its existing slot instead of a second one.
+        ScanParams<
+          EffectiveQuery,
+          CteDB,
+          Sources,
+          '',
+          '',
+          CteIndexed,
+          CteSequential,
+          CteSequentialNames
+        >
       : unknown[]
-  : unknown[];
+    : unknown[];
 
 // Same guard InferRowWith applies (issue #206): the parameter tuple is
 // derived from the merged text too, so a stacked statement would otherwise

--- a/tests/cte-named-param-dedup.test-d.ts
+++ b/tests/cte-named-param-dedup.test-d.ts
@@ -1,0 +1,97 @@
+import type { Params } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  orders: { id: number; user_id: number; total: number; region: string; created_at: string };
+}
+
+// The adapters dedupe by name across the whole statement, so a name written in
+// a CTE body and again outside it binds once. The type layer scanned the two
+// halves with separate registries and demanded a value for each occurrence, so
+// every parameter after the duplicate shifted by one at runtime (issue #268).
+type NamedRepeatedAcrossCteAndOuter = Expect<
+  Equal<
+    Params<DB, 'with t as (select id from users where id = @id) select id from t where id = @id'>,
+    [number]
+  >
+>;
+
+type ColonRepeatedAcrossCteAndOuter = Expect<
+  Equal<
+    Params<DB, 'with t as (select id from users where id = :id) select id from t where id = :id'>,
+    [number]
+  >
+>;
+
+// The runtime-corruption shape from the issue: the third value used to be
+// dropped and @region received @since's value. @region types as unknown
+// because the outer FROM is the CTE, which projects only id - that part is
+// unchanged, what matters here is that there are two slots and not three.
+type DuplicateDoesNotShiftTheParametersAfterIt = Expect<
+  Equal<
+    Params<
+      DB,
+      'with recent as (select id from orders where created_at > @since) select id from recent where total > @since and region = @region'
+    >,
+    [string, unknown]
+  >
+>;
+
+type NamedRepeatedAcrossTwoCteBodies = Expect<
+  Equal<
+    Params<
+      DB,
+      'with a as (select id from users where id = @id), b as (select id from orders where user_id = @id) select id from b'
+    >,
+    [number]
+  >
+>;
+
+// Controls: distinct names still get a slot each, in textual order with the
+// CTE body first.
+type DistinctNamesKeepTheirSlots = Expect<
+  Equal<
+    Params<
+      DB,
+      'with t as (select id from users where name = @name) select id from t where id = @id'
+    >,
+    [string, number]
+  >
+>;
+
+type NumberedAcrossTheBoundaryIsUnchanged = Expect<
+  Equal<
+    Params<DB, 'with t as (select id from users where id = $1) select id from t where id = $1'>,
+    [number]
+  >
+>;
+
+type NumberedDistinctAcrossTheBoundary = Expect<
+  Equal<
+    Params<DB, 'with t as (select id from users where id = $1) select id from t where id = $2'>,
+    [number, number]
+  >
+>;
+
+type QuestionIsNeverDeduped = Expect<
+  Equal<
+    Params<DB, 'with t as (select id from users where id = ?) select id from t where id = ?'>,
+    [number, number]
+  >
+>;
+
+export type CteNamedParamDedupLock = [
+  NamedRepeatedAcrossCteAndOuter,
+  ColonRepeatedAcrossCteAndOuter,
+  DuplicateDoesNotShiftTheParametersAfterIt,
+  NamedRepeatedAcrossTwoCteBodies,
+  DistinctNamesKeepTheirSlots,
+  NumberedAcrossTheBoundaryIsUnchanged,
+  NumberedDistinctAcrossTheBoundary,
+  QuestionIsNeverDeduped,
+];


### PR DESCRIPTION
Fixes #268.

## The bug

```ts
Params<DB, 'with t as (select id from users where id = @id) select id from t where id = @id'>
// [number, number] - should be [number]
```

The runtime side dedupes by name globally, so the value list is always one longer than the name list. Following the 3-slot tuple the types demanded:

```ts
await executor(
  'with recent as (select id from orders where created_at > @since) select id from recent where total > @since and region = @region',
  ['2026-01-01', '2026-01-01', 'emea'],
);
```

On mssql that binds `input('since', ...)` and `input('region', '2026-01-01')` — `@region` receives the duplicated value and `'emea'` is dropped without any error. On node:sqlite the query returns `[]`. The README says "A repeated `@name` binds once", and within a single scan it does.

## The fix

`CteBodyParamScan` and the outer `ScanParamsRaw` each started a fresh `SequentialNames` registry, and the two results were concatenated. That registry is what dedups a repeat to one slot, so a name could only ever be matched within its own half.

It now threads through every CTE body and on into the outer scan. Seeding the outer scan with what the CTE bodies produced replaces the concatenation outright:

- numbered slots merge at their own positions the way `SetSlot` already merges a repeat — which is exactly what `ZipIntersectIndexed` was doing by hand, so it has no callers left and is removed
- sequential slots still come out CTE-first, in textual order
- a name already registered by a CTE body resolves to its existing slot

Numbered `$1` across the same boundary was never affected and stays as it was.

## Verification

`tests/cte-named-param-dedup.test-d.ts`, eight cases. Four red on master:

```
tests/cte-named-param-dedup.test-d.ts(18,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/cte-named-param-dedup.test-d.ts(25,3): ...
tests/cte-named-param-dedup.test-d.ts(36,3): ...
tests/cte-named-param-dedup.test-d.ts(46,3): ...
```

- `@name` and `:name` repeated across the boundary collapse to one slot
- the issue's own three-parameter query is now two slots, not three
- a name repeated across two CTE bodies collapses too

Controls: distinct names keep a slot each in CTE-first order, `$1` across the boundary is unchanged (repeat merges, distinct stays two), and a bare `?` is still never deduped.

`tsc --noEmit` clean, 192 runtime tests pass. Budget 192,519, **33 above master** — the threading replaces work rather than adding it.