### PR TITLE
fix(parse): end the OUTPUT column list at FROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- The T-SQL `UPDATE ... OUTPUT ... FROM` and `DELETE ... OUTPUT ... FROM` forms type their OUTPUT columns. Only `where` ended the OUTPUT list, so the FROM clause was accumulated into it and `inserted.id from users` parsed as one entry with `from users` as its alias ([#300](https://github.com/tiagolauer/OwlSQL/issues/300)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -340,7 +340,12 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
         }
       : IsKeyword<Keyword, 'update'> extends true
         ? {
-            columns: ReturningOrOutputColumns<S, 'where'>;
+            // `from` stops the OUTPUT list as well as `where`: T-SQL writes
+            // `UPDATE t SET ... OUTPUT inserted.id FROM t JOIN ...`, and with
+            // `where` as the only boundary the whole FROM clause was
+            // accumulated into the column list, where `inserted.id from users`
+            // parsed as one entry with `from users` as its alias (issue #300).
+            columns: ReturningOrOutputColumns<S, 'where' | 'from'>;
             sources: [
               ...SingleSource<RestAfterKeyword<S, 'update'>>,
               ...ExtraSourcesAfterKeyword<S, 'from'>,
@@ -350,7 +355,7 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
           }
         : IsKeyword<Keyword, 'delete'> extends true
           ? {
-              columns: ReturningOrOutputColumns<S, 'where'>;
+              columns: ReturningOrOutputColumns<S, 'where' | 'from'>;
               sources: [
                 ...SingleSource<RestAfterKeyword<S, 'from'>>,
                 ...ExtraSourcesAfterKeyword<S, 'using'>,

--- a/tests/tsql-output-from.test-d.ts
+++ b/tests/tsql-output-from.test-d.ts
@@ -1,0 +1,68 @@
+import type { Row, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  audit: { id: number; user_id: number; note: string };
+}
+
+// `where` was the only boundary of the OUTPUT list, so the FROM clause was
+// accumulated into it and `inserted.id from users` parsed as a single entry
+// with `from users` as its alias (issue #300).
+type UpdateOutputBeforeFrom = Expect<
+  Equal<
+    Row<DB, 'update users set name = @p1 output inserted.id from audit where id = @p2'>,
+    { id: number }
+  >
+>;
+
+type UpdateOutputWithSeveralColumns = Expect<
+  Equal<
+    Row<DB, 'update users set name = @p1 output inserted.id, inserted.name from audit where id = @p2'>,
+    { id: number; name: string }
+  >
+>;
+
+type DeleteOutputBeforeFrom = Expect<
+  Equal<
+    Row<DB, 'delete from users output deleted.id from audit where id = @p1'>,
+    { id: number }
+  >
+>;
+
+// `inserted.` is stripped before resolution, so the OUTPUT column is looked
+// up against both sources - `name` is the one only `users` has - and the
+// WHERE has to qualify `id`, which both of them carry.
+type UpdateOutputBeforeFromInStrictMode = Expect<
+  Equal<
+    StrictRow<DB, 'update users set name = @p1 output inserted.name from audit where users.id = @p2'>,
+    { name: string }
+  >
+>;
+
+// Controls: the forms that already worked.
+type UpdateOutputWithoutFrom = Expect<
+  Equal<Row<DB, 'update users set name = @p1 output inserted.id where id = @p2'>, { id: number }>
+>;
+
+type UpdateOutputAsTheLastClause = Expect<
+  Equal<Row<DB, 'update users set name = @p1 output inserted.id'>, { id: number }>
+>;
+
+type UpdateReturningIsUnaffected = Expect<
+  Equal<Row<DB, 'update users set name = $1 where id = $2 returning id, name'>, { id: number; name: string }>
+>;
+
+export type TsqlOutputFromLock = [
+  UpdateOutputBeforeFrom,
+  UpdateOutputWithSeveralColumns,
+  DeleteOutputBeforeFrom,
+  UpdateOutputBeforeFromInStrictMode,
+  UpdateOutputWithoutFrom,
+  UpdateOutputAsTheLastClause,
+  UpdateReturningIsUnaffected,
+];


### PR DESCRIPTION
Fixes #300.

## The bug

```ts
Row<DB, 'update users set name = @p1 output inserted.id from users where id = @p2'>
// { 'from users': number }
```

Expected `{ id: number }`. The docs describe OUTPUT support without excluding the `UPDATE ... FROM` form, and this variant is common in real T-SQL.

## The fix

`OutputClauseColumns<S, 'where'>` accumulated entries until it saw `where` and nothing else, so `from` did not stop it and `inserted.id from users` became a single column entry that `ParseColumnEntry` read as a bare alias.

`from` now ends the list the same way `where` does, for both UPDATE and DELETE. `IsKeyword` compares through `Lowercase`, which distributes over a union, so the existing stop-keyword parameter takes `'where' | 'from'` without any other change.

## Verification

`tests/tsql-output-from.test-d.ts`, seven cases. Four red on master:

```
tests/tsql-output-from.test-d.ts(17,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/tsql-output-from.test-d.ts(24,3): ...
tests/tsql-output-from.test-d.ts(31,3): ...
tests/tsql-output-from.test-d.ts(41,3): ...
```

- `UPDATE ... OUTPUT ... FROM ... WHERE`, one column and several, the DELETE form, and the strict-mode variant

The strict case is worth reading: `inserted.` is stripped before resolution, so an OUTPUT column is looked up against *both* sources — the test uses `inserted.name`, which only `users` has, and qualifies the WHERE. That is existing behaviour, unchanged here.

Controls: OUTPUT without a FROM, OUTPUT as the last clause, and `RETURNING` are all unchanged.

`tsc --noEmit` clean, 192 runtime tests pass, budget 192,547 (+61).