### PR TITLE
fix(parse): strip a DISTINCT ON group written without a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- `select distinct on(team_id) id from users` - the glued spelling Postgres accepts alongside the spaced one - types its projection. The first word of it is `on(team_id)`, which failed the whole-word compare, so the ON group was never stripped and leaked into the column list as a call to a function named `on`, aliased to the column beside it; `id` came back `unknown` in both modes ([#289](https://github.com/tiagolauer/OwlSQL/issues/289)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -85,13 +85,25 @@ type StripTopClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'top'> ext
     : S
   : S;
 
-type StripDistinctOn<S extends string> = IsKeyword<FirstWord<S>, 'on'> extends true
-  ? Trim<DropFirstWord<S>> extends `(${infer AfterOpen}`
+// Postgres accepts `distinct on (a)` and `distinct on(a)` alike. The glued
+// spelling makes the first word `on(a)`, which fails a whole-word compare, so
+// the ON group leaked into the column list and `on(team_id)` was read as a
+// call to a function named `on` aliased to the column beside it (issue #289).
+type AfterDistinctOnKeyword<S extends string> = IsKeyword<FirstWord<S>, 'on'> extends true
+  ? Trim<DropFirstWord<S>>
+  : Trim<S> extends `${infer Head}(${infer AfterOpen}`
+    ? IsKeyword<Head, 'on'> extends true
+      ? `(${AfterOpen}`
+      : never
+    : never;
+
+type StripDistinctOn<S extends string> = [AfterDistinctOnKeyword<S>] extends [never]
+  ? S
+  : AfterDistinctOnKeyword<S> extends `(${infer AfterOpen}`
     ? ExtractParenGroup<AfterOpen> extends { rest: infer Rest extends string }
       ? Trim<Rest>
       : S
-    : S
-  : S;
+    : S;
 
 type StripDistinctClause<S extends string> = IsKeyword<FirstWord<Trim<S>>, 'distinct'> extends true
   ? StripDistinctOn<Trim<DropFirstWord<Trim<S>>>>

--- a/tests/distinct.test-d.ts
+++ b/tests/distinct.test-d.ts
@@ -13,6 +13,9 @@ interface DB {
     name: string;
     team_id: number;
   };
+  users2: {
+    onboarding: string;
+  };
 }
 
 type DistinctColumnsResolve = Expect<
@@ -52,6 +55,27 @@ type StrictDistinctResolves = Expect<
   Equal<StrictRow<DB, 'select distinct id from users'>, { id: number }>
 >;
 
+// Regression for #289: Postgres accepts the glued spelling too, and the first
+// word of it is `on(team_id)`, which failed the whole-word compare - so the ON
+// group leaked into the column list and was read as a call to a function
+// named `on`, aliased to the column beside it.
+type GluedDistinctOnGroupStripped = Expect<
+  Equal<Query<DB, 'select distinct on(team_id) id from users'>, { id: number }[]>
+>;
+
+type GluedDistinctOnResolvesInStrictMode = Expect<
+  Equal<StrictRow<DB, 'select distinct on(team_id) id, name from users'>, { id: number; name: string }>
+>;
+
+type GluedDistinctOnWithMultipleKeys = Expect<
+  Equal<Query<DB, 'select distinct on(team_id, name) id from users'>, { id: number }[]>
+>;
+
+// A column actually named `on` is still a column, not the keyword.
+type ColumnNamedOnIsUnaffected = Expect<
+  Equal<Query<DB, 'select distinct onboarding from users2'>, { onboarding: string }[]>
+>;
+
 export type Assertions = [
   DistinctColumnsResolve,
   DistinctUppercaseResolves,
@@ -60,4 +84,8 @@ export type Assertions = [
   DistinctCombinesWithTop,
   DistinctStar,
   StrictDistinctResolves,
+  GluedDistinctOnGroupStripped,
+  GluedDistinctOnResolvesInStrictMode,
+  GluedDistinctOnWithMultipleKeys,
+  ColumnNamedOnIsUnaffected,
 ];


### PR DESCRIPTION
Fixes #289.

## The bug

```ts
Query<DB, 'select distinct on(team_id) id from users'>      // { id: unknown }[]
StrictRow<DB, 'select distinct on(team_id) id from users'>  // same
```

The spaced form `distinct on (team_id)` works. Postgres accepts both, and the glued form types `id` as `unknown` in both modes because `on(team_id)` is read as a call to a function named `on`, aliased `id`.

## The fix

`StripDistinctOn` tested `IsKeyword<FirstWord<S>, 'on'>`, and the first word of the glued form is `on(team_id)` — a whole-word compare it fails, so the ON group was never stripped.

The keyword test now also accepts an `on` glued to its opening paren, and hands the group to the same `ExtractParenGroup` either way. The test is on the word *before* the paren, not on a prefix, so a column named `onboarding` is still a column.

## Verification

`tests/distinct.test-d.ts`, four new cases (three red on master):

```
tests/distinct.test-d.ts(63,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/distinct.test-d.ts(67,3): ...
tests/distinct.test-d.ts(71,3): ...
```

- the glued form in normal mode, in strict mode, and with a multi-column key
- a control that `select distinct onboarding` is still a column reference

The seven existing assertions in the file (spaced `on`, `distinct top`, `distinct *`, strict) stay pinned.

`tsc --noEmit` clean, budget 192,582 (+96).