### PR TITLE
fix(parse): type a column wrapped in parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A column wrapped in parentheses keeps its type. `select (id) as x from users` came back `{ x: unknown }` in both modes, because `IsFunctionCall` matched `(id)` - its leading `${string}` also matches the empty string - and typed it as a call to a function with no name. Strict mode even validated the column on the way there and still returned unknown ([#288](https://github.com/tiagolauer/OwlSQL/issues/288)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -41,8 +41,15 @@ export interface FunctionReturnTypes {
   nth_value: unknown;
 }
 
+// The name has to be there. `${string}` happily matches the empty string, so
+// `(id)` - a column in parentheses, which is valid everywhere and something
+// people write around an expression - was read as a call to a function named
+// `''` and typed `unknown`, in strict mode too, after the column had already
+// resolved (issue #288).
 export type IsFunctionCall<Expr extends string> = Expr extends `${string}(${string})`
-  ? true
+  ? Trim<FunctionName<Expr>> extends ''
+    ? false
+    : true
   : false;
 
 export type FunctionName<Expr extends string> = Expr extends `${infer Name}(${string}`

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -468,10 +468,10 @@ type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends tr
     : IsParenthesizedEntry<Entry> extends true
       ? SplitParenthesizedEntry<Entry> extends { expr: infer Expr extends string; after: infer After extends string }
         ? After extends ''
-          ? [Trim<Entry>, Expr]
+          ? [Trim<Entry>, UnwrapRedundantParens<Expr>]
           : IsKeyword<FirstWord<After>, 'as'> extends true
-            ? [Unquote<Trim<DropFirstWord<After>>>, Expr]
-            : [Unquote<Trim<After>>, Expr]
+            ? [Unquote<Trim<DropFirstWord<After>>>, UnwrapRedundantParens<Expr>]
+            : [Unquote<Trim<After>>, UnwrapRedundantParens<Expr>]
         : [Trim<Entry>, Trim<Entry>]
       : [FindTopLevelAsKeyword<Entry>] extends [never]
       ? Entry extends `${infer Expression} ${infer Alias}`
@@ -621,6 +621,40 @@ type QualifiedColumnType<
       : never
   : never;
 
+// `(id)` is a column someone wrapped in parentheses, which every dialect
+// accepts and people write around an expression they are editing. It used to
+// resolve as a call to a function named `''` - `IsFunctionCall` matched it
+// because its leading `${string}` also matches the empty string - and then as
+// a literal column named `(id)` once that was tightened, so it stayed
+// `unknown` either way, in strict mode too, after the column had already been
+// validated (issue #288).
+//
+// Only a group holding no parens of its own is unwrapped, which is enough for
+// a plain column and keeps `(a) + (b)` - where the outer match would be
+// spurious - out of it.
+type UnwrapRedundantParens<Expression extends string> = Expression extends `(${infer Inner})`
+  ? Inner extends `${string})${string}`
+    ? Expression
+    : IsKeyword<FirstWord<Trim<Inner>>, 'select'> extends true
+      ? Expression
+      : Trim<Inner>
+  : Expression;
+
+type ResolveColumnName<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Expression extends string,
+  Strict extends boolean,
+> = Qualifier<Expression> extends ''
+  ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
+  : QualifiedColumnType<
+      DB,
+      Sources,
+      Unquote<Qualifier<Expression>>,
+      Unquote<StripQualifier<Expression>>,
+      Strict
+    >;
+
 type OperatorChar = '*' | '+' | '-' | '/' | '%' | '|' | '<' | '>' | '=' | '^';
 
 type ContainsOperatorChar<S extends string> = S extends `${string}${OperatorChar}${string}`
@@ -762,15 +796,7 @@ export type ResolveColumnType<
       : [LiteralType<Expression>] extends [never]
         ? IsOperatorExpression<Expression> extends true
           ? unknown
-          : Qualifier<Expression> extends ''
-            ? BareColumnType<DB, Sources, Unquote<StripQualifier<Expression>>, Strict>
-            : QualifiedColumnType<
-                DB,
-                Sources,
-                Unquote<Qualifier<Expression>>,
-                Unquote<StripQualifier<Expression>>,
-                Strict
-              >
+          : ResolveColumnName<DB, Sources, Expression, Strict>
         : LiteralType<Expression>
     : ScalarSubqueryType<DB, ScalarSubqueryInner<Expression>, Strict>;
 

--- a/tests/parenthesized-column.test-d.ts
+++ b/tests/parenthesized-column.test-d.ts
@@ -1,0 +1,64 @@
+import type { Query, QueryTypeError, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  posts: { id: number; user_id: number; title: string };
+}
+
+// Wrapping a column in parentheses is valid everywhere, and something people
+// do while editing an expression. It used to resolve as a call to a function
+// named `''`, so the column came back unknown - in strict mode too, after the
+// column had already been validated on the way there (issue #288).
+type ParenthesizedColumnWithAlias = Expect<
+  Equal<Query<DB, 'select (id) as x from users'>, { x: number }[]>
+>;
+
+type ParenthesizedColumnInStrictMode = Expect<
+  Equal<StrictRow<DB, 'select (id) as x from users'>, { x: number }>
+>;
+
+type ParenthesizedQualifiedColumn = Expect<
+  Equal<Query<DB, 'select (u.name) as handle from users u'>, { handle: string }[]>
+>;
+
+type ParenthesizedColumnAmongOthers = Expect<
+  Equal<Query<DB, 'select id, (name) as handle from users'>, { id: number; handle: string }[]>
+>;
+
+// An unknown column inside the parentheses is still an unknown column.
+type ParenthesizedTypoStillErrors = Expect<
+  Equal<StrictRow<DB, 'select (naem) as x from users'>, QueryTypeError<'unknown column: naem'>>
+>;
+
+// Controls: a real function call is still a call, and a group holding more
+// than a name is left alone.
+type FunctionCallIsUnaffected = Expect<
+  Equal<Query<DB, 'select count(*) as total from users'>, { total: number }[]>
+>;
+
+type LowerCallIsUnaffected = Expect<
+  Equal<Query<DB, 'select lower(name) as handle from users'>, { handle: string }[]>
+>;
+
+type ScalarSubqueryIsUnaffected = Expect<
+  Equal<
+    Query<DB, 'select (select count(*) from posts) as total from users'>,
+    { total: number }[]
+  >
+>;
+
+export type ParenthesizedColumnLock = [
+  ParenthesizedColumnWithAlias,
+  ParenthesizedColumnInStrictMode,
+  ParenthesizedQualifiedColumn,
+  ParenthesizedColumnAmongOthers,
+  ParenthesizedTypoStillErrors,
+  FunctionCallIsUnaffected,
+  LowerCallIsUnaffected,
+  ScalarSubqueryIsUnaffected,
+];


### PR DESCRIPTION
Fixes #288.

## The bug

```ts
Query<DB, 'select (id) as x from users'>      // { x: unknown }[]
StrictRow<DB, 'select (id) as x from users'>  // { x: unknown }
```

Expected `{ x: number }`. Strict mode even validates `id` successfully along the way and still returns `unknown`.

## The fix

Two things:

1. **`IsFunctionCall<'(id)'>` returned true** — the leading `${string}` in `${string}(${string})` also matches the empty string, so the expression was typed as a call to a function named `''`. It now requires a non-empty name.

2. That alone leaves `(id)` to be looked up as a literal column *name*, so the parenthesized entry now unwraps a group that holds nothing but a column reference. Two groups are deliberately left alone: one carrying parens of its own (a nested call is still a call), and a scalar subquery, whose meaning *is* the query inside it — `tests/scalar-subquery.test-d.ts` caught that one going red mid-change.

The unwrap sits in the parenthesized-entry branch rather than in `ResolveColumnType`, so it costs nothing for ordinary columns.

## Verification

`tests/parenthesized-column.test-d.ts`, eight cases. Four red on master:

```
tests/parenthesized-column.test-d.ts(18,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/parenthesized-column.test-d.ts(22,3): ...
tests/parenthesized-column.test-d.ts(26,3): ...
tests/parenthesized-column.test-d.ts(30,3): ...
```

- `(id) as x` in normal and strict mode, a qualified `(u.name)`, and one among ordinary columns
- a typo inside the parentheses still errors (`unknown column: naem`)
- controls: `count(*)`, `lower(name)` and a scalar subquery are unchanged

`tsc --noEmit` clean, 192 runtime tests pass, budget 194,776 (+2,290 — the unwrap plus the name check on paren-carrying expressions).