### PR TITLE
fix(parse): name an unrecognized statement in strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A statement the parser does not recognize says so in strict mode: `QueryTypeError<'unsupported or unrecognized statement'>`. `truncate users`, a `selct` keyword typo and an empty query all resolved to a bare `never`, which explains nothing, and before the #275 guard landed they produced `unknown table: ''` - a message naming no table and pointing a keyword typo at the wrong layer ([#303](https://github.com/tiagolauer/OwlSQL/issues/303)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -971,6 +971,9 @@ type ApplyWhereCheck<
 export type MultipleStatementsError =
   QueryTypeError<'multiple statements are not supported: found a semicolon before the end of the query'>;
 
+export type UnrecognizedStatementError =
+  QueryTypeError<'unsupported or unrecognized statement'>;
+
 export type InferRowWith<
   DB extends SchemaLike,
   Q extends string,
@@ -994,7 +997,13 @@ type InferRowWithChecked<
     // constraint, which built a row out of `string` keys instead of failing
     // (issue #275).
     [ParseStatementNormalized<EffectiveQuery>] extends [never]
-    ? never
+    ? // Strict mode says what happened. `never` is a correct answer - there is
+      // no row - but it explains nothing, and the message this used to produce
+      // was worse: `unknown table: ''`, which named no table and pointed a
+      // `selct` typo at the wrong layer entirely (issue #303).
+      Strict extends true
+      ? UnrecognizedStatementError
+      : never
     : ParseStatementNormalized<EffectiveQuery> extends {
           columns: infer Columns extends string;
           sources: infer Sources extends Source[];

--- a/tests/unrecognized-statement.test-d.ts
+++ b/tests/unrecognized-statement.test-d.ts
@@ -1,0 +1,63 @@
+import type { Query, QueryTypeError, Row, StrictQuery, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+type Unrecognized = QueryTypeError<'unsupported or unrecognized statement'>;
+
+// Failing loudly is right; the message is what was missing. `never` says
+// nothing, and the message this produced before the #275 guard landed named no
+// table at all: `unknown table: ''` (issue #303).
+type UnsupportedStatementIsNamed = Expect<
+  Equal<StrictRow<DB, 'truncate users'>, Unrecognized>
+>;
+
+// A keyword typo is a keyword typo, not a table problem.
+type KeywordTypoIsNamed = Expect<Equal<StrictRow<DB, 'selct id from users'>, Unrecognized>>;
+
+type EmptyQueryIsNamed = Expect<Equal<StrictRow<DB, ''>, Unrecognized>>;
+
+type StrictQueryReportsItToo = Expect<
+  Equal<StrictQuery<DB, 'truncate users'>, Unrecognized[]>
+>;
+
+// Loose mode keeps failing quietly rather than degrading into an index
+// signature, which is what the #275 guard put in place.
+type LooseModeIsUnchanged = Expect<Equal<Row<DB, 'truncate users'>, never>>;
+
+// Controls: recognized statements are untouched, and the other statement-level
+// error still reads the way it did.
+type SelectIsUnaffected = Expect<Equal<StrictRow<DB, 'select id from users'>, { id: number }>>;
+
+type UpdateIsUnaffected = Expect<
+  Equal<StrictRow<DB, 'update users set name = $1 where id = $2 returning id'>, { id: number }>
+>;
+
+type StackedStatementsStillReportThemselves = Expect<
+  Equal<
+    StrictQuery<DB, 'select id from users; drop table users'>,
+    QueryTypeError<'multiple statements are not supported: found a semicolon before the end of the query'>[]
+  >
+>;
+
+type LooseSelectIsUnaffected = Expect<
+  Equal<Query<DB, 'select id from users'>, { id: number }[]>
+>;
+
+export type UnrecognizedStatementLock = [
+  UnsupportedStatementIsNamed,
+  KeywordTypoIsNamed,
+  EmptyQueryIsNamed,
+  StrictQueryReportsItToo,
+  LooseModeIsUnchanged,
+  SelectIsUnaffected,
+  UpdateIsUnaffected,
+  StackedStatementsStillReportThemselves,
+  LooseSelectIsUnaffected,
+];


### PR DESCRIPTION
Fixes #303.

## The bug

```ts
StrictRow<DB, 'truncate users'>       // never
StrictRow<DB, 'selct id from users'>  // never - a keyword typo
StrictRow<DB, ''>                     // never
```

Failing loudly is right. The message is the problem — and on the version the issue was filed against it was `QueryTypeError<'unknown table: ''>`, which names no table and points a `selct` typo at entirely the wrong layer. The `[never]` guard from #275 has since turned that into a bare `never`, which is honest but still explains nothing.

## The fix

Strict mode reports `QueryTypeError<'unsupported or unrecognized statement'>`, in the same shape as the multiple-statements error the parser already produces.

Loose mode keeps returning `never` rather than degrading into `{ [x: string]: unknown }`, which is what #275 deliberately put in place — a query the parser cannot read should not come back looking like a successful parse.

## Verification

`tests/unrecognized-statement.test-d.ts`, nine cases. Four red on master:

```
tests/unrecognized-statement.test-d.ts(18,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/unrecognized-statement.test-d.ts(22,34): ...
tests/unrecognized-statement.test-d.ts(24,33): ...
tests/unrecognized-statement.test-d.ts(27,3): ...
```

- `truncate users`, the `selct` typo and the empty query, through both `StrictRow` and `StrictQuery`
- loose mode pinned as `never`

Controls: a plain SELECT, an UPDATE with RETURNING, the stacked-statement error, and loose mode on a valid query are all unchanged.

`tsc --noEmit` clean, 192 runtime tests pass, budget 191,574 (**912 below master** — the strict branch replaces work the never path was doing downstream).