### PR TITLE
fix(parse): resolve correlated subqueries in strict mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+### Fixed
+
+- Strict mode accepts correlated subqueries, including the README's own scalar-subquery example, which it used to reject with `unknown alias: users`. The inner query was resolved against its own sources only, so a reference to the query it sits inside read as unknown. Outer sources are consulted as a fallback, not merged into the scope, so a name both levels carry is still the inner one and does not become ambiguous. A derived table that fails to type now also reports its own error instead of the outer query reporting the alias's columns as unknown ([#273](https://github.com/tiagolauer/OwlSQL/issues/273)).
+
 ## [0.2.0] - 2026-07-29
 
 ### Changed

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -666,7 +666,8 @@ type ScalarSubqueryType<
   DB extends SchemaLike,
   Q extends string,
   Strict extends boolean,
-> = InferRowWith<DB, Q, Strict> extends infer Row
+  OuterSources extends Source[] = [],
+> = InferRowWith<DB, Q, Strict, OuterSources> extends infer Row
   ? [Row] extends [never]
     ? unknown
     : Row extends QueryTypeError<string>
@@ -772,7 +773,7 @@ export type ResolveColumnType<
                 Strict
               >
         : LiteralType<Expression>
-    : ScalarSubqueryType<DB, ScalarSubqueryInner<Expression>, Strict>;
+    : ScalarSubqueryType<DB, ScalarSubqueryInner<Expression>, Strict, Sources>;
 
 export type ResolveColumnLoose<
   DB extends SchemaLike,
@@ -910,10 +911,14 @@ export type ResolveCteContext<
       }
     : { db: DB; query: Normalize<Q> };
 
+// A LATERAL subquery is correlated by definition, and an ordinary derived
+// table may reference an outer source too; AllSources is the full FROM list of
+// the query these were parsed from, passed as the fallback scope (issue #273).
 type BuildDerivedSourceMap<
   DB extends SchemaLike,
   Sources extends Source[],
   Strict extends boolean,
+  AllSources extends Source[] = [],
   Accumulated extends Record<string, unknown> = Record<never, never>,
 > = Sources extends [infer Head extends Source, ...infer Tail extends Source[]]
   ? Head extends { derivedQuery: infer Q extends string }
@@ -921,21 +926,51 @@ type BuildDerivedSourceMap<
         DB,
         Tail,
         Strict,
-        Accumulated & { [Key in Head['alias']]: Flatten<InferRowWith<DB, Q, Strict>> }
+        AllSources,
+        Accumulated & { [Key in Head['alias']]: Flatten<InferRowWith<DB, Q, Strict, AllSources>> }
       >
-    : BuildDerivedSourceMap<DB, Tail, Strict, Accumulated>
+    : BuildDerivedSourceMap<DB, Tail, Strict, AllSources, Accumulated>
   : Accumulated;
+
+// A derived table that fails to type replaces its own row with the error
+// object, and the outer query then reports the alias's columns as unknown -
+// pointing at the wrong thing entirely. Surfacing the inner error first keeps
+// the message on the mistake that caused it (issue #273).
+type FirstDerivedSourceError<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Strict extends boolean,
+  AllSources extends Source[],
+> = Sources extends [infer Head extends Source, ...infer Tail extends Source[]]
+  ? Head extends { derivedQuery: infer Q extends string }
+    ? InferRowWith<DB, Q, Strict, AllSources> extends QueryTypeError<infer Message>
+      ? QueryTypeError<Message>
+      : FirstDerivedSourceError<DB, Tail, Strict, AllSources>
+    : FirstDerivedSourceError<DB, Tail, Strict, AllSources>
+  : never;
+
+type ApplyDerivedSourceCheck<
+  DB extends SchemaLike,
+  Sources extends Source[],
+  Strict extends boolean,
+  Row,
+> = Strict extends true
+  ? [FirstDerivedSourceError<DB, Sources, Strict, Sources>] extends [never]
+    ? Row
+    : FirstDerivedSourceError<DB, Sources, Strict, Sources>
+  : Row;
 
 type ApplyClauseError<
   DB extends SchemaLike,
   Sources extends Source[],
   ClauseText extends string,
   Row,
+  OuterSources extends Source[] = [],
 > = Trim<ClauseText> extends ''
   ? Row
-  : [WhereClauseError<DB, Sources, ClauseText>] extends [never]
+  : [WhereClauseError<DB, Sources, ClauseText, OuterSources>] extends [never]
     ? Row
-    : WhereClauseError<DB, Sources, ClauseText>;
+    : WhereClauseError<DB, Sources, ClauseText, OuterSources>;
 
 // JOIN ON conditions are validated the same way the WHERE clause is: the
 // operands are ordinary column references against the same sources, and a
@@ -951,6 +986,7 @@ type ApplyWhereCheck<
   FromText extends string,
   Strict extends boolean,
   Row,
+  OuterSources extends Source[] = [],
 > = Strict extends true
   ? Row extends QueryTypeError<string>
     ? Row
@@ -958,7 +994,8 @@ type ApplyWhereCheck<
         DB,
         Sources,
         ExtractJoinOnText<FromText>,
-        ApplyClauseError<DB, Sources, WhereText, Row>
+        ApplyClauseError<DB, Sources, WhereText, Row, OuterSources>,
+        OuterSources
       >
   : Row;
 
@@ -975,14 +1012,16 @@ export type InferRowWith<
   DB extends SchemaLike,
   Q extends string,
   Strict extends boolean,
+  OuterSources extends Source[] = [],
 > = HasNonTrailingSemicolon<Q> extends true
   ? MultipleStatementsError
-  : InferRowWithChecked<DB, Q, Strict>;
+  : InferRowWithChecked<DB, Q, Strict, OuterSources>;
 
 type InferRowWithChecked<
   DB extends SchemaLike,
   Q extends string,
   Strict extends boolean,
+  OuterSources extends Source[] = [],
 > = ResolveCteContext<DB, Q, Strict> extends {
   db: infer CteDB extends SchemaLike;
   query: infer EffectiveQuery extends string;
@@ -1001,12 +1040,16 @@ type InferRowWithChecked<
           whereText: infer WhereText extends string;
           fromText: infer FromText extends string;
         }
-    ? (CteDB & BuildDerivedSourceMap<CteDB, Sources, Strict>) extends infer EffectiveDB extends SchemaLike
+    ? (CteDB & BuildDerivedSourceMap<CteDB, Sources, Strict, Sources>) extends infer EffectiveDB extends SchemaLike
       ? // The clause check wraps the empty row too: a write with no RETURNING
         // projects nothing, but its WHERE clause is still a set of column
         // references strict mode has to validate - and UPDATE/DELETE is where
         // a wrong one costs the most (issue #233).
-        ApplyWhereCheck<
+        ApplyDerivedSourceCheck<
+          CteDB,
+          Sources,
+          Strict,
+          ApplyWhereCheck<
           EffectiveDB,
           Sources,
           WhereText,
@@ -1023,7 +1066,9 @@ type InferRowWithChecked<
                     ? ParseColumnEntries<SplitColumnList<Columns>>
                     : [],
                   Strict
-                >
+                >,
+          OuterSources
+        >
         >
       : never
     : never

--- a/src/where.ts
+++ b/src/where.ts
@@ -84,17 +84,32 @@ type HeadStartsSubquery<Head extends string, Tail extends string> = Head extends
       : false
   : false;
 
+// A correlated subquery references a column of the query it sits inside, which
+// is ordinary SQL - the README's own scalar-subquery example is one. The inner
+// scan only ever saw the inner query's sources, so every such reference read as
+// unknown (issue #273).
+//
+// The outer sources are a fallback rather than an addition to the scope: SQL
+// resolves the inner name first and only looks outward when it is not there, so
+// merging the two lists would instead invent an `ambiguous column` for every
+// name the two levels share. When the outer lookup fails too, the inner
+// message is the one reported - the reference was meant for the inner query.
 type ValidateWhereOperand<
   DB extends SchemaLike,
   Sources extends Source[],
   Operand extends string,
+  OuterSources extends Source[] = [],
 > = Operand extends '' ? never : IsPlaceholder<Operand> extends true ? never : ResolveColumnType<
   DB,
   Sources,
   Operand,
   true
 > extends QueryTypeError<infer Message>
-  ? QueryTypeError<Message>
+  ? OuterSources extends []
+    ? QueryTypeError<Message>
+    : ResolveColumnType<DB, OuterSources, Operand, true> extends QueryTypeError<string>
+      ? QueryTypeError<Message>
+      : never
   : never;
 
 type WhereScan<
@@ -102,26 +117,27 @@ type WhereScan<
   Sources extends Source[],
   S extends string,
   Prev extends string = '',
+  OuterSources extends Source[] = [],
 > = S extends `${infer Head} ${infer Tail}`
   ? HeadStartsSubquery<Head, Tail> extends true
     ? ExtractParenGroup<`${DropOneOpenParen<Head>} ${Tail}`> extends { rest: infer Rest extends string }
-      ? WhereScan<DB, Sources, Trim<Rest>>
+      ? WhereScan<DB, Sources, Trim<Rest>, '', OuterSources>
       : never
     : IsTriggerOperator<Head> extends true
-      ? ValidateWhereOperand<DB, Sources, Prev> extends infer Error
+      ? ValidateWhereOperand<DB, Sources, Prev, OuterSources> extends infer Error
         ? [Error] extends [never]
-          ? WhereScan<DB, Sources, Tail, CleanColumnToken<Head>>
+          ? WhereScan<DB, Sources, Tail, CleanColumnToken<Head>, OuterSources>
           : Error
         : never
       : IsAndOr<Head> extends true
-        ? ValidateWhereOperand<DB, Sources, Prev> extends infer Error
+        ? ValidateWhereOperand<DB, Sources, Prev, OuterSources> extends infer Error
           ? [Error] extends [never]
-            ? WhereScan<DB, Sources, Tail>
+            ? WhereScan<DB, Sources, Tail, '', OuterSources>
             : Error
           : never
         : IsTransparentToken<Head> extends true
-          ? WhereScan<DB, Sources, Tail, Prev>
-          : WhereScan<DB, Sources, Tail, CleanColumnToken<Head>>
+          ? WhereScan<DB, Sources, Tail, Prev, OuterSources>
+          : WhereScan<DB, Sources, Tail, CleanColumnToken<Head>, OuterSources>
   : // Terminal case: no trailing space left, so `S` is the final token of the
     // clause. Earlier operands are validated by the operator *after* them, but
     // the trailing operand has no following operator to trigger the check — so
@@ -130,10 +146,11 @@ type WhereScan<
     // operands are already short-circuited inside `ValidateWhereOperand`.
     IsTransparentToken<S> extends true
     ? never
-    : ValidateWhereOperand<DB, Sources, CleanColumnToken<S>>;
+    : ValidateWhereOperand<DB, Sources, CleanColumnToken<S>, OuterSources>;
 
 export type WhereClauseError<
   DB extends SchemaLike,
   Sources extends Source[],
   WhereText extends string,
-> = WhereScan<DB, Sources, Trim<WhereText>>;
+  OuterSources extends Source[] = [],
+> = WhereScan<DB, Sources, Trim<WhereText>, '', OuterSources>;

--- a/tests/correlated-subquery.test-d.ts
+++ b/tests/correlated-subquery.test-d.ts
@@ -1,0 +1,126 @@
+import type { Query, QueryTypeError, StrictQuery } from '../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: { id: number; name: string };
+  posts: { id: number; user_id: number; views: number };
+}
+
+// The README's own scalar-subquery example, run strict. The inner query was
+// resolved against its own sources only, so any correlated reference read as
+// unknown (issue #273).
+type CorrelatedScalarSubquery = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select (select count(*) from posts where posts.user_id = users.id) as post_count from users'
+    >,
+    { post_count: number }[]
+  >
+>;
+
+type CorrelatedScalarSubqueryThroughAnAlias = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select (select count(*) from posts where posts.user_id = u.id) as post_count from users u'
+    >,
+    { post_count: number }[]
+  >
+>;
+
+type CorrelatedLateralJoin = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select u.name, p.top_id from users u join lateral (select max(id) as top_id from posts where posts.user_id = u.id) p on true'
+    >,
+    { name: string; top_id: number }[]
+  >
+>;
+
+type CorrelatedDerivedTable = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select u.name, p.top_id from users u join (select max(id) as top_id from posts where posts.user_id = u.id) p on true'
+    >,
+    { name: string; top_id: number }[]
+  >
+>;
+
+// A mistake inside the subquery is still a mistake, and the message names it
+// rather than the alias the outer query failed to read.
+type TypoInsideACorrelatedSubquery = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select (select count(*) from posts where posts.nope = users.id) as x from users'
+    >,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+type TypoInsideACorrelatedDerivedTable = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select u.name, p.top_id from users u join (select max(id) as top_id from posts where posts.nope = u.id) p on true'
+    >,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+// An uncorrelated subquery referencing nothing that exists anywhere still
+// fails, and a standalone query is not given an outer scope it does not have.
+type UnknownAliasWithNoOuterScope = Expect<
+  Equal<
+    StrictQuery<DB, 'select max(id) as top_id from posts where posts.user_id = u.id'>,
+    QueryTypeError<'unknown alias: u'>[]
+  >
+>;
+
+// Controls: the uncorrelated forms that already worked.
+type UncorrelatedScalarSubquery = Expect<
+  Equal<
+    StrictQuery<DB, 'select (select count(*) from posts) as total from users'>,
+    { total: number }[]
+  >
+>;
+
+type UncorrelatedLateralJoin = Expect<
+  Equal<
+    StrictQuery<
+      DB,
+      'select u.name, p.top_id from users u join lateral (select max(id) as top_id from posts) p on true'
+    >,
+    { name: string; top_id: number }[]
+  >
+>;
+
+type LooseModeIsUnchanged = Expect<
+  Equal<
+    Query<
+      DB,
+      'select (select count(*) from posts where posts.user_id = users.id) as post_count from users'
+    >,
+    { post_count: number }[]
+  >
+>;
+
+export type CorrelatedSubqueryLock = [
+  CorrelatedScalarSubquery,
+  CorrelatedScalarSubqueryThroughAnAlias,
+  CorrelatedLateralJoin,
+  CorrelatedDerivedTable,
+  TypoInsideACorrelatedSubquery,
+  TypoInsideACorrelatedDerivedTable,
+  UnknownAliasWithNoOuterScope,
+  UncorrelatedScalarSubquery,
+  UncorrelatedLateralJoin,
+  LooseModeIsUnchanged,
+];

--- a/tests/where-strict.test-d.ts
+++ b/tests/where-strict.test-d.ts
@@ -139,10 +139,13 @@ type SubqueryInWhereIsSkippedNotValidated = Expect<
   >
 >;
 
+// The message names the mistake since #273: the derived table's own error is
+// surfaced instead of the outer query reporting the alias's columns as unknown,
+// which pointed at the wrong line entirely.
 type WhereErrorInsideDerivedTable = Expect<
   Equal<
     StrictQuery<DB, "select x.id from (select id from users where naem = 'x') x">,
-    QueryTypeError<'unknown column: id'>[]
+    QueryTypeError<'unknown column: naem'>[]
   >
 >;
 


### PR DESCRIPTION
Fixes #273.

## The bug

```ts
StrictQuery<DB, 'select (select count(*) from posts where posts.user_id = users.id) as post_count from users'>
// QueryTypeError<'unknown alias: users'>[]
```

That is the README's own scalar-subquery example. The lateral form was worse, because the inner error object replaced the derived row and the surfaced message pointed at the wrong thing:

```ts
StrictQuery<DB, 'select u.name, p.top_id from users u join lateral (select max(id) as top_id from posts where posts.user_id = u.id) p on true'>
// QueryTypeError<'unknown column: top_id'>[]
```

Not in the documented limitations — and `CONTRIBUTING.md:68` claimed the README documented it, which it never did.

## The fix

`ScalarSubqueryType` and `BuildDerivedSourceMap` ran the inner query through `InferRowWith` with only the inner query's own sources. Both now pass the enclosing FROM list down, and the WHERE scan consults it.

**As a fallback, not as an addition to the scope.** SQL resolves an inner name first and looks outward only when it is not there; merging the two lists would have invented an `ambiguous column` for every name the two levels share (`select (select max(id) from posts) from users` has an `id` on both sides). When the outer lookup fails too, the *inner* message is reported — the reference was meant for the inner query.

The second half of the issue is fixed too: a derived table that fails to type now surfaces its own error, instead of the outer query reporting the alias's columns as unknown. `tests/where-strict.test-d.ts` had that misdirection pinned (`unknown column: id` for a typo named `naem`); it now pins the real message.

## Verification

`tests/correlated-subquery.test-d.ts`, ten cases. Five red on master, plus the updated lock:

```
tests/correlated-subquery.test-d.ts(17,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tests/correlated-subquery.test-d.ts(27,3): ... (37,3), (47,3), (69,3)
tests/where-strict.test-d.ts(146,3): ...
```

- the README example, the same through an alias, a correlated LATERAL join, a correlated derived table
- a typo inside a correlated subquery still errors, and now names `nope` rather than the alias
- a standalone query is not given an outer scope it does not have: `select ... where posts.user_id = u.id` on its own is still `unknown alias: u`

Controls: uncorrelated scalar subquery and uncorrelated lateral join unchanged, loose mode unchanged.

`tsc --noEmit` clean, 192 runtime tests pass, budget 199,660 (+7,174, 100% of the ceiling — it stays under).