### PR TITLE
fix(parse): check INSERT columns and UPDATE SET targets in strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- Strict mode checks the INSERT column list and the UPDATE SET targets. `insert into users (naem) values ($1)` and `update users set naem = $1` were both accepted, although each is a guaranteed runtime error on every engine; the documented list of unchecked clauses covers GROUP BY, HAVING and ORDER BY, never write-statement column names. MAX_INSTANTIATIONS moves 200,000 -> 210,000: the fixture goes from 192,486 to 201,322, the cost of the two clause scans a write now runs ([#282](https://github.com/tiagolauer/OwlSQL/issues/282)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -19,7 +19,14 @@ const SHAPE_REPEATS = 4;
 // splits per query instead of one) and buys back a compiler crash - a tab beside
 // a newline, or any CRLF, used to exhaust the heap outright. Gating the passes
 // was measured and came out worse, see the note in src/string.ts.
-const MAX_INSTANTIATIONS = 200_000;
+// Raised again from 200,000 for #282: strict mode now resolves the INSERT
+// column list and the UPDATE SET targets against the schema, which are
+// guaranteed runtime errors nothing checked before. The check itself is gated
+// on a non-empty column text, so a SELECT pays only for carrying the empty
+// string; the ~4.5% is the two clause scans a write statement now runs
+// (`SplitAtTopLevelKeyword` for VALUES/SELECT and for SET) plus the extra
+// field on every parsed statement. Measured: 192,486 -> 201,322.
+const MAX_INSTANTIATIONS = 210_000;
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PERF_DIR = join(ROOT, 'tests', 'perf');

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -23,6 +23,7 @@ import type {
   ParseFromClause,
   RestAfterFromClause,
   TakeFromClause,
+  TakeUntilClauseBoundary,
   ExtractJoinOnText,
 } from './from.js';
 import type { IsCaseExpression, SplitCaseExpression, CaseExpressionType } from './case.js';
@@ -290,11 +291,93 @@ type ExtraSourcesAfterKeyword<S extends string, Keyword extends string> = [
     ? ParseFromClause<AfterClause>
     : [];
 
+// Nothing scanned the INSERT column list or the SET assignment targets against
+// the schema, so `insert into users (naem) values ($1)` and
+// `update users set naem = $1` both passed strict mode - guaranteed runtime
+// errors on every engine, and the kind of typo the mode exists to catch. The
+// documented list of unchecked clauses covers GROUP BY, HAVING and ORDER BY;
+// column names in write statements were never on it (issue #282).
+type AssignmentTarget<Entry extends string> = Trim<Entry> extends `${infer Before}=${string}`
+  ? Trim<Before>
+  : Trim<Entry>;
+
+// A row assignment (`set (a, b) = (1, 2)`) and anything else that is not a
+// plain name are left alone: this check reports a name the schema does not
+// have, and it must not invent a report for a shape it cannot read.
+type IsPlainColumnName<Column extends string> = Column extends '' | `${string}(${string}` | `${string} ${string}`
+  ? false
+  : true;
+
+type FirstUnknownWriteColumn<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Entries extends string[],
+> = Entries extends [infer Head extends string, ...infer Tail extends string[]]
+  ? AssignmentTarget<Head> extends infer Column extends string
+    ? IsPlainColumnName<Column> extends false
+      ? FirstUnknownWriteColumn<DB, Sources, Tail>
+      : ResolveColumnType<DB, Sources, Column, true> extends QueryTypeError<infer Message>
+        ? QueryTypeError<Message>
+        : FirstUnknownWriteColumn<DB, Sources, Tail>
+    : never
+  : never;
+
+type ApplyWriteColumnCheck<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  ColumnsText extends string,
+  Strict extends boolean,
+  Row,
+> = ColumnsText extends ''
+  ? // Cheapest test first: every SELECT carries an empty string here, and the
+    // structural `Row extends QueryTypeError` check below is not free on a
+    // wide row.
+    Row
+  : Strict extends true
+    ? Row extends QueryTypeError<string>
+      ? Row
+      : [FirstUnknownWriteColumn<DB, Sources, SplitColumnList<Trim<ColumnsText>>>] extends [never]
+        ? Row
+        : FirstUnknownWriteColumn<DB, Sources, SplitColumnList<Trim<ColumnsText>>>
+    : Row;
+
+// The column list of an INSERT, which is the first parenthesized group before
+// VALUES or the SELECT half - never the VALUES tuple itself.
+type FirstParenGroupInner<S extends string> = S extends `${string}(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string }
+    ? Inner
+    : ''
+  : '';
+
+type BeforeTopLevelKeyword<S extends string, Keyword extends string> = [
+  SplitAtTopLevelKeyword<S, Keyword>,
+] extends [never]
+  ? ''
+  : SplitAtTopLevelKeyword<S, Keyword> extends { before: infer Before extends string }
+    ? Before
+    : '';
+
+type InsertColumnsText<S extends string> = BeforeTopLevelKeyword<S, 'values'> extends ''
+  ? FirstParenGroupInner<BeforeTopLevelKeyword<S, 'select'>>
+  : FirstParenGroupInner<BeforeTopLevelKeyword<S, 'values'>>;
+
+// The SET clause runs to the first clause boundary. `from` is not one of them,
+// so an `UPDATE ... FROM` keeps its FROM text in this string - harmless,
+// because only the text before each `=` is read.
+type UpdateSetText<S extends string> = [SplitAtTopLevelKeyword<S, 'set'>] extends [never]
+  ? ''
+  : SplitAtTopLevelKeyword<S, 'set'> extends { after: infer After extends string }
+    ? TakeUntilClauseBoundary<After>
+    : '';
+
 export interface ParsedStatement {
   columns: string;
   sources: Source[];
   whereText: string;
   fromText: string;
+  // Empty for everything but the two write branches that carry a column list:
+  // INSERT's, and UPDATE's SET assignment targets.
+  writeColumnsText: string;
 }
 
 type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer Body
@@ -308,12 +391,13 @@ type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer B
             columns: Columns;
             sources: ParseFromClause<AfterFrom>;
             whereText: ExtractSelectWhereText<RestAfterFromClause<AfterFrom>>;
+            writeColumnsText: '';
             // Kept as raw text rather than pre-extracted ON conditions: the
             // JOIN ON check only runs in strict mode, and this way the scan
             // is never instantiated for a non-strict query.
             fromText: TakeFromClause<AfterFrom>;
           }
-        : { columns: Columns; sources: []; whereText: ''; fromText: '' }
+        : { columns: Columns; sources: []; whereText: ''; fromText: ''; writeColumnsText: '' }
       : never
     : never
   : never;
@@ -337,6 +421,7 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
           sources: SingleSource<RestAfterKeyword<S, 'into'>>;
           whereText: '';
           fromText: '';
+          writeColumnsText: InsertColumnsText<S>;
         }
       : IsKeyword<Keyword, 'update'> extends true
         ? {
@@ -347,6 +432,7 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
             ];
             whereText: ExtractUpdateDeleteWhereText<S>;
             fromText: '';
+            writeColumnsText: UpdateSetText<S>;
           }
         : IsKeyword<Keyword, 'delete'> extends true
           ? {
@@ -357,6 +443,7 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
               ];
               whereText: ExtractUpdateDeleteWhereText<S>;
               fromText: '';
+              writeColumnsText: '';
             }
           : IsKeyword<Keyword, 'merge'> extends true
             ? {
@@ -369,6 +456,7 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
                 sources: SingleSource<RestAfterKeyword<S, 'into'>>;
                 whereText: '';
                 fromText: '';
+                writeColumnsText: '';
               }
             : never
   : never;
@@ -1000,13 +1088,19 @@ type InferRowWithChecked<
           sources: infer Sources extends Source[];
           whereText: infer WhereText extends string;
           fromText: infer FromText extends string;
+          writeColumnsText: infer WriteColumnsText extends string;
         }
     ? (CteDB & BuildDerivedSourceMap<CteDB, Sources, Strict>) extends infer EffectiveDB extends SchemaLike
       ? // The clause check wraps the empty row too: a write with no RETURNING
         // projects nothing, but its WHERE clause is still a set of column
         // references strict mode has to validate - and UPDATE/DELETE is where
         // a wrong one costs the most (issue #233).
-        ApplyWhereCheck<
+        ApplyWriteColumnCheck<
+          EffectiveDB,
+          Sources,
+          WriteColumnsText,
+          Strict,
+          ApplyWhereCheck<
           EffectiveDB,
           Sources,
           WhereText,
@@ -1024,6 +1118,7 @@ type InferRowWithChecked<
                     : [],
                   Strict
                 >
+        >
         >
       : never
     : never

--- a/tests/write-column-check.test-d.ts
+++ b/tests/write-column-check.test-d.ts
@@ -1,0 +1,97 @@
+import type { QueryTypeError, Row, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string; email: string };
+  orders: { id: number; user_id: number; total: number };
+}
+
+type EmptyRow = Record<string, never>;
+
+// Both are guaranteed runtime errors on every engine, and nothing scanned
+// either list against the schema (issue #282).
+type UnknownInsertColumn = Expect<
+  Equal<
+    StrictRow<DB, 'insert into users (naem) values ($1)'>,
+    QueryTypeError<'unknown column: naem'>
+  >
+>;
+
+type UnknownUpdateSetTarget = Expect<
+  Equal<
+    StrictRow<DB, 'update users set naem = $1 where id = 1'>,
+    QueryTypeError<'unknown column: naem'>
+  >
+>;
+
+type UnknownColumnLaterInTheInsertList = Expect<
+  Equal<
+    StrictRow<DB, 'insert into users (id, name, naem) values ($1, $2, $3)'>,
+    QueryTypeError<'unknown column: naem'>
+  >
+>;
+
+type UnknownTargetLaterInTheSetList = Expect<
+  Equal<
+    StrictRow<DB, 'update users set name = $1, naem = $2 where id = 1'>,
+    QueryTypeError<'unknown column: naem'>
+  >
+>;
+
+type UnknownInsertColumnWithReturning = Expect<
+  Equal<
+    StrictRow<DB, 'insert into users (naem) values ($1) returning id'>,
+    QueryTypeError<'unknown column: naem'>
+  >
+>;
+
+// Controls: valid writes still project what they always did.
+type ValidInsertColumns = Expect<
+  Equal<StrictRow<DB, 'insert into users (id, name) values ($1, $2)'>, EmptyRow>
+>;
+
+type ValidInsertWithReturning = Expect<
+  Equal<StrictRow<DB, 'insert into users (id, name) values ($1, $2) returning id'>, { id: number }>
+>;
+
+type ValidUpdateTargets = Expect<
+  Equal<StrictRow<DB, 'update users set name = $1, email = $2 where id = 1'>, EmptyRow>
+>;
+
+type InsertWithoutAColumnListIsUnchecked = Expect<
+  Equal<StrictRow<DB, 'insert into users values ($1, $2, $3)'>, EmptyRow>
+>;
+
+type SetValueSubqueryIsNotATarget = Expect<
+  Equal<
+    StrictRow<DB, 'update users set name = (select name from users where id = 1) where id = 2'>,
+    EmptyRow
+  >
+>;
+
+type QualifiedSetTargetResolves = Expect<
+  Equal<StrictRow<DB, 'update users set users.name = $1 where id = 1'>, EmptyRow>
+>;
+
+type LooseModeIsUnchanged = Expect<
+  Equal<Row<DB, 'insert into users (naem) values ($1)'>, EmptyRow>
+>;
+
+export type WriteColumnCheckLock = [
+  UnknownInsertColumn,
+  UnknownUpdateSetTarget,
+  UnknownColumnLaterInTheInsertList,
+  UnknownTargetLaterInTheSetList,
+  UnknownInsertColumnWithReturning,
+  ValidInsertColumns,
+  ValidInsertWithReturning,
+  ValidUpdateTargets,
+  InsertWithoutAColumnListIsUnchecked,
+  SetValueSubqueryIsNotATarget,
+  QualifiedSetTargetResolves,
+  LooseModeIsUnchanged,
+];


### PR DESCRIPTION
Fixes #282.

## The bug

```ts
StrictRow<DB, 'insert into users (naem) values ($1)'>       // Record<string, never> - no error
StrictRow<DB, 'update users set naem = $1 where id = 1'>    // same
```

Both are guaranteed runtime errors on every engine. The documented list of unchecked clauses covers GROUP BY, HAVING and ORDER BY; column names in write statements are not on it, and no test pinned this either way.

## The fix

Nothing scanned the SET assignment targets or the INSERT column list against the schema — the DML branches used those lists only to position placeholders for params inference.

The parsed statement now carries the write column text (INSERT's list, or UPDATE's SET targets), and the row check resolves each name through the same `ResolveColumnType` that RETURNING columns go through, so the message is identical to the one every other path produces.

Shapes it cannot read are left alone rather than guessed at:

- a row assignment (`set (a, b) = (1, 2)`)
- an INSERT with no column list
- anything whose target is not a plain name

## Budget

`MAX_INSTANTIATIONS` moves **200,000 → 210,000**, raised in this commit as the script asks.

| | instantiations |
| --- | --- |
| master | 192,486 |
| naive (structural row test first) | 204,196 |
| gated on the column text first | **201,322** |

A SELECT carries an empty string here and pays only for that; the ~4.5% is the two clause scans a *write* now runs (`SplitAtTopLevelKeyword` for VALUES/SELECT, and for SET) plus the extra field on the parsed statement.

## Verification

`tests/write-column-check.test-d.ts`, twelve cases. Five red on master:

```
tests/write-column-check.test-d.ts(18,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/write-column-check.test-d.ts(25,3): ... (32,3), (39,3), (46,3)
```

- unknown INSERT column, unknown SET target, each also when it is not the first entry, and an unknown INSERT column with a RETURNING that would otherwise have typed fine

Controls: valid writes (with and without RETURNING), an INSERT with no column list, a subquery on the *value* side of a SET, a qualified SET target, and loose mode.

`tsc --noEmit` clean, 192 runtime tests pass.