### PR TITLE
fix(parse): split a bare alias at a top-level space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- An unaliased function call whose arguments carry a space keeps its name. `select power(age, 2) from users` produced a column keyed `2)` in normal mode and `unknown column: power(age,` in strict mode, because the bare-alias fallback split the entry at its first space with no paren tracking - the same for `cast(id as text)`, `extract(epoch from created_at)` and `coalesce(name, 'anon')` ([#276](https://github.com/tiagolauer/OwlSQL/issues/276)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -453,6 +453,25 @@ type FindTopLevelAsKeyword<
     : FindTopLevelAsKeyword<Tail, ApplyParenDelta<Depth, Head>, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
   : never;
 
+// The bare-alias fallback used to split the entry at its first space, with no
+// paren tracking, so an unaliased call whose arguments carry one - `power(age,
+// 2)`, `cast(id as text)`, `extract(epoch from created_at)` - was cut in half:
+// loose mode keyed the column `2)` and strict mode reported `unknown column:
+// power(age,` on valid SQL (issue #276). The split now happens at the first
+// space that is not inside a call, so an entry that is one call from end to
+// end has no alias to find.
+type SplitAtTopLevelSpace<
+  S extends string,
+  Depth extends unknown[] = [],
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? ApplyParenDelta<Depth, Head> extends infer NextDepth extends unknown[]
+    ? NextDepth extends []
+      ? { expr: Accumulated extends '' ? Head : `${Accumulated} ${Head}`; alias: Tail }
+      : SplitAtTopLevelSpace<Tail, NextDepth, Accumulated extends '' ? Head : `${Accumulated} ${Head}`>
+    : never
+  : never;
+
 type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends true
   ? SplitCaseExpression<Entry> extends { body: infer Body extends string; alias: infer Alias extends string }
     ? [Alias, `case ${Body} end`]
@@ -474,11 +493,16 @@ type ParseColumnEntry<Entry extends string> = IsCaseExpression<Entry> extends tr
             : [Unquote<Trim<After>>, Expr]
         : [Trim<Entry>, Trim<Entry>]
       : [FindTopLevelAsKeyword<Entry>] extends [never]
-      ? Entry extends `${infer Expression} ${infer Alias}`
-        ? IsOperatorExpression<Alias> extends true
-          ? [Trim<Entry>, Trim<Entry>]
-          : [Unquote<Trim<Alias>>, Trim<Expression>]
-        : [OutputName<Trim<Entry>>, Trim<Entry>]
+      ? [SplitAtTopLevelSpace<Entry>] extends [never]
+        ? [OutputName<Trim<Entry>>, Trim<Entry>]
+        : SplitAtTopLevelSpace<Entry> extends {
+              expr: infer Expression extends string;
+              alias: infer Alias extends string;
+            }
+          ? IsOperatorExpression<Alias> extends true
+            ? [Trim<Entry>, Trim<Entry>]
+            : [Unquote<Trim<Alias>>, Trim<Expression>]
+          : [OutputName<Trim<Entry>>, Trim<Entry>]
       : FindTopLevelAsKeyword<Entry> extends { expr: infer Expr extends string; alias: infer Alias extends string }
         ? [Unquote<Trim<Alias>>, Expr]
         : [OutputName<Trim<Entry>>, Trim<Entry>];

--- a/tests/multiarg-call-alias.test-d.ts
+++ b/tests/multiarg-call-alias.test-d.ts
@@ -1,0 +1,71 @@
+import type { Query, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; age: number; created_at: Date };
+}
+
+// The bare-alias fallback split at the first space with no paren tracking, so
+// an unaliased call carrying a space in its arguments was cut in half: the
+// tail became a fake alias and the head a fake column name (issue #276).
+type MultiArgumentCallKeepsItsName = Expect<
+  Equal<Query<DB, 'select power(age, 2) from users'>, { power: number }[]>
+>;
+
+type MultiArgumentCallInStrictMode = Expect<
+  Equal<StrictRow<DB, 'select power(age, 2) from users'>, { power: number }>
+>;
+
+type CastCallKeepsItsName = Expect<
+  Equal<Query<DB, 'select cast(id as text) from users'>, { cast: unknown }[]>
+>;
+
+type ExtractCallKeepsItsName = Expect<
+  Equal<Query<DB, 'select extract(epoch from created_at) from users'>, { extract: unknown }[]>
+>;
+
+type CoalesceCallKeepsItsName = Expect<
+  Equal<Query<DB, "select coalesce(name, 'anon') from users">, { coalesce: unknown }[]>
+>;
+
+type MultiArgumentCallAmongOtherColumns = Expect<
+  Equal<Query<DB, 'select id, power(age, 2) from users'>, { id: number; power: number }[]>
+>;
+
+// An alias after the call is still an alias, with or without AS.
+type MultiArgumentCallWithBareAlias = Expect<
+  Equal<Query<DB, 'select power(age, 2) p from users'>, { p: number }[]>
+>;
+
+type MultiArgumentCallWithAsAlias = Expect<
+  Equal<Query<DB, 'select power(age, 2) as p from users'>, { p: number }[]>
+>;
+
+// Controls: single-argument calls and plain bare aliases are unchanged.
+type SingleArgumentCall = Expect<
+  Equal<Query<DB, 'select lower(name) from users'>, { lower: string }[]>
+>;
+
+type CountStar = Expect<Equal<Query<DB, 'select count(*) from users'>, { count: number }[]>>;
+
+type PlainBareAlias = Expect<
+  Equal<Query<DB, 'select name handle from users'>, { handle: string }[]>
+>;
+
+export type MultiArgumentCallLock = [
+  MultiArgumentCallKeepsItsName,
+  MultiArgumentCallInStrictMode,
+  CastCallKeepsItsName,
+  ExtractCallKeepsItsName,
+  CoalesceCallKeepsItsName,
+  MultiArgumentCallAmongOtherColumns,
+  MultiArgumentCallWithBareAlias,
+  MultiArgumentCallWithAsAlias,
+  SingleArgumentCall,
+  CountStar,
+  PlainBareAlias,
+];


### PR DESCRIPTION
Fixes #276.

## The bug

```ts
Query<DB, 'select power(age, 2) from users'>            // { '2)': unknown }[]
StrictRow<DB, 'select power(age, 2) from users'>        // QueryTypeError<'unknown column: power(age,'>
Query<DB, 'select cast(id as text) from users'>         // { 'as text)': unknown }[]
Query<DB, 'select extract(epoch from created_at) from users'> // { 'from created_at)': unknown }[]
Query<DB, "select coalesce(name, 'anon') from users">   // { "'')": unknown }[]
```

Adding an explicit alias made it work, but `select power(age, 2)` is everyday SQL and should give a `power` column like other unaliased calls do.

## The fix

The bare-alias fallback matched `` `${infer Expression} ${infer Alias}` ``, which splits at the *first* space with no paren-balance check guarding the branch.

The split is now depth-tracked, reusing the `ApplyParenDelta` the sibling scans (`FindTopLevelAsKeyword`, `ColumnsBeforeFrom`) already use. A space inside a call is no longer a boundary, so an entry that is one call from end to end has no alias to find and falls through to `OutputName` — which is how `count(*)` has always been named.

## Verification

`tests/multiarg-call-alias.test-d.ts`, eleven cases. Six red on master:

```
tests/multiarg-call-alias.test-d.ts(20,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/multiarg-call-alias.test-d.ts(24,3): ...  (28,3), (32,3), (36,3), (41,3)
```

- `power(age, 2)` in both modes, `cast(id as text)`, `extract(epoch from created_at)`, `coalesce(name, 'anon')`, and one among ordinary columns
- an alias after the call is still an alias, bare or with `AS`

Controls: `lower(name)`, `count(*)` and a plain bare alias are unchanged.

`tsc --noEmit` clean, 192 runtime tests pass. Budget **191,482 — 1,004 below master**: the naive match was building an alias candidate for entries that went on to discard it.