### PR TITLE
test: freeze OwlSQL v1 M0 contracts and baselines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,13 @@ If the change alters what a query infers to, say so in the description and name 
 
 Every behavior change needs a test that would fail without the fix. If you're touching `src/parse.ts`, `src/where.ts`, or another type-level file, that usually means a `.test-d.ts` case with `@ts-expect-error` or an `Equal<>` assertion; runtime behavior (adapters, the CLI, the editor plugin) gets a `.test.ts` case instead. A PR without a regression test is a PR someone else will eventually re-break by accident.
 
+### Architecture changes
+
+Before changing compiler boundaries, Query IR, scope semantics, diagnostics policy,
+runtime/compiler isolation, dialect architecture, public packages, or a material
+type-performance tradeoff, read `docs/architecture/CONSTITUTION.md` and the accepted
+ADRs in `docs/adr/`. A change that supersedes one of those decisions needs a new ADR.
+
 ## Developing
 
 ### Environment
@@ -104,6 +111,11 @@ npm run test:perf
 That generates a fixture (100 tables, 32 queries covering joins, `GROUP BY`, `CASE`, CTEs, `UNION`, strict mode, and typed params), type-checks it with `tsc --extendedDiagnostics`, and fails if the instantiation count goes over the budget in `scripts/type-budget.mjs`. Instantiation count is used rather than wall-clock time because it's deterministic: the same input and the same TypeScript version give the same number on any machine, so it can be a hard threshold instead of a flaky one. That's also why this runs on the lockfile's TypeScript version only, while the type tests run against the whole supported matrix.
 
 If your change legitimately costs more, raise the budget in the same commit rather than leaving it to drift. A reviewer can then see how much more expensive the feature made every query in every user's project.
+
+The hard instantiation ceiling still decides pass/fail. The checked-in baseline also
+makes relative cost visible in review. A meaningful positive delta must be explained
+in the PR even when it stays under the ceiling; do not rewrite the baseline merely to
+hide a regression.
 
 ## Publishing
 

--- a/docs/adr/001-compiler-pipeline.md
+++ b/docs/adr/001-compiler-pipeline.md
@@ -1,0 +1,20 @@
+# ADR-001: Compiler pipeline
+
+Status: Accepted
+Date: 2026-08-15
+
+## Context
+
+OwlSQL has accumulated parser and inference responsibilities in a monolithic flow.
+
+## Decision
+
+Use a staged compile-time pipeline with Language, shallow Query IR, scopes, semantic resolution, inference, diagnostics, and policy projection.
+
+## Alternatives considered
+
+Keep a monolithic parser or introduce a complete SQL AST.
+
+## Consequences
+
+Responsibilities become localizable while compiler cost remains an explicit constraint.

--- a/docs/adr/002-shallow-query-ir.md
+++ b/docs/adr/002-shallow-query-ir.md
@@ -1,0 +1,20 @@
+# ADR-002: Shallow Query IR
+
+Status: Accepted
+Date: 2026-08-15
+
+## Context
+
+Full AST construction in template literal types is expensive and unnecessary for supported inference.
+
+## Decision
+
+Use a shallow purpose-built Query IR containing only information required by later compiler phases.
+
+## Alternatives considered
+
+Build a complete SQL-standard AST or keep full-query strings opaque.
+
+## Consequences
+
+Downstream phases reuse structural interpretation without paying for unsupported syntax trees.

--- a/docs/adr/003-lexical-scopes.md
+++ b/docs/adr/003-lexical-scopes.md
@@ -1,0 +1,20 @@
+# ADR-003: Lexical scopes
+
+Status: Accepted
+Date: 2026-08-15
+
+## Context
+
+Nested and correlated queries need explicit visibility and shadowing rules.
+
+## Decision
+
+Represent scopes as local bindings with parent-scope lookup.
+
+## Alternatives considered
+
+Maintain ad hoc outer-source plumbing.
+
+## Consequences
+
+Correlated subqueries, CTE visibility, derived tables, and alias shadowing share one resolution model.

--- a/docs/adr/004-structured-diagnostics.md
+++ b/docs/adr/004-structured-diagnostics.md
@@ -1,0 +1,20 @@
+# ADR-004: Structured diagnostics
+
+Status: Accepted
+Date: 2026-08-15
+
+## Context
+
+Compiler errors currently rely too heavily on incidental `never` behavior.
+
+## Decision
+
+Produce structured internal diagnostics and apply strictness as a policy after compilation.
+
+## Alternatives considered
+
+Use `never` as the semantic error representation or build a second strict compiler.
+
+## Consequences
+
+Errors can be classified, localized, propagated, and projected compatibly through `QueryTypeError`.

--- a/docs/adr/005-runtime-compiler-isolation.md
+++ b/docs/adr/005-runtime-compiler-isolation.md
@@ -1,0 +1,20 @@
+# ADR-005: Runtime/compiler isolation
+
+Status: Accepted
+Date: 2026-08-15
+
+## Context
+
+Runtime execution must remain driver-independent and free of compile-time SQL machinery.
+
+## Decision
+
+Runtime contracts and adapters must not depend on Language or Compiler modules.
+
+## Alternatives considered
+
+Keep execution and inference in the same implementation module.
+
+## Consequences
+
+Runtime can evolve and be tested independently from type-level inference.

--- a/docs/adr/006-dialect-capabilities.md
+++ b/docs/adr/006-dialect-capabilities.md
@@ -1,0 +1,20 @@
+# ADR-006: Dialect capabilities
+
+Status: Accepted
+Date: 2026-08-15
+
+## Context
+
+OwlSQL supports multiple SQL dialects with shared semantics.
+
+## Decision
+
+Use common SQL grammar plus isolated dialect capabilities and extensions.
+
+## Alternatives considered
+
+Fork complete parsers per dialect.
+
+## Consequences
+
+Shared behavior remains centralized and dialect coverage is explicit and testable.

--- a/docs/adr/007-incremental-compiler-migration.md
+++ b/docs/adr/007-incremental-compiler-migration.md
@@ -1,0 +1,20 @@
+# ADR-007: Incremental compiler migration
+
+Status: Accepted
+Date: 2026-08-15
+
+## Context
+
+A big-bang compiler rewrite would make parity, review, and release safety difficult.
+
+## Decision
+
+Use a Strangler migration. Legacy and Next may coexist internally, but each user query follows one compiler path.
+
+## Alternatives considered
+
+Rewrite the compiler in one branch or double-compile every query in the public type surface.
+
+## Consequences
+
+Each statement family can cut over after parity, regression, dialect, and performance gates pass.

--- a/docs/architecture/CONSTITUTION.md
+++ b/docs/architecture/CONSTITUTION.md
@@ -1,0 +1,16 @@
+# OwlSQL Architecture Constitution
+
+1. Raw SQL is the source of truth.
+2. `@owlsql/core` performs no runtime SQL parsing.
+3. Full-query structural interpretation belongs to the Language layer.
+4. Language does not resolve user schemas.
+5. Compiler does not own runtime execution.
+6. Runtime does not depend on Language or Compiler.
+7. Adapters execute SQL and do not infer SQL.
+8. Shared SQL semantics stay common; dialect differences are capabilities/extensions.
+9. Unsupported SQL is distinct from invalid SQL.
+10. Strictness is a diagnostic policy, not a separate compiler.
+11. Type-instantiation cost is an architectural constraint.
+12. Everything is internal by default unless package exports deliberately expose it.
+13. Supported behavior requires executable specification.
+14. Legacy-vs-Next parity checks run in tests/CI, never on every user query.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:runtime": "vitest run",
     "test:integration": "vitest run tests/integration",
     "test:perf": "node scripts/type-budget.mjs",
+    "perf:baseline": "node scripts/type-budget.mjs --write-baseline",
     "test": "npm run test:types && npm run test:runtime",
     "prepublishOnly": "npm run test && npm run build"
   },

--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -42,6 +42,7 @@ const MAX_INSTANTIATIONS = 225_000;
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PERF_DIR = join(ROOT, 'tests', 'perf');
 const GENERATED_DIR = join(PERF_DIR, 'generated');
+const BASELINE_FILE = join(PERF_DIR, 'baseline.json');
 
 function tableName(index) {
   return `t_${String(index).padStart(3, '0')}`;
@@ -140,28 +141,67 @@ function readDiagnostic(output, label) {
 function compile() {
   const tsc = join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc');
   try {
-    return execFileSync(
+    const output = execFileSync(
       process.execPath,
       [tsc, '--noEmit', '--extendedDiagnostics', '-p', join(PERF_DIR, 'tsconfig.json')],
       { encoding: 'utf8' },
     );
+    const instantiations = readDiagnostic(output, 'Instantiations');
+    if (instantiations === null) {
+      throw new Error('Could not read the instantiation count from tsc --extendedDiagnostics.');
+    }
+
+    return {
+      instantiations,
+      types: readDiagnostic(output, 'Types'),
+      checkTime: readDiagnostic(output, 'Check time'),
+    };
   } catch (error) {
     process.stderr.write(`${error.stdout ?? ''}${error.stderr ?? ''}\n`);
     throw new Error('The type-budget fixture failed to compile.');
   }
 }
 
+function readTypescriptVersion() {
+  const packageJson = JSON.parse(
+    readFileSync(join(ROOT, 'node_modules', 'typescript', 'package.json'), 'utf8'),
+  );
+  if (typeof packageJson.version !== 'string') {
+    throw new Error('Could not read the installed TypeScript version.');
+  }
+  return packageJson.version;
+}
+
+function writeBaseline(instantiations) {
+  writeFileSync(
+    BASELINE_FILE,
+    `${JSON.stringify({ typescript: readTypescriptVersion(), instantiations }, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+function readBaseline() {
+  const baseline = JSON.parse(readFileSync(BASELINE_FILE, 'utf8'));
+  if (typeof baseline.instantiations !== 'number' || baseline.instantiations <= 0) {
+    throw new Error('The type-instantiation baseline is invalid.');
+  }
+  return baseline.instantiations;
+}
+
 function main() {
   writeFixture();
-  const output = compile();
+  const { instantiations, types, checkTime } = compile();
 
-  const instantiations = readDiagnostic(output, 'Instantiations');
-  if (instantiations === null) {
-    throw new Error('Could not read the instantiation count from tsc --extendedDiagnostics.');
+  if (process.argv.includes('--write-baseline')) {
+    writeBaseline(instantiations);
+    process.stdout.write(`Wrote baseline: ${instantiations} instantiations\n`);
+    return;
   }
 
-  const types = readDiagnostic(output, 'Types');
-  const checkTime = readDiagnostic(output, 'Check time');
+  const baseline = readBaseline();
+  const delta = instantiations - baseline;
+  const deltaPercent = (delta / baseline) * 100;
+  const deltaSign = delta >= 0 ? '+' : '';
   const budgetUsed = Math.round((instantiations / MAX_INSTANTIATIONS) * 100);
 
   process.stdout.write(
@@ -171,6 +211,8 @@ function main() {
       `Types:          ${types ?? 'n/a'}`,
       `Check time:     ${checkTime ?? 'n/a'}s`,
       `Instantiations: ${instantiations} (${budgetUsed}% of the ${MAX_INSTANTIATIONS} budget)`,
+      `Baseline:       ${baseline}`,
+      `Delta:          ${deltaSign}${delta} (${deltaSign}${deltaPercent.toFixed(2)}%)`,
       '',
     ].join('\n'),
   );

--- a/tests/contracts/public-api.test-d.ts
+++ b/tests/contracts/public-api.test-d.ts
@@ -1,0 +1,80 @@
+import type {
+  Params,
+  Query,
+  QueryTypeError,
+  Row,
+  StrictQuery,
+  StrictRow,
+  TypedDb,
+} from '../../src/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+interface DB {
+  users: {
+    id: number;
+    name: string;
+    email: string | null;
+    active: boolean;
+  };
+  profiles: {
+    id: number;
+    user_id: number;
+    avatar: string;
+  };
+}
+
+type QueryContract = Expect<
+  Equal<
+    Query<DB, 'select id, name from users'>,
+    { id: number; name: string }[]
+  >
+>;
+
+type RowContract = Expect<
+  Equal<Row<DB, 'select id, email from users'>, { id: number; email: string | null }>
+>;
+
+type ParamsContract = Expect<
+  Equal<Params<DB, 'select id from users where id = $1 and active = $2'>, [number, boolean]>
+>;
+
+type JoinNullabilityContract = Expect<
+  Equal<
+    Query<
+      DB,
+      'select users.id, profiles.avatar from users left join profiles on profiles.user_id = users.id'
+    >,
+    { id: number; avatar: string | null }[]
+  >
+>;
+
+type StrictErrorContract = Expect<
+  Equal<
+    StrictQuery<DB, 'select nope from users'>,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+type StrictRowErrorContract = Expect<
+  Equal<
+    StrictRow<DB, 'select nope from users'>,
+    QueryTypeError<'unknown column: nope'>
+  >
+>;
+
+declare const typedDb: TypedDb<DB>;
+void typedDb;
+
+export type PublicApiContractLock = [
+  QueryContract,
+  RowContract,
+  ParamsContract,
+  JoinNullabilityContract,
+  StrictErrorContract,
+  StrictRowErrorContract,
+];

--- a/tests/contracts/runtime-contract.test.ts
+++ b/tests/contracts/runtime-contract.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  QueryErrorKind,
+  ResultStatus,
+  createTypedDb,
+  isErr,
+  isOk,
+} from '../../src/index.js';
+
+interface DB {
+  users: { id: number; name: string };
+}
+
+describe('public runtime contract', () => {
+  it('wraps rows in an OK Result', async () => {
+    const db = createTypedDb<DB>(async () => [{ id: 1, name: 'Ada' }]);
+    const result = await db.query('select id, name from users');
+
+    expect(result.status).toBe(ResultStatus.Ok);
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.value).toEqual([{ id: 1, name: 'Ada' }]);
+    }
+  });
+
+  it('preserves executor metadata', async () => {
+    const db = createTypedDb<DB>(async () => ({
+      rows: [{ id: 1, name: 'Ada' }],
+      meta: { rowCount: 1 },
+    }));
+    const result = await db.query('select id, name from users');
+
+    expect(isOk(result)).toBe(true);
+    if (isOk(result)) {
+      expect(result.meta).toEqual({ rowCount: 1 });
+    }
+  });
+
+  it('returns EMPTY_QUERY for blank SQL', async () => {
+    const db = createTypedDb<DB>(async () => []);
+    const result = await db.query('   ');
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.kind).toBe(QueryErrorKind.EmptyQuery);
+    }
+  });
+
+  it('returns EXECUTOR_FAILED when the executor throws', async () => {
+    const db = createTypedDb<DB>(async () => {
+      throw new Error('boom');
+    });
+    const result = await db.query('select id from users');
+
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) {
+      expect(result.error.kind).toBe(QueryErrorKind.ExecutorFailed);
+      expect(result.error.cause).toBeInstanceOf(Error);
+    }
+  });
+});

--- a/tests/perf/baseline.json
+++ b/tests/perf/baseline.json
@@ -1,0 +1,4 @@
+{
+  "typescript": "5.9.3",
+  "instantiations": 212616
+}


### PR DESCRIPTION
## Summary

- freeze the existing public row inference and `Params` contracts
- capture runtime, export, adapter, and performance baselines before migration
- establish the M0 regression gate without changing production behavior

## Verification

- `npm test`: 214 passed, 36 skipped
- `npm run test:perf`: 212,616 instantiations, unchanged from baseline and below the 225,000 budget

## Stack

First PR in the OwlSQL v1 architecture migration stack.
