### PR TITLE
fix(from): model JOIN ... USING as a merged column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- The merged column of a `JOIN ... USING` is no longer reported as ambiguous. `select id from a join b using (id)` produced `QueryTypeError<'ambiguous column: id'>` although USING makes one column out of the pair - referencing it bare is the whole point of the syntax. The joined table also keeps its own name as its alias, which used to be set to the literal word `using` ([#284](https://github.com/tiagolauer/OwlSQL/issues/284)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/from.ts
+++ b/src/from.ts
@@ -15,6 +15,11 @@ export interface Source {
   alias: string;
   nullable: boolean;
   derivedQuery?: string;
+  // The columns a `JOIN ... USING (...)` merges. USING makes one column out of
+  // the pair, so the name is not ambiguous the way the same name coming from
+  // two independent tables is - it is carried here because the count that
+  // decides ambiguity sees only the sources (issue #284).
+  mergedColumns?: string;
 }
 
 type ClauseBoundary =
@@ -169,7 +174,7 @@ type AliasOf<Segment extends string, Table extends string> =
   DropFirstWord<Segment> extends ''
     ? Table
     : FirstWord<DropFirstWord<Segment>> extends infer Next extends string
-      ? IsKeyword<Next, 'on'> extends true
+      ? IsKeyword<Next, 'on' | 'using'> extends true
         ? Table
         : IsKeyword<Next, 'as'> extends true
           ? FirstWord<DropFirstWord<DropFirstWord<Segment>>> extends infer Aliased extends string
@@ -213,6 +218,19 @@ type StripLateral<Segment extends string> = Trim<Segment> extends `${infer Head}
     : Trim<Segment>
   : Trim<Segment>;
 
+// The USING list of the join this segment belongs to. Only the spaced form is
+// read; `using(id)` glued to its paren keeps the old behaviour of no merge,
+// which errs on the side of the existing report rather than a silent one.
+type UsingColumnsOf<Segment extends string> = Segment extends `${infer Head} ${infer Tail}`
+  ? IsKeyword<Head, 'using'> extends true
+    ? Trim<Tail> extends `(${infer AfterOpen}`
+      ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string }
+        ? Inner
+        : ''
+      : ''
+    : UsingColumnsOf<Tail>
+  : '';
+
 type SegmentToSource<Segment extends string, Nullable extends boolean> = StripLateral<Segment> extends `(${string}`
   ? DerivedSegmentToSource<StripLateral<Segment>, Nullable>
   : CleanIdentifier<FirstWord<Segment>> extends infer Table extends string
@@ -220,6 +238,7 @@ type SegmentToSource<Segment extends string, Nullable extends boolean> = StripLa
         table: Table;
         alias: Unquote<AliasOf<Segment, Table>>;
         nullable: Nullable;
+        mergedColumns: UsingColumnsOf<Segment>;
       }
     : never;
 
@@ -238,7 +257,9 @@ type SegmentToSources<Segment extends string, Nullable extends boolean> = PartsT
 type MarkNullable<Sources extends Source[]> = {
   [Index in keyof Sources]: Sources[Index] extends { derivedQuery: infer Q extends string }
     ? { table: Sources[Index]['table']; alias: Sources[Index]['alias']; nullable: true; derivedQuery: Q }
-    : { table: Sources[Index]['table']; alias: Sources[Index]['alias']; nullable: true };
+    : Sources[Index] extends { mergedColumns: infer M extends string }
+      ? { table: Sources[Index]['table']; alias: Sources[Index]['alias']; nullable: true; mergedColumns: M }
+      : { table: Sources[Index]['table']; alias: Sources[Index]['alias']; nullable: true };
 };
 
 type CollectSources<

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -552,6 +552,25 @@ type FirstSourceTable<Sources extends Source[]> = Sources extends [
   ? Head['table']
   : '';
 
+// `a join b using (id)` produces one `id`, not two - that is what USING is for,
+// and referencing it bare is the whole point of the syntax. The source the
+// join merged carries the list, so its copy of the column does not count
+// towards ambiguity (issue #284).
+type ColumnListIncludes<List extends string, Column extends string> =
+  List extends `${infer Head},${infer Tail}`
+    ? IsKeyword<Trim<Head>, Column> extends true
+      ? true
+      : ColumnListIncludes<Tail, Column>
+    : IsKeyword<Trim<List>, Column>;
+
+type IsMergedColumn<Head extends Source, Column extends string> = Head extends {
+  mergedColumns: infer Merged extends string;
+}
+  ? Merged extends ''
+    ? false
+    : ColumnListIncludes<Merged, Column>
+  : false;
+
 type CountBareMatches<
   DB extends SchemaLike,
   Sources extends Source[],
@@ -560,7 +579,9 @@ type CountBareMatches<
 > = Sources extends [infer Head extends Source, ...infer Tail extends Source[]]
   ? [SourceColumnType<DB, Head, Column>] extends [never]
     ? CountBareMatches<DB, Tail, Column, Count>
-    : CountBareMatches<DB, Tail, Column, [...Count, unknown]>
+    : IsMergedColumn<Head, Column> extends true
+      ? CountBareMatches<DB, Tail, Column, Count>
+      : CountBareMatches<DB, Tail, Column, [...Count, unknown]>
   : Count;
 
 type BareColumnType<

--- a/tests/join-using-merged.test-d.ts
+++ b/tests/join-using-merged.test-d.ts
@@ -1,0 +1,79 @@
+import type { Query, QueryTypeError, StrictQuery } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  a: { id: number; x: string };
+  b: { id: number; y: string };
+  c: { id: number; z: string };
+}
+
+// USING merges the join column in every dialect that has it, and referencing
+// it bare is the whole point of the syntax - it was reported as ambiguous
+// because the count that decides ambiguity sees one source per table (#284).
+type MergedColumnResolves = Expect<
+  Equal<StrictQuery<DB, 'select id from a join b using (id)'>, { id: number }[]>
+>;
+
+type MergedColumnBesideOthers = Expect<
+  Equal<
+    StrictQuery<DB, 'select id, x, y from a join b using (id)'>,
+    { id: number; x: string; y: string }[]
+  >
+>;
+
+type MergedColumnAcrossTwoJoins = Expect<
+  Equal<StrictQuery<DB, 'select id from a join b using (id) join c using (id)'>, { id: number }[]>
+>;
+
+type LeftJoinUsingResolves = Expect<
+  Equal<StrictQuery<DB, 'select id from a left join b using (id)'>, { id: number }[]>
+>;
+
+// The joined table keeps its own name as its alias: it used to be set to the
+// literal word `using`.
+type QualifiedReferenceThroughAUsingJoin = Expect<
+  Equal<StrictQuery<DB, 'select b.y from a join b using (id)'>, { y: string }[]>
+>;
+
+// Controls: a genuine ambiguity is still reported, a column outside the USING
+// list is still ambiguous, and ON joins are untouched.
+type OnJoinStillReportsAmbiguity = Expect<
+  Equal<
+    StrictQuery<DB, 'select id from a join b on a.id = b.id'>,
+    QueryTypeError<'ambiguous column: id'>[]
+  >
+>;
+
+type NonMergedColumnStillAmbiguous = Expect<
+  Equal<
+    StrictQuery<DB, 'select id from a join b using (x)'>,
+    QueryTypeError<'ambiguous column: id'>[]
+  >
+>;
+
+type LooseModeIsUnchanged = Expect<
+  Equal<Query<DB, 'select id from a join b using (id)'>, { id: number }[]>
+>;
+
+type UnknownColumnStillReported = Expect<
+  Equal<
+    StrictQuery<DB, 'select nope from a join b using (id)'>,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+export type JoinUsingMergedLock = [
+  MergedColumnResolves,
+  MergedColumnBesideOthers,
+  MergedColumnAcrossTwoJoins,
+  LeftJoinUsingResolves,
+  QualifiedReferenceThroughAUsingJoin,
+  OnJoinStillReportsAmbiguity,
+  NonMergedColumnStillAmbiguous,
+  LooseModeIsUnchanged,
+  UnknownColumnStillReported,
+];


### PR DESCRIPTION
Fixes #284.

## The bug

```ts
// DB: a: {id, x}, b: {id, y}
StrictQuery<DB, 'select id from a join b using (id)'>
// QueryTypeError<'ambiguous column: id'>[]
```

Expected `{ id: number }[]`. USING merges the join column in every dialect that has it; referencing it bare is the whole point of the syntax.

## The fix

USING was not modeled at all:

- `AliasOf` only special-cased `on` and `as`, so the joined table's alias was set to the literal word **`using`** — which also broke `select b.y from a join b using (id)`.
- `CountBareMatches` counted the column once per source, with no merge exemption.

A `Source` now carries the columns its join merged (`mergedColumns`, alongside the existing optional `derivedQuery`), and a source's copy of one of those columns does not count towards ambiguity. The type still resolves from the first matching source, so nothing about the value changes.

`using(id)` glued to its paren is deliberately left alone — only the spaced form is read — so that case keeps the report it already gave rather than silently merging.

## Verification

`tests/join-using-merged.test-d.ts`, nine cases. Four red on master:

```
tests/join-using-merged.test-d.ts(18,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/join-using-merged.test-d.ts(22,3): ... (29,3), (33,3)
```

- the merged column alone, beside other columns, across two USING joins, and through a LEFT JOIN
- a qualified reference through the joined table (`b.y`), which the `using` alias used to break

Controls, all still reporting: an ON join is still `ambiguous column: id`, a column *outside* the USING list is still ambiguous, an unknown column is still unknown, and loose mode is unchanged.

`tsc --noEmit` clean, 192 core + 155 plugin runtime tests pass, budget 194,721 (+2,235).