### PR TITLE
fix(parse): recognize a window function using a named window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A window function using a named window (`sum(salary) over w ... window w as (order by id)`) is keyed by the function instead of by `over w`. Only the inline `over (...)` form was recognized, so the entry fell to the bare-alias split and the window reference became the alias ([#301](https://github.com/tiagolauer/OwlSQL/issues/301)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -412,13 +412,27 @@ type FindOverKeyword<S extends string, Accumulated extends string = ''> =
 
 type StripLeadingOpenParen<S extends string> = Trim<S> extends `(${infer Rest}` ? Rest : never;
 
-type SplitWindowExpression<Entry extends string> = FindOverKeyword<Entry> extends {
-  expr: infer Expr extends string;
-  rest: infer Rest extends string;
-}
+// The [never] guard is load-bearing now that the paren is no longer required:
+// FindOverKeyword resolves to never for an entry with no OVER at all, and
+// `never extends { expr: infer E extends string; rest: infer R extends string }`
+// passes with both infers falling back to `string` - which the named-window
+// branch below would then accept as a window name.
+type SplitWindowExpression<Entry extends string> = [FindOverKeyword<Entry>] extends [never]
+  ? never
+  : FindOverKeyword<Entry> extends {
+        expr: infer Expr extends string;
+        rest: infer Rest extends string;
+      }
   ? StripLeadingOpenParen<Rest> extends infer AfterOpen extends string
     ? [AfterOpen] extends [never]
-      ? never
+      ? // `over w`, referring to a window declared in a WINDOW clause, is the
+        // other half of the syntax: what follows OVER is a name rather than an
+        // inline definition. Requiring the paren meant the entry was not
+        // recognized as a window expression at all, so it fell to the bare-alias
+        // split and `over w` became the alias of `sum(salary)` (issue #301).
+        Trim<Rest> extends ''
+        ? never
+        : { expr: Expr; after: Trim<DropFirstWord<Trim<Rest>>> }
       : ExtractParenGroup<AfterOpen> extends { rest: infer AfterClose extends string }
         ? { expr: Expr; after: Trim<AfterClose> }
         : never

--- a/tests/window.test-d.ts
+++ b/tests/window.test-d.ts
@@ -39,9 +39,37 @@ type WindowFunctionAlongsideRegularColumn = Expect<
   >
 >;
 
+// Regression for #301: `over w` refers to a window declared in a WINDOW
+// clause, the other half of the syntax. Requiring a paren after OVER meant the
+// entry was not read as a window expression at all, so it fell to the
+// bare-alias split and `over w` became the alias of `sum(salary)`.
+type NamedWindowKeepsTheFunctionName = Expect<
+  Equal<
+    Query<DB, 'select sum(salary) over w from employees window w as (order by id)'>,
+    { sum: number }[]
+  >
+>;
+
+type NamedWindowWithAlias = Expect<
+  Equal<
+    Query<DB, 'select sum(salary) over w as total from employees window w as (order by id)'>,
+    { total: number }[]
+  >
+>;
+
+type NamedWindowAlongsideRegularColumn = Expect<
+  Equal<
+    Query<DB, 'select dept, rank() over w from employees window w as (order by salary)'>,
+    { dept: string; rank: number }[]
+  >
+>;
+
 export type WindowLock = [
   RowNumberWithAlias,
   RankWithoutAliasDefaultsToFunctionName,
   EmptyOverClause,
   WindowFunctionAlongsideRegularColumn,
+  NamedWindowKeepsTheFunctionName,
+  NamedWindowWithAlias,
+  NamedWindowAlongsideRegularColumn,
 ];


### PR DESCRIPTION
Fixes #301.

## The bug

```ts
Query<DB, 'select sum(salary) over w from users window w as (order by id)'>
// { 'over w': number }[]
```

Expected `{ sum: number }[]`. The value type comes out right by coincidence; the key is nonsense.

## The fix

`FindOverKeyword`/`SplitWindowExpression` required a `(` directly after `over`, so the named-window form was not recognized as a window expression and the entry fell through to the first-space bare-alias split — making `over w` the alias of `sum(salary)`.

What follows `OVER` may now be a name instead of an inline definition, in which case it is consumed as the window reference and whatever comes after it is treated as the alias, exactly as the parenthesized form already does.

**The `[never]` guard that came with it is the interesting part.** `FindOverKeyword` resolves to `never` for an entry with no `OVER` at all, and `never extends { expr: infer E extends string; rest: infer R extends string }` passes with both infers falling back to their constraints — so with the paren no longer required, `Rest` came through as `string` and *every column in the suite* was read as a window function (308 errors across 42 files on the first run). Same `[never]` pattern `ExtraSourcesAfterKeyword` and `ParseWithClause` already carry.

## Verification

`tests/window.test-d.ts`, three new cases, all red on master:

```
tests/window.test-d.ts(47,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/window.test-d.ts(54,3): ...
tests/window.test-d.ts(61,3): ...
```

- `over w` unaliased (keyed `sum`), with an `as total` alias, and alongside a regular column

The four existing assertions (inline `over (...)`, empty `over ()`, aliased, alongside a column) stay pinned.

`tsc --noEmit` clean, 192 runtime tests pass, budget 192,572 (+86).