### PR TITLE
fix(parse): keep the alias when an expression continues past a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- An expression that continues after a parenthesized group keeps its alias. `select (id + 1) * 2 as x` produced a column keyed `* 2 as x`: the paren branch assumed everything after the closing paren was the alias, while the bare-entry branch has always guarded the same case ([#290](https://github.com/tiagolauer/OwlSQL/issues/290)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -471,7 +471,22 @@ type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends tr
           ? [Trim<Entry>, Expr]
           : IsKeyword<FirstWord<After>, 'as'> extends true
             ? [Unquote<Trim<DropFirstWord<After>>>, Expr]
-            : [Unquote<Trim<After>>, Expr]
+            : // What follows the group is not always an alias: an expression can
+              // continue past it (`(id + 1) * 2 as x`), and this branch used to
+              // take the whole tail as the name, so the real alias was lost
+              // inside a key reading `* 2 as x` (issue #290). The bare-entry
+              // branch below guards the same situation with IsOperatorExpression;
+              // this one had no such check.
+              IsOperatorExpression<After> extends true
+              ? [FindTopLevelAsKeyword<Entry>] extends [never]
+                ? [Trim<Entry>, Trim<Entry>]
+                : FindTopLevelAsKeyword<Entry> extends {
+                      expr: infer FullExpr extends string;
+                      alias: infer FullAlias extends string;
+                    }
+                  ? [Unquote<Trim<FullAlias>>, FullExpr]
+                  : [Trim<Entry>, Trim<Entry>]
+              : [Unquote<Trim<After>>, Expr]
         : [Trim<Entry>, Trim<Entry>]
       : [FindTopLevelAsKeyword<Entry>] extends [never]
       ? Entry extends `${infer Expression} ${infer Alias}`

--- a/tests/paren-expression-alias.test-d.ts
+++ b/tests/paren-expression-alias.test-d.ts
@@ -1,0 +1,68 @@
+import type { Query } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; age: number };
+  posts: { id: number; user_id: number; views: number };
+}
+
+// Everything after the closing paren was taken as the alias, so the real one
+// was lost inside a key reading `* 2 as x` (issue #290). The value staying
+// unknown is fine - an arithmetic expression is not typed - the key is the bug.
+type ExpressionContinuingAfterAGroup = Expect<
+  Equal<Query<DB, 'select (id + 1) * 2 as x from users'>, { x: unknown }[]>
+>;
+
+// Without an AS there is nothing to tell an alias apart from the rest of the
+// expression, so the whole entry becomes the key - the same answer the
+// bare-entry branch gives for `id + 1 x`. Better than the old `* 2 x`, which
+// named a fragment.
+type ExpressionContinuingWithoutAs = Expect<
+  Equal<Query<DB, 'select (id + 1) * 2 x from users'>, { '(id + 1) * 2 x': unknown }[]>
+>;
+
+type DivisionAfterAGroup = Expect<
+  Equal<Query<DB, 'select (age + id) / 2 as average from users'>, { average: unknown }[]>
+>;
+
+type ContinuationAmongOtherColumns = Expect<
+  Equal<
+    Query<DB, 'select name, (id + 1) * 2 as doubled from users'>,
+    { name: string; doubled: unknown }[]
+  >
+>;
+
+// Controls: a group followed by a plain alias, by AS, or by nothing at all.
+type GroupWithAsAlias = Expect<
+  Equal<Query<DB, 'select (id + 1) as next from users'>, { next: unknown }[]>
+>;
+
+type GroupWithBareAlias = Expect<
+  Equal<Query<DB, 'select (id + 1) next from users'>, { next: unknown }[]>
+>;
+
+type ScalarSubqueryWithAlias = Expect<
+  Equal<
+    Query<DB, 'select (select count(*) from posts) as total from users'>,
+    { total: number }[]
+  >
+>;
+
+type FunctionCallIsUnaffected = Expect<
+  Equal<Query<DB, 'select count(*) as total from users'>, { total: number }[]>
+>;
+
+export type ParenExpressionAliasLock = [
+  ExpressionContinuingAfterAGroup,
+  ExpressionContinuingWithoutAs,
+  DivisionAfterAGroup,
+  ContinuationAmongOtherColumns,
+  GroupWithAsAlias,
+  GroupWithBareAlias,
+  ScalarSubqueryWithAlias,
+  FunctionCallIsUnaffected,
+];


### PR DESCRIPTION
Fixes #290.

## The bug

```ts
Query<DB, 'select (id + 1) * 2 as x from users'>
// { '* 2 as x': unknown }[]
```

Expected `{ x: unknown }[]` — the value being `unknown` is fine, the key is the bug.

## The fix

The paren-entry branch assumed whatever follows the closing paren is an alias and returned `[Trim<After>, Expr]` directly. The bare-entry branch guards the same situation with `IsOperatorExpression`; this branch had no such check.

When the tail is operator-shaped, the entry is now split at its top-level `AS` — the same signal the rest of the parser uses — so `(id + 1) * 2 as x` gives alias `x` and expression `(id + 1) * 2`.

Without an `AS` there is nothing to tell an alias from the rest of the expression, so the whole entry becomes the key (`'(id + 1) * 2 x'`). That is the answer the bare-entry branch gives for the same shape, and better than the old `'* 2 x'`, which named a fragment. That case is pinned by a test.

## Verification

`tests/paren-expression-alias.test-d.ts`, eight cases. Four red on master:

```
tests/paren-expression-alias.test-d.ts(17,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/paren-expression-alias.test-d.ts(25,3): ...
tests/paren-expression-alias.test-d.ts(29,3): ...
tests/paren-expression-alias.test-d.ts(33,3): ...
```

- `* 2 as x`, `/ 2 as average`, the no-AS form, and one among ordinary columns

Controls: `(id + 1) as next`, `(id + 1) next`, a scalar subquery with an alias, and `count(*) as total` are all unchanged.

`tsc --noEmit` clean, budget 192,636 (+150).