### PR TITLE
fix(parse): check the write target when nothing else does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- Strict mode checks the target of a write that has no RETURNING and no WHERE - which is to say, the everyday INSERT. `insert into ghosts (name) values ($1)`, `delete from ghosts` and `update ghosts set name = $1` were all accepted, because table existence was only ever verified as a side effect of resolving some column ([#271](https://github.com/tiagolauer/OwlSQL/issues/271)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -878,6 +878,22 @@ type IsSelectAll<Columns extends string> = Trim<Columns> extends '*' ? true : fa
 
 type EmptyRow = Record<string, never>;
 
+// A write projecting nothing still names a table, and until now nothing looked
+// it up: table existence was only ever checked as a side effect of resolving
+// some column, in RETURNING or in WHERE. So `insert into ghosts (name) values
+// ($1)` - the everyday INSERT, and the most common write typo there is -
+// passed strict mode, while adding `returning id` to it failed properly
+// (issue #271).
+type EmptyRowChecked<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Strict extends boolean,
+> = Strict extends true
+  ? AllKnownTables<DB, Sources> extends true
+    ? EmptyRow
+    : QueryTypeError<`unknown table: ${FirstUnknownTable<DB, Sources>}`>
+  : EmptyRow;
+
 // A CTE shadows a real table of the same name for the rest of the query -
 // only its own projected columns stay visible. Merging the CTE map into DB
 // with a plain intersection doesn't do that: object intersection is
@@ -1013,7 +1029,7 @@ type InferRowWithChecked<
           FromText,
           Strict,
           Trim<Columns> extends ''
-            ? EmptyRow
+            ? EmptyRowChecked<EffectiveDB, Sources, Strict>
             : IsSelectAll<Columns> extends true
               ? StarRow<EffectiveDB, Sources, Strict>
               : BuildSelection<

--- a/tests/unknown-write-target.test-d.ts
+++ b/tests/unknown-write-target.test-d.ts
@@ -1,0 +1,71 @@
+import type { QueryTypeError, Row, StrictQuery, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  orders: { id: number; user_id: number; total: number };
+}
+
+type EmptyRow = Record<string, never>;
+
+// Table existence was only ever verified as a side effect of resolving some
+// column, in RETURNING or in WHERE - so a write with neither, which is the
+// everyday INSERT, never checked its target at all (issue #271).
+type UnknownInsertTarget = Expect<
+  Equal<StrictRow<DB, 'insert into ghosts (name) values ($1)'>, QueryTypeError<'unknown table: ghosts'>>
+>;
+
+type UnknownDeleteTarget = Expect<
+  Equal<StrictRow<DB, 'delete from ghosts'>, QueryTypeError<'unknown table: ghosts'>>
+>;
+
+type UnknownUpdateTarget = Expect<
+  Equal<StrictRow<DB, 'update ghosts set name = $1'>, QueryTypeError<'unknown table: ghosts'>>
+>;
+
+type UnknownTargetThroughStrictQuery = Expect<
+  Equal<StrictQuery<DB, 'insert into ghosts (name) values ($1)'>, QueryTypeError<'unknown table: ghosts'>[]>
+>;
+
+// The forms that already reported it keep reporting it.
+type UnknownTargetWithReturning = Expect<
+  Equal<StrictRow<DB, 'insert into ghosts (name) values ($1) returning id'>, QueryTypeError<'unknown table: ghosts'>>
+>;
+
+// Controls: a real target with no RETURNING and no WHERE still projects
+// nothing, in every write shape.
+type KnownInsertTarget = Expect<
+  Equal<StrictRow<DB, 'insert into users (name) values ($1)'>, EmptyRow>
+>;
+
+type KnownDeleteTarget = Expect<Equal<StrictRow<DB, 'delete from users'>, EmptyRow>>;
+
+type KnownUpdateTarget = Expect<
+  Equal<StrictRow<DB, 'update users set name = $1'>, EmptyRow>
+>;
+
+type KnownUpdateWithFromClause = Expect<
+  Equal<StrictRow<DB, 'update users set name = $1 from orders'>, EmptyRow>
+>;
+
+// Loose mode is unchanged: it does not report unknown tables.
+type LooseModeIsUnchanged = Expect<
+  Equal<Row<DB, 'insert into ghosts (name) values ($1)'>, EmptyRow>
+>;
+
+export type UnknownWriteTargetLock = [
+  UnknownInsertTarget,
+  UnknownDeleteTarget,
+  UnknownUpdateTarget,
+  UnknownTargetThroughStrictQuery,
+  UnknownTargetWithReturning,
+  KnownInsertTarget,
+  KnownDeleteTarget,
+  KnownUpdateTarget,
+  KnownUpdateWithFromClause,
+  LooseModeIsUnchanged,
+];


### PR DESCRIPTION
Fixes #271.

## The bug

```ts
StrictQuery<DB, 'insert into ghosts (name) values ($1)'>  // Record<string, never>[] - no error
StrictQuery<DB, 'delete from ghosts'>                     // same
StrictQuery<DB, 'update ghosts set name = $1'>            // same
```

Add `returning id` and the expected `QueryTypeError<'unknown table: ghosts'>` appears. Add a WHERE to the DELETE and it also errors. So the hole sits exactly on the everyday INSERT — and a mistyped write target is about the most common write mistake there is. The README's limitations section says strict mode turns unknown tables into a `QueryTypeError`.

## The fix

Table existence was only ever verified as a *side effect* of resolving some column, in RETURNING or in WHERE/ON. The `EmptyRow` path in `InferRowWithChecked` never resolved `Sources` against the schema at all.

It now does, in strict mode, reusing the `AllKnownTables` / `FirstUnknownTable` pair `StarRow` already reports with — so the message is identical to the one every other path produces. Loose mode still returns the empty row.

## Verification

`tests/unknown-write-target.test-d.ts`, ten cases. Four red on master:

```
tests/unknown-write-target.test-d.ts(19,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/unknown-write-target.test-d.ts(23,3): ... (27,3), (31,3)
```

- unknown INSERT / DELETE / UPDATE targets, through `StrictRow` and `StrictQuery`
- the RETURNING form that already reported it still does

Controls: a real target with no RETURNING and no WHERE still projects nothing (all three write shapes, plus `update ... from orders`), and loose mode is unchanged.

`tsc --noEmit` clean, 192 runtime tests pass, budget 193,122 (+636).