### PR TITLE
fix(parse): validate the SELECT half of an INSERT ... SELECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- Strict mode validates the SELECT half of an `INSERT ... SELECT`. The INSERT branch read the target and the RETURNING clause and stopped, so `insert into users (name) select naem from ghosts where nope = 1` - an unknown table, an unknown column and a second unknown column in the WHERE - was accepted whole ([#272](https://github.com/tiagolauer/OwlSQL/issues/272)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -290,11 +290,44 @@ type ExtraSourcesAfterKeyword<S extends string, Keyword extends string> = [
     ? ParseFromClause<AfterClause>
     : [];
 
+// The SELECT half of an `INSERT ... SELECT`. The INSERT branch reads the
+// target and the RETURNING/OUTPUT clause and stops there, so the trailing
+// SELECT was never parsed as a statement: its sources, its columns and its
+// WHERE did not exist as far as validation was concerned, and
+// `insert into users (name) select naem from ghosts where nope = 1` - three
+// mistakes in one line - passed strict mode (issue #272).
+type InsertSelectText<S extends string> = [SplitAtTopLevelKeyword<S, 'select'>] extends [never]
+  ? ''
+  : SplitAtTopLevelKeyword<S, 'select'> extends { after: infer After extends string }
+    ? `select ${After}`
+    : '';
+
+// Reported as the row, the way every other strict failure is. The nested query
+// resolves through the same entry point, so its own CTEs, joins and clause
+// checks all apply.
+type ApplyNestedSelectCheck<
+  DB extends SchemaLike,
+  QueryText extends string,
+  Strict extends boolean,
+  Row,
+> = QueryText extends ''
+  ? Row
+  : Strict extends true
+    ? Row extends QueryTypeError<string>
+      ? Row
+      : InferRowWith<DB, QueryText, true> extends QueryTypeError<infer Message>
+        ? QueryTypeError<Message>
+        : Row
+    : Row;
+
 export interface ParsedStatement {
   columns: string;
   sources: Source[];
   whereText: string;
   fromText: string;
+  // Empty unless the statement is an `INSERT ... SELECT`, whose SELECT half is
+  // a statement of its own.
+  nestedSelect: string;
 }
 
 type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer Body
@@ -308,12 +341,13 @@ type ParseSelectBody<S extends string> = StatementAfterSelect<S> extends infer B
             columns: Columns;
             sources: ParseFromClause<AfterFrom>;
             whereText: ExtractSelectWhereText<RestAfterFromClause<AfterFrom>>;
+            nestedSelect: '';
             // Kept as raw text rather than pre-extracted ON conditions: the
             // JOIN ON check only runs in strict mode, and this way the scan
             // is never instantiated for a non-strict query.
             fromText: TakeFromClause<AfterFrom>;
           }
-        : { columns: Columns; sources: []; whereText: ''; fromText: '' }
+        : { columns: Columns; sources: []; whereText: ''; fromText: ''; nestedSelect: '' }
       : never
     : never
   : never;
@@ -337,6 +371,7 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
           sources: SingleSource<RestAfterKeyword<S, 'into'>>;
           whereText: '';
           fromText: '';
+          nestedSelect: InsertSelectText<S>;
         }
       : IsKeyword<Keyword, 'update'> extends true
         ? {
@@ -347,6 +382,7 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
             ];
             whereText: ExtractUpdateDeleteWhereText<S>;
             fromText: '';
+            nestedSelect: '';
           }
         : IsKeyword<Keyword, 'delete'> extends true
           ? {
@@ -357,6 +393,7 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
               ];
               whereText: ExtractUpdateDeleteWhereText<S>;
               fromText: '';
+              nestedSelect: '';
             }
           : IsKeyword<Keyword, 'merge'> extends true
             ? {
@@ -369,6 +406,7 @@ type ParseStatementNormalized<S extends string> = Trim<S> extends `(${infer Afte
                 sources: SingleSource<RestAfterKeyword<S, 'into'>>;
                 whereText: '';
                 fromText: '';
+                nestedSelect: '';
               }
             : never
   : never;
@@ -1000,13 +1038,18 @@ type InferRowWithChecked<
           sources: infer Sources extends Source[];
           whereText: infer WhereText extends string;
           fromText: infer FromText extends string;
+          nestedSelect: infer NestedSelect extends string;
         }
     ? (CteDB & BuildDerivedSourceMap<CteDB, Sources, Strict>) extends infer EffectiveDB extends SchemaLike
       ? // The clause check wraps the empty row too: a write with no RETURNING
         // projects nothing, but its WHERE clause is still a set of column
         // references strict mode has to validate - and UPDATE/DELETE is where
         // a wrong one costs the most (issue #233).
-        ApplyWhereCheck<
+        ApplyNestedSelectCheck<
+          DB,
+          NestedSelect,
+          Strict,
+          ApplyWhereCheck<
           EffectiveDB,
           Sources,
           WhereText,
@@ -1024,6 +1067,7 @@ type InferRowWithChecked<
                     : [],
                   Strict
                 >
+        >
         >
       : never
     : never

--- a/tests/insert-select-strict.test-d.ts
+++ b/tests/insert-select-strict.test-d.ts
@@ -1,0 +1,80 @@
+import type { QueryTypeError, Row, StrictRow } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  archive: { id: number; name: string; archived_at: string };
+}
+
+type EmptyRow = Record<string, never>;
+
+// The INSERT branch read the target and the RETURNING clause and stopped, so
+// the trailing SELECT was never parsed as a statement - its sources, columns
+// and WHERE did not exist as far as validation was concerned (issue #272).
+type UnknownSourceTableInTheSelectHalf = Expect<
+  Equal<
+    StrictRow<DB, 'insert into users (name) select naem from ghosts where nope = 1'>,
+    QueryTypeError<'unknown table: ghosts'>
+  >
+>;
+
+type UnknownColumnInTheSelectHalf = Expect<
+  Equal<
+    StrictRow<DB, 'insert into users (name) select naem from archive'>,
+    QueryTypeError<'unknown column: naem'>
+  >
+>;
+
+type UnknownColumnInTheSelectHalfWhere = Expect<
+  Equal<
+    StrictRow<DB, 'insert into users (name) select name from archive where nope = 1'>,
+    QueryTypeError<'unknown column: nope'>
+  >
+>;
+
+// Controls: a valid INSERT ... SELECT still projects what it always did.
+type ValidInsertSelect = Expect<
+  Equal<StrictRow<DB, 'insert into users (name) select name from archive'>, EmptyRow>
+>;
+
+type ValidInsertSelectWithWhere = Expect<
+  Equal<
+    StrictRow<DB, 'insert into users (name) select name from archive where id = 1'>,
+    EmptyRow
+  >
+>;
+
+type ValidInsertSelectWithReturning = Expect<
+  Equal<
+    StrictRow<DB, 'insert into users (id, name) select id, name from archive returning id'>,
+    { id: number }
+  >
+>;
+
+type InsertValuesIsUnaffected = Expect<
+  Equal<StrictRow<DB, 'insert into users (name) values ($1)'>, EmptyRow>
+>;
+
+type PlainSelectIsUnaffected = Expect<
+  Equal<StrictRow<DB, 'select name from archive'>, { name: string }>
+>;
+
+type LooseModeIsUnchanged = Expect<
+  Equal<Row<DB, 'insert into users (name) select naem from ghosts'>, EmptyRow>
+>;
+
+export type InsertSelectStrictLock = [
+  UnknownSourceTableInTheSelectHalf,
+  UnknownColumnInTheSelectHalf,
+  UnknownColumnInTheSelectHalfWhere,
+  ValidInsertSelect,
+  ValidInsertSelectWithWhere,
+  ValidInsertSelectWithReturning,
+  InsertValuesIsUnaffected,
+  PlainSelectIsUnaffected,
+  LooseModeIsUnchanged,
+];


### PR DESCRIPTION
Fixes #272.

## The bug

```ts
StrictRow<DB, 'insert into users (name) select naem from ghosts where nope = 1'>
// Record<string, never> - no error
```

Three mistakes ride through in one line: `ghosts` is not a table, `naem` is not a column, and `nope` is not one either. The README says strict mode checks the SELECT list and the WHERE clause; this statement has both.

## The fix

The INSERT branch extracted the target and the RETURNING/OUTPUT clause and stopped. The parsed statement now carries the SELECT half as its own query text, and strict mode resolves it through the same entry point the outer query uses — so the nested statement's CTEs, joins, column resolution and clause checks all apply for free, and an error surfaces as the row, the way every other strict failure does.

When the SELECT half is clean, the INSERT's own RETURNING columns still decide the row shape.

## Verification

`tests/insert-select-strict.test-d.ts`, nine cases. Three red on master:

```
tests/insert-select-strict.test-d.ts(19,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/insert-select-strict.test-d.ts(26,3): ... (33,3)
```

- an unknown table, an unknown column in the SELECT list, and an unknown column in the SELECT's WHERE

Controls: valid `INSERT ... SELECT` with and without a WHERE, one with `RETURNING` (still `{ id: number }`), `INSERT ... VALUES`, a plain SELECT, and loose mode.

`tsc --noEmit` clean, 192 runtime tests pass, budget 194,103 (+1,617).