### PR TITLE
fix(string): keep a quoted identifier out of the comment scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- A quoted identifier holding `--` or an apostrophe parses. Comment stripping and literal masking ran with no double-quote awareness, so the `--` in `"a--b"` was read as a line comment and ate the rest of the query, and the `'` in `"it's"` opened a literal mask - and quoted identifiers are the documented escape hatch for exactly these names. The scan now dispatches on the character it already read, which also makes it cheaper: 184,737 instantiations against master's 192,486 ([#287](https://github.com/tiagolauer/OwlSQL/issues/287)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/string.ts
+++ b/src/string.ts
@@ -153,6 +153,26 @@ type HasMaskableToken<S extends string> = S extends
   ? true
   : false;
 
+// The body of a quoted identifier is a name, not SQL, so nothing inside it
+// opens a comment or a string literal. Without this the scan below read the
+// `--` in `"a--b"` as a line comment and ate the rest of the query, and the
+// `'` in `"it's"` as the start of a literal - and quoted identifiers are the
+// documented escape hatch for exactly those names (issue #287).
+type SplitQuotedIdentifier<S extends string, Close extends string> =
+  S extends `${infer Body}${Close}${infer Rest}` ? { body: Body; rest: Rest } : never;
+
+type CopyQuotedIdentifier<
+  S extends string,
+  Open extends string,
+  Close extends string,
+  Accumulated extends string,
+> = SplitQuotedIdentifier<S, Close> extends {
+  body: infer Body extends string;
+  rest: infer Rest extends string;
+}
+  ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${Open}${Body}${Close}`>
+  : `${Accumulated}${Open}${S}`;
+
 export type StripCommentsAndMaskLiterals<
   S extends string,
   Accumulated extends string = '',
@@ -160,32 +180,57 @@ export type StripCommentsAndMaskLiterals<
   ? Accumulated
   : HasMaskableToken<S> extends false
     ? `${Accumulated}${S}`
-    : S extends `'${infer AfterQuote}`
-      ? SkipLiteralBody<AfterQuote> extends { rest: infer Rest extends string }
-        ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}''`>
-        : `${Accumulated}${S}`
-      : S extends `--${infer AfterDash}`
-        ? StripCommentsAndMaskLiterals<AfterLineComment<AfterDash>, `${Accumulated} `>
-        : S extends `/*${infer AfterBlock}`
-          ? StripCommentsAndMaskLiterals<AfterBlockComment<AfterBlock>, `${Accumulated} `>
-          : S extends `$${infer AfterDollar}`
-            ? [DollarQuoteOpen<AfterDollar>] extends [never]
-              ? S extends `${infer Head}${infer Rest}`
-                ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${Head}`>
+    : S extends `${infer Opener}${infer AfterOpen}`
+      ? // One character comparison rather than three more whole-string pattern
+        // matches per step: this scan runs over every query, and the pattern
+        // form measured +15,778 instantiations on the fixture.
+        Opener extends IdentifierQuoteOpen
+        ? CopyQuotedIdentifier<AfterOpen, Opener, IdentifierQuoteClose[Opener], Accumulated>
+        : StripCommentsAndMaskLiteralsRest<S, Opener, AfterOpen, Accumulated>
+      : Accumulated;
+
+interface IdentifierQuoteClose {
+  '"': '"';
+  '[': ']';
+  '`': '`';
+}
+
+type IdentifierQuoteOpen = keyof IdentifierQuoteClose;
+
+// Everything below keys off the character already destructured by the caller,
+// so one step costs one comparison per case instead of a whole-string pattern
+// match per case.
+type StripCommentsAndMaskLiteralsRest<
+  S extends string,
+  Opener extends string,
+  AfterOpen extends string,
+  Accumulated extends string,
+> = Opener extends "'"
+  ? SkipLiteralBody<AfterOpen> extends { rest: infer Rest extends string }
+    ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}''`>
+    : `${Accumulated}${S}`
+  : Opener extends '-'
+    ? AfterOpen extends `-${infer AfterDash}`
+      ? StripCommentsAndMaskLiterals<AfterLineComment<AfterDash>, `${Accumulated} `>
+      : StripCommentsAndMaskLiterals<AfterOpen, `${Accumulated}${Opener}`>
+    : Opener extends '/'
+      ? AfterOpen extends `*${infer AfterBlock}`
+        ? StripCommentsAndMaskLiterals<AfterBlockComment<AfterBlock>, `${Accumulated} `>
+        : StripCommentsAndMaskLiterals<AfterOpen, `${Accumulated}${Opener}`>
+      : Opener extends '$'
+        ? [DollarQuoteOpen<AfterOpen>] extends [never]
+          ? StripCommentsAndMaskLiterals<AfterOpen, `${Accumulated}${Opener}`>
+          : DollarQuoteOpen<AfterOpen> extends {
+                tag: infer Tag extends string;
+                afterOpen: infer AfterBody extends string;
+              }
+            ? [SkipDollarQuotedBody<AfterBody, Tag>] extends [never]
+              ? `${Accumulated}${S}`
+              : SkipDollarQuotedBody<AfterBody, Tag> extends { rest: infer Rest extends string }
+                ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}''`>
                 : Accumulated
-              : DollarQuoteOpen<AfterDollar> extends {
-                    tag: infer Tag extends string;
-                    afterOpen: infer AfterOpen extends string;
-                  }
-                ? [SkipDollarQuotedBody<AfterOpen, Tag>] extends [never]
-                  ? `${Accumulated}${S}`
-                  : SkipDollarQuotedBody<AfterOpen, Tag> extends { rest: infer Rest extends string }
-                    ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}''`>
-                    : Accumulated
-                : Accumulated
-            : S extends `${infer Head}${infer Rest}`
-              ? StripCommentsAndMaskLiterals<Rest, `${Accumulated}${Head}`>
-              : Accumulated;
+            : Accumulated
+        : StripCommentsAndMaskLiterals<AfterOpen, `${Accumulated}${Opener}`>;
 
 // Everything downstream splits the query on spaces, so a quoted identifier
 // holding one - `"first name"`, `[Order Details]` - was torn in half: the

--- a/tests/quoted-identifier-punctuation.test-d.ts
+++ b/tests/quoted-identifier-punctuation.test-d.ts
@@ -1,0 +1,80 @@
+import type { Query, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    'a--b': string;
+    "it's": string;
+    'a/*b': string;
+    'a$b': string;
+  };
+  'weird-table': { id: number };
+}
+
+// Comment stripping and literal masking ran before anything knew about double
+// quotes, so the `--` inside a quoted name ate the rest of the query and the
+// `'` opened a literal mask (issue #287). Quoted identifiers are the
+// documented escape hatch for exactly these names.
+type DashDashInsideAQuotedName = Expect<
+  Equal<Query<DB, 'select "a--b" from users'>, { 'a--b': string }[]>
+>;
+
+type DashDashInsideAQuotedNameInStrictMode = Expect<
+  Equal<StrictRow<DB, 'select "a--b" from users'>, { 'a--b': string }>
+>;
+
+type ApostropheInsideAQuotedName = Expect<
+  Equal<Query<DB, `select "it's" from users`>, { "it's": string }[]>
+>;
+
+type BlockCommentOpenerInsideAQuotedName = Expect<
+  Equal<Query<DB, 'select "a/*b" from users'>, { 'a/*b': string }[]>
+>;
+
+type DollarInsideAQuotedName = Expect<
+  Equal<Query<DB, 'select "a$b" from users'>, { 'a$b': string }[]>
+>;
+
+type QuotedNameAmongOtherColumns = Expect<
+  Equal<Query<DB, 'select id, "a--b" from users'>, { id: number; 'a--b': string }[]>
+>;
+
+// A real comment and a real literal still do their job when a quoted
+// identifier is in the same query.
+type RealCommentStillStripped = Expect<
+  Equal<Query<DB, 'select "a--b" from users -- trailing note'>, { 'a--b': string }[]>
+>;
+
+type RealLiteralStillMasked = Expect<
+  Equal<Query<DB, `select "a--b" from users where id = 'x'`>, { 'a--b': string }[]>
+>;
+
+// Controls: ordinary quoting, backticks and brackets are unchanged.
+type PlainQuotedName = Expect<Equal<Query<DB, 'select "id" from users'>, { id: number }[]>>;
+
+type BracketQuotedTable = Expect<
+  Equal<Query<DB, 'select id from [weird-table]'>, { id: number }[]>
+>;
+
+type BacktickQuotedName = Expect<
+  Equal<Query<DB, 'select `id` from users'>, { id: number }[]>
+>;
+
+export type QuotedIdentifierPunctuationLock = [
+  DashDashInsideAQuotedName,
+  DashDashInsideAQuotedNameInStrictMode,
+  ApostropheInsideAQuotedName,
+  BlockCommentOpenerInsideAQuotedName,
+  DollarInsideAQuotedName,
+  QuotedNameAmongOtherColumns,
+  RealCommentStillStripped,
+  RealLiteralStillMasked,
+  PlainQuotedName,
+  BracketQuotedTable,
+  BacktickQuotedName,
+];


### PR DESCRIPTION
Fixes #287.

## The bug

```ts
// DB has a column literally named a--b
StrictRow<DB, 'select "a--b" from users'>
// QueryTypeError<'no FROM clause: cannot resolve column ""a"'>
// loose: { '"a': unknown }[]

Query<DB, `select "it's" from users`>
// the strict error text even leaked a non-literal ${string} into the message
```

The `--` inside the quotes was taken as a line comment and ate the rest of the query; the `'` opened a string-literal mask. Quoted identifiers are the documented escape hatch for special names, and these are exactly the names that need it.

## The fix

`StripCommentsAndMaskLiterals` now recognizes the three identifier quotes and copies the body through verbatim — nothing inside a quoted name opens a comment or a literal. `MaskQuotedIdentifiers` already exists to protect `;` from the same class of scan (#232); this extends that treatment to the pass that runs *before* it.

**The structure of the scan changed with it, and it is the reason this is not expensive.** Written as three more whole-string pattern matches per step, the fix measured **208,264** instantiations — over the 200,000 budget. Destructuring the leading character once and dispatching on it (`Opener extends "'"`, `Opener extends '-'`, …) makes every case a character comparison instead of a pattern match:

| | instantiations |
| --- | --- |
| master | 192,486 |
| fix, pattern-matched | 208,264 (over budget) |
| fix, character-dispatched | **184,737** |

So the fix lands 7,749 *below* master.

## Verification

`tests/quoted-identifier-punctuation.test-d.ts`, eleven cases. Six red on master:

```
tests/quoted-identifier-punctuation.test-d.ts(28,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/quoted-identifier-punctuation.test-d.ts(32,3): ... (36,3), (44,3), (50,3), (54,3)
```

- `"a--b"` in both modes, `"it's"`, `"a/*b"`, `"a$b"`, and one among ordinary columns
- a real trailing `--` comment and a real `'x'` literal in the same query as a quoted name still work

Controls: plain `"id"`, `[weird-table]` and `` `id` `` are unchanged.

`tsc --noEmit` clean, 192 runtime tests pass.