### PR TITLE
feat: add OwlSQL v1 M2 Next compiler foundation

### DIFF
--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -6,6 +6,17 @@ const SOURCE_EXTENSIONS = ['.ts', '.cts', '.mts'];
 
 const RULES = [
   {
+    from: 'src/language/',
+    forbidden: [
+      'src/compiler/',
+      'src/runtime/',
+      'src/public/',
+      'src/parse.ts',
+      'src/params.ts',
+    ],
+    name: 'language isolation',
+  },
+  {
     from: 'src/runtime/',
     forbidden: [
       'src/compiler/',
@@ -25,6 +36,11 @@ const RULES = [
     forbidden: ['src/runtime/'],
     allow: ['src/compiler/legacy.ts'],
     name: 'compiler isolation',
+  },
+  {
+    from: 'src/compiler/next/',
+    forbidden: ['src/compiler/legacy.ts'],
+    name: 'next compiler isolation',
   },
 ];
 

--- a/src/compiler/contracts/compilation.ts
+++ b/src/compiler/contracts/compilation.ts
@@ -1,0 +1,63 @@
+import type { QueryTypeError } from './public-error.js';
+import type { Diagnostic } from './diagnostic.js';
+
+export interface CompileOk<
+  Value,
+  Diagnostics extends readonly Diagnostic[] = [],
+> {
+  kind: 'ok';
+  value: Value;
+  diagnostics: Diagnostics;
+}
+
+export interface CompileFatal<
+  Value,
+  Diagnostics extends readonly Diagnostic[],
+> {
+  kind: 'fatal';
+  readonly __value?: Value;
+  diagnostics: Diagnostics;
+}
+
+export type Compilation<
+  Value,
+  Diagnostics extends readonly Diagnostic[] = readonly Diagnostic[],
+> = CompileOk<Value, Diagnostics> | CompileFatal<Value, Diagnostics>;
+
+type FirstError<
+  Diagnostics extends readonly Diagnostic[],
+> = Diagnostics extends readonly [
+  infer Head extends Diagnostic,
+  ...infer Tail extends Diagnostic[],
+]
+  ? Head['severity'] extends 'error' | 'fatal'
+    ? Head
+    : FirstError<Tail>
+  : never;
+
+type ProjectError<Value, Error extends Diagnostic> =
+  Value extends readonly unknown[]
+    ? QueryTypeError<Error['message']>[]
+    : QueryTypeError<Error['message']>;
+
+export type ApplyLoosePolicy<CompilationResult> =
+  CompilationResult extends CompileOk<infer Value, readonly Diagnostic[]>
+    ? Value
+    : CompilationResult extends CompileFatal<infer Value, infer Diagnostics>
+      ? FirstError<Diagnostics> extends infer Error extends Diagnostic
+        ? ProjectError<Value, Error>
+        : never
+      : never;
+
+export type ApplyStrictPolicy<CompilationResult> =
+  CompilationResult extends CompileOk<infer Value, infer Diagnostics>
+    ? [FirstError<Diagnostics>] extends [never]
+      ? Value
+      : FirstError<Diagnostics> extends infer Error extends Diagnostic
+        ? ProjectError<Value, Error>
+        : never
+    : CompilationResult extends CompileFatal<infer Value, infer Diagnostics>
+      ? FirstError<Diagnostics> extends infer Error extends Diagnostic
+        ? ProjectError<Value, Error>
+        : never
+      : never;

--- a/src/compiler/contracts/diagnostic.ts
+++ b/src/compiler/contracts/diagnostic.ts
@@ -1,0 +1,42 @@
+export type QueryDiagnosticCode =
+  | 'UNKNOWN_TABLE'
+  | 'UNKNOWN_COLUMN'
+  | 'UNKNOWN_ALIAS'
+  | 'AMBIGUOUS_COLUMN'
+  | 'PARAM_TYPE_CONFLICT'
+  | 'PARAM_STYLE_MISMATCH'
+  | 'UNSUPPORTED_STATEMENT'
+  | 'MALFORMED_QUERY'
+  | 'MULTIPLE_STATEMENTS'
+  | 'INVALID_WRITE_TARGET'
+  | 'INVALID_SCALAR_SUBQUERY'
+  | 'UNSUPPORTED_DIALECT_FEATURE'
+  | 'UNSUPPORTED_EXPRESSION';
+
+export type DiagnosticSeverity = 'warning' | 'error' | 'fatal';
+
+export type DiagnosticLocation =
+  | 'statement'
+  | 'select'
+  | 'from'
+  | 'join-on'
+  | 'where'
+  | 'having'
+  | 'returning'
+  | 'output'
+  | 'parameter'
+  | 'cte';
+
+export interface Diagnostic<
+  Code extends QueryDiagnosticCode = QueryDiagnosticCode,
+  Message extends string = string,
+  Severity extends DiagnosticSeverity = DiagnosticSeverity,
+  Location extends DiagnosticLocation = DiagnosticLocation,
+  Reference extends string = string,
+> {
+  code: Code;
+  message: Message;
+  severity: Severity;
+  location: Location;
+  reference: Reference;
+}

--- a/src/compiler/contracts/public-error.ts
+++ b/src/compiler/contracts/public-error.ts
@@ -1,0 +1,3 @@
+export type QueryTypeError<Message extends string> = {
+  readonly __sqlTypeError: Message;
+};

--- a/src/compiler/next/compile-select.ts
+++ b/src/compiler/next/compile-select.ts
@@ -1,0 +1,37 @@
+import type { ProjectionIR, SelectQueryIR } from '../../language/ir/query.js';
+import type { SourceIR } from '../../language/ir/source.js';
+import type { ParseSelectIR } from '../../language/select/parse-select.js';
+import type {
+  CompileFatal,
+  CompileOk,
+} from '../contracts/compilation.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { InferProjections } from './infer-projection.js';
+import type { RootScope } from './scope.js';
+
+type CompileIR<
+  DB,
+  IR extends SelectQueryIR,
+> = IR extends SelectQueryIR<
+  infer Sources extends readonly SourceIR[],
+  infer Projections extends readonly ProjectionIR[],
+  readonly [],
+  readonly [],
+  readonly []
+>
+  ? InferProjections<DB, RootScope<Sources>, Projections> extends {
+      row: infer Row;
+      diagnostics: infer Diagnostics extends readonly Diagnostic[];
+    }
+    ? CompileOk<Row[], Diagnostics>
+    : never
+  : never;
+
+export type CompileSelect<DB, Sql extends string> =
+  ParseSelectIR<Sql> extends infer Parsed
+    ? Parsed extends { kind: 'ok'; value: infer IR extends SelectQueryIR }
+      ? CompileIR<DB, IR>
+      : Parsed extends CompileFatal<SelectQueryIR, infer Diagnostics>
+        ? CompileFatal<unknown[], Diagnostics>
+        : never
+    : never;

--- a/src/compiler/next/index.ts
+++ b/src/compiler/next/index.ts
@@ -1,0 +1,27 @@
+import type { StatementKind } from '../../language/lexical/statement.js';
+import type {
+  ApplyLoosePolicy,
+  ApplyStrictPolicy,
+  CompileFatal,
+} from '../contracts/compilation.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { CompileSelect } from './compile-select.js';
+
+type UnsupportedStatement<Sql extends string> = Diagnostic<
+  'UNSUPPORTED_STATEMENT',
+  'unsupported statement',
+  'fatal',
+  'statement',
+  Sql
+>;
+
+export type CompileNext<DB, Sql extends string> =
+  StatementKind<Sql> extends 'select'
+    ? CompileSelect<DB, Sql>
+    : CompileFatal<unknown[], [UnsupportedStatement<Sql>]>;
+
+export type NextQuery<DB, Sql extends string> =
+  ApplyLoosePolicy<CompileNext<DB, Sql>>;
+
+export type NextStrictQuery<DB, Sql extends string> =
+  ApplyStrictPolicy<CompileNext<DB, Sql>>;

--- a/src/compiler/next/infer-projection.ts
+++ b/src/compiler/next/infer-projection.ts
@@ -1,0 +1,90 @@
+import type { ProjectionIR } from '../../language/ir/query.js';
+import type {
+  ColumnProjectionIR,
+  ExpressionProjectionIR,
+  StarProjectionIR,
+} from '../../language/ir/projection.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { ResolveColumn } from './resolve-column.js';
+
+type UnsupportedExpression<Fragment extends string> = Diagnostic<
+  'UNSUPPORTED_EXPRESSION',
+  `unsupported expression: ${Fragment}`,
+  'error',
+  'select',
+  Fragment
+>;
+
+type AddProperty<Row, Name extends string, Value> = Row & {
+  [Key in Name]: Value;
+};
+
+type Flatten<Value> = { [Key in keyof Value]: Value[Key] };
+
+type ProjectionResult<Row, Diagnostics extends readonly Diagnostic[]> = {
+  row: Row;
+  diagnostics: Diagnostics;
+};
+
+type InferColumn<
+  DB,
+  CurrentScope,
+  Projection extends ColumnProjectionIR,
+  Row,
+  Diagnostics extends readonly Diagnostic[],
+> = ResolveColumn<
+  DB,
+  CurrentScope,
+  Projection['qualifier'],
+  Projection['name']
+> extends infer Resolution
+  ? Resolution extends { kind: 'ok'; value: infer Value }
+    ? ProjectionResult<
+        AddProperty<Row, Projection['outputName'], Value>,
+        Diagnostics
+      >
+    : Resolution extends {
+          kind: 'error';
+          diagnostic: infer Error extends Diagnostic;
+        }
+      ? ProjectionResult<
+          AddProperty<Row, Projection['outputName'], unknown>,
+          [...Diagnostics, Error]
+        >
+      : never
+  : never;
+
+type InferOne<
+  DB,
+  CurrentScope,
+  Projection extends ProjectionIR,
+  Row,
+  Diagnostics extends readonly Diagnostic[],
+> = Projection extends ColumnProjectionIR
+  ? InferColumn<DB, CurrentScope, Projection, Row, Diagnostics>
+  : Projection extends ExpressionProjectionIR
+    ? ProjectionResult<
+        AddProperty<Row, Projection['outputName'], unknown>,
+        [...Diagnostics, UnsupportedExpression<Projection['fragment']>]
+      >
+    : Projection extends StarProjectionIR
+      ? ProjectionResult<Row, [...Diagnostics, UnsupportedExpression<'*'>]>
+      : never;
+
+export type InferProjections<
+  DB,
+  CurrentScope,
+  Projections extends readonly ProjectionIR[],
+  Row = {},
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Projections extends readonly [
+  infer Head extends ProjectionIR,
+  ...infer Tail extends ProjectionIR[],
+]
+  ? InferOne<DB, CurrentScope, Head, Row, Diagnostics> extends ProjectionResult<
+      infer NextRow,
+      infer NextDiagnostics
+    >
+    ? InferProjections<DB, CurrentScope, Tail, NextRow, NextDiagnostics>
+    : never
+  : ProjectionResult<Flatten<Row>, Diagnostics>;

--- a/src/compiler/next/resolve-column.ts
+++ b/src/compiler/next/resolve-column.ts
@@ -1,0 +1,116 @@
+import type { SourceIR, TableSourceIR } from '../../language/ir/source.js';
+import type { ColumnValue, ResolveKey, TableRow } from '../schema/model.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { Scope } from './scope.js';
+import type {
+  ResolveBinding,
+  ResolveError,
+  ResolveOk,
+} from './resolve-source.js';
+
+type UnknownTable<Name extends string> = Diagnostic<
+  'UNKNOWN_TABLE',
+  `unknown table: ${Name}`,
+  'error',
+  'from',
+  Name
+>;
+
+type UnknownColumn<Name extends string> = Diagnostic<
+  'UNKNOWN_COLUMN',
+  `unknown column: ${Name}`,
+  'error',
+  'select',
+  Name
+>;
+
+type AmbiguousColumn<Name extends string> = Diagnostic<
+  'AMBIGUOUS_COLUMN',
+  `ambiguous column: ${Name}`,
+  'error',
+  'select',
+  Name
+>;
+
+type WithNullability<Value, Nullable extends boolean> =
+  Nullable extends true ? Value | null : Value;
+
+type ResolveTableColumn<
+  DB,
+  Source extends TableSourceIR,
+  Column extends string,
+> = ResolveKey<DB, Source['name']> extends never
+  ? ResolveError<UnknownTable<Source['name']>>
+  : ResolveKey<TableRow<DB, Source['name']>, Column> extends never
+    ? ResolveError<UnknownColumn<Column>>
+    : ResolveOk<
+        WithNullability<
+          ColumnValue<TableRow<DB, Source['name']>, Column>,
+          Source['nullable']
+        >
+      >;
+
+type ResolveQualified<
+  DB,
+  CurrentScope,
+  Qualifier extends string,
+  Column extends string,
+> = ResolveBinding<CurrentScope, Qualifier> extends infer Binding
+  ? Binding extends ResolveOk<infer Source extends TableSourceIR>
+    ? ResolveTableColumn<DB, Source, Column>
+    : Binding
+  : never;
+
+type LocalColumnMatches<
+  DB,
+  Sources extends readonly SourceIR[],
+  Column extends string,
+  Matches extends unknown[] = [],
+> = Sources extends readonly [
+  infer Head extends SourceIR,
+  ...infer Tail extends SourceIR[],
+]
+  ? Head extends TableSourceIR
+    ? ResolveKey<DB, Head['name']> extends never
+      ? LocalColumnMatches<DB, Tail, Column, Matches>
+      : ResolveKey<TableRow<DB, Head['name']>, Column> extends never
+        ? LocalColumnMatches<DB, Tail, Column, Matches>
+        : LocalColumnMatches<
+            DB,
+            Tail,
+            Column,
+            [
+              ...Matches,
+              WithNullability<
+                ColumnValue<TableRow<DB, Head['name']>, Column>,
+                Head['nullable']
+              >,
+            ]
+          >
+    : LocalColumnMatches<DB, Tail, Column, Matches>
+  : Matches;
+
+type ResolveUnqualified<
+  DB,
+  CurrentScope,
+  Column extends string,
+> = CurrentScope extends Scope<infer Sources, infer Parent>
+  ? LocalColumnMatches<DB, Sources, Column> extends infer Matches extends unknown[]
+    ? Matches extends [infer Value]
+      ? ResolveOk<Value>
+      : Matches extends [unknown, unknown, ...unknown[]]
+        ? ResolveError<AmbiguousColumn<Column>>
+        : Parent extends Scope<readonly SourceIR[], unknown>
+          ? ResolveUnqualified<DB, Parent, Column>
+          : ResolveError<UnknownColumn<Column>>
+    : never
+  : ResolveError<UnknownColumn<Column>>;
+
+export type ResolveColumn<
+  DB,
+  CurrentScope,
+  Qualifier extends string | null,
+  Column extends string,
+> = Qualifier extends string
+  ? ResolveQualified<DB, CurrentScope, Qualifier, Column>
+  : ResolveUnqualified<DB, CurrentScope, Column>;

--- a/src/compiler/next/resolve-source.ts
+++ b/src/compiler/next/resolve-source.ts
@@ -1,0 +1,50 @@
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { SourceIR } from '../../language/ir/source.js';
+import type { Scope } from './scope.js';
+
+export type ResolveOk<Value> = { kind: 'ok'; value: Value };
+
+export type ResolveError<Error extends Diagnostic> = {
+  kind: 'error';
+  diagnostic: Error;
+};
+
+type Matches<Source extends SourceIR, Name extends string> =
+  Lowercase<Source['alias']> extends Lowercase<Name>
+    ? true
+    : Source extends { name: infer Table extends string }
+      ? Lowercase<Table> extends Lowercase<Name>
+        ? true
+        : false
+      : false;
+
+type FindLocal<
+  Sources extends readonly SourceIR[],
+  Name extends string,
+> = Sources extends readonly [
+  infer Head extends SourceIR,
+  ...infer Tail extends SourceIR[],
+]
+  ? Matches<Head, Name> extends true
+    ? Head
+    : FindLocal<Tail, Name>
+  : never;
+
+type UnknownAlias<Name extends string> = Diagnostic<
+  'UNKNOWN_ALIAS',
+  `unknown alias: ${Name}`,
+  'error',
+  'from',
+  Name
+>;
+
+export type ResolveBinding<
+  CurrentScope,
+  Name extends string,
+> = CurrentScope extends Scope<infer Sources, infer Parent>
+  ? [FindLocal<Sources, Name>] extends [never]
+    ? Parent extends Scope<readonly SourceIR[], unknown>
+      ? ResolveBinding<Parent, Name>
+      : ResolveError<UnknownAlias<Name>>
+    : ResolveOk<FindLocal<Sources, Name>>
+  : ResolveError<UnknownAlias<Name>>;

--- a/src/compiler/next/scope.ts
+++ b/src/compiler/next/scope.ts
@@ -1,0 +1,16 @@
+import type { SourceIR } from '../../language/ir/source.js';
+
+export interface Scope<
+  Sources extends readonly SourceIR[],
+  Parent = null,
+> {
+  sources: Sources;
+  parent: Parent;
+}
+
+export type RootScope<Sources extends readonly SourceIR[]> = Scope<Sources>;
+
+export type ChildScope<
+  Sources extends readonly SourceIR[],
+  Parent,
+> = Scope<Sources, Parent>;

--- a/src/compiler/schema/model.ts
+++ b/src/compiler/schema/model.ts
@@ -1,0 +1,19 @@
+export type Schema = Record<string, Record<string, unknown>>;
+
+export type SchemaLike = object;
+
+export type ResolveKey<T, Name extends string> = Name extends keyof T
+  ? Name
+  : {
+      [Key in keyof T]: Key extends string
+        ? Lowercase<Key> extends Lowercase<Name>
+          ? Key
+          : never
+        : never;
+    }[keyof T];
+
+export type TableRow<DB, Name extends string> =
+  ResolveKey<DB, Name> extends infer Key extends keyof DB ? DB[Key] : never;
+
+export type ColumnValue<Row, Name extends string> =
+  ResolveKey<Row, Name> extends infer Key extends keyof Row ? Row[Key] : never;

--- a/src/language/ir/cte.ts
+++ b/src/language/ir/cte.ts
@@ -1,0 +1,11 @@
+export interface CteIR<
+  Name extends string = string,
+  Columns extends readonly string[] | null = null,
+  Query = unknown,
+  Recursive extends boolean = false,
+> {
+  name: Name;
+  columns: Columns;
+  query: Query;
+  recursive: Recursive;
+}

--- a/src/language/ir/parameter.ts
+++ b/src/language/ir/parameter.ts
@@ -1,0 +1,14 @@
+export type ParameterStyle = 'numbered' | 'named' | 'positional';
+
+export interface ParameterIR<
+  Token extends string = string,
+  Style extends ParameterStyle = ParameterStyle,
+  Identity extends string = string,
+  Fragment extends string = string,
+> {
+  kind: 'parameter';
+  token: Token;
+  style: Style;
+  identity: Identity;
+  context: Fragment;
+}

--- a/src/language/ir/predicate.ts
+++ b/src/language/ir/predicate.ts
@@ -1,0 +1,8 @@
+export interface PredicateIR<
+  Location extends 'join-on' | 'where' | 'having' = 'where',
+  Fragment extends string = string,
+> {
+  kind: 'predicate';
+  location: Location;
+  fragment: Fragment;
+}

--- a/src/language/ir/projection.ts
+++ b/src/language/ir/projection.ts
@@ -1,0 +1,26 @@
+export interface ColumnProjectionIR<
+  Qualifier extends string | null = string | null,
+  Name extends string = string,
+  OutputName extends string = Name,
+> {
+  kind: 'column';
+  qualifier: Qualifier;
+  name: Name;
+  outputName: OutputName;
+}
+
+export interface StarProjectionIR<
+  Qualifier extends string | null = null,
+> {
+  kind: 'star';
+  qualifier: Qualifier;
+}
+
+export interface ExpressionProjectionIR<
+  Fragment extends string = string,
+  OutputName extends string = string,
+> {
+  kind: 'expression';
+  fragment: Fragment;
+  outputName: OutputName;
+}

--- a/src/language/ir/query.ts
+++ b/src/language/ir/query.ts
@@ -1,0 +1,29 @@
+import type { CteIR } from './cte.js';
+import type { ParameterIR } from './parameter.js';
+import type { PredicateIR } from './predicate.js';
+import type {
+  ColumnProjectionIR,
+  ExpressionProjectionIR,
+  StarProjectionIR,
+} from './projection.js';
+import type { SourceIR } from './source.js';
+
+export type ProjectionIR =
+  | ColumnProjectionIR
+  | ExpressionProjectionIR
+  | StarProjectionIR;
+
+export interface SelectQueryIR<
+  Sources extends readonly SourceIR[] = readonly SourceIR[],
+  Projections extends readonly ProjectionIR[] = readonly ProjectionIR[],
+  Predicates extends readonly PredicateIR[] = readonly PredicateIR[],
+  Parameters extends readonly ParameterIR[] = readonly ParameterIR[],
+  Ctes extends readonly CteIR[] = readonly CteIR[],
+> {
+  kind: 'select';
+  sources: Sources;
+  projections: Projections;
+  predicates: Predicates;
+  parameters: Parameters;
+  ctes: Ctes;
+}

--- a/src/language/ir/source.ts
+++ b/src/language/ir/source.ts
@@ -1,0 +1,31 @@
+export type JoinKind = 'root' | 'inner' | 'left' | 'right' | 'full' | 'cross';
+
+export interface TableSourceIR<
+  Name extends string = string,
+  Alias extends string = Name,
+  Nullable extends boolean = false,
+  Join extends JoinKind = 'root',
+  MergedColumns extends readonly string[] = [],
+> {
+  kind: 'table';
+  name: Name;
+  alias: Alias;
+  join: Join;
+  nullable: Nullable;
+  mergedColumns: MergedColumns;
+}
+
+export interface DerivedSourceIR<
+  Alias extends string = string,
+  Query = unknown,
+  Nullable extends boolean = false,
+  Join extends JoinKind = 'root',
+> {
+  kind: 'derived';
+  alias: Alias;
+  query: Query;
+  join: Join;
+  nullable: Nullable;
+}
+
+export type SourceIR = TableSourceIR | DerivedSourceIR;

--- a/src/language/lexical/statement.ts
+++ b/src/language/lexical/statement.ts
@@ -1,6 +1,6 @@
 import type { FirstWord, IsKeyword, Normalize } from '../../string.js';
 
-export type StatementKind =
+type StatementKindName =
   | 'select'
   | 'with'
   | 'insert'
@@ -18,4 +18,6 @@ type KindOf<Token extends string> =
   : IsKeyword<Token, 'merge'> extends true ? 'merge'
   : 'unknown';
 
-export type ClassifyStatement<Sql extends string> = KindOf<FirstWord<Normalize<Sql>>>;
+export type StatementKind<Sql extends string> = KindOf<FirstWord<Normalize<Sql>>>;
+
+export type ClassifyStatement<Sql extends string> = StatementKind<Sql>;

--- a/src/language/lexical/statement.ts
+++ b/src/language/lexical/statement.ts
@@ -1,0 +1,21 @@
+import type { FirstWord, IsKeyword, Normalize } from '../../string.js';
+
+export type StatementKind =
+  | 'select'
+  | 'with'
+  | 'insert'
+  | 'update'
+  | 'delete'
+  | 'merge'
+  | 'unknown';
+
+type KindOf<Token extends string> =
+  IsKeyword<Token, 'select'> extends true ? 'select'
+  : IsKeyword<Token, 'with'> extends true ? 'with'
+  : IsKeyword<Token, 'insert'> extends true ? 'insert'
+  : IsKeyword<Token, 'update'> extends true ? 'update'
+  : IsKeyword<Token, 'delete'> extends true ? 'delete'
+  : IsKeyword<Token, 'merge'> extends true ? 'merge'
+  : 'unknown';
+
+export type ClassifyStatement<Sql extends string> = KindOf<FirstWord<Normalize<Sql>>>;

--- a/src/language/select/parse-from.ts
+++ b/src/language/select/parse-from.ts
@@ -1,0 +1,19 @@
+import type { IsKeyword, Normalize, Unquote } from '../../string.js';
+import type { TableSourceIR } from '../ir/source.js';
+
+type ParseWords<Sql extends string> =
+  Normalize<Sql> extends `${infer Name} ${infer As} ${infer Alias}`
+    ? Alias extends `${string} ${string}`
+      ? never
+      : IsKeyword<As, 'as'> extends true
+        ? TableSourceIR<Unquote<Name>, Unquote<Alias>>
+        : never
+    : Normalize<Sql> extends `${infer Name} ${infer Alias}`
+      ? TableSourceIR<Unquote<Name>, Unquote<Alias>>
+      : Normalize<Sql> extends infer Name extends string
+        ? Name extends ''
+          ? never
+          : TableSourceIR<Unquote<Name>, Unquote<Name>>
+        : never;
+
+export type ParseRootSource<Sql extends string> = ParseWords<Sql>;

--- a/src/language/select/parse-projection.ts
+++ b/src/language/select/parse-projection.ts
@@ -1,0 +1,55 @@
+import type { SplitColumnList, Trim, Unquote } from '../../string.js';
+import type {
+  ColumnProjectionIR,
+  ExpressionProjectionIR,
+  StarProjectionIR,
+} from '../ir/projection.js';
+
+type SplitAlias<Fragment extends string> =
+  Fragment extends `${infer Expression} as ${infer Alias}` ? [Expression, Alias]
+  : Fragment extends `${infer Expression} AS ${infer Alias}` ? [Expression, Alias]
+  : Fragment extends `${infer Expression} As ${infer Alias}` ? [Expression, Alias]
+  : Fragment extends `${infer Expression} aS ${infer Alias}` ? [Expression, Alias]
+  : [Fragment, null];
+
+type OutputName<Name extends string, Alias extends string | null> =
+  Alias extends string ? Unquote<Trim<Alias>> : Unquote<Name>;
+
+type ParseProjectionExpression<
+  Expression extends string,
+  Alias extends string | null,
+> = Trim<Expression> extends infer Value extends string
+  ? Value extends '*'
+    ? StarProjectionIR
+    : Value extends `${infer Qualifier}.*`
+      ? StarProjectionIR<Unquote<Trim<Qualifier>>>
+      : Value extends `${infer Qualifier}.${infer Name}`
+        ? ColumnProjectionIR<
+            Unquote<Trim<Qualifier>>,
+            Unquote<Trim<Name>>,
+            OutputName<Unquote<Trim<Name>>, Alias>
+          >
+        : Value extends `${string} ${string}` | `${string}(${string}` | `${string})${string}`
+          ? ExpressionProjectionIR<Value, Alias extends string ? Unquote<Trim<Alias>> : Value>
+          : ColumnProjectionIR<null, Unquote<Value>, OutputName<Unquote<Value>, Alias>>
+  : never;
+
+type ParseProjection<Fragment extends string> =
+  SplitAlias<Trim<Fragment>> extends [
+    infer Expression extends string,
+    infer Alias extends string | null,
+  ]
+    ? ParseProjectionExpression<Expression, Alias>
+    : never;
+
+type ParseProjectionItems<
+  Items extends readonly string[],
+  Result extends unknown[] = [],
+> = Items extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? ParseProjectionItems<Tail, [...Result, ParseProjection<Head>]>
+  : Result;
+
+export type ParseProjectionList<Sql extends string> = ParseProjectionItems<SplitColumnList<Sql>>;

--- a/src/language/select/parse-select.ts
+++ b/src/language/select/parse-select.ts
@@ -1,0 +1,68 @@
+import type {
+  ApplyParenDelta,
+  IsKeyword,
+  Normalize,
+  Trim,
+} from '../../string.js';
+import type { SelectQueryIR } from '../ir/query.js';
+import type { TableSourceIR } from '../ir/source.js';
+import type { ParseRootSource } from './parse-from.js';
+import type { ParseProjectionList } from './parse-projection.js';
+
+type SplitAtFrom<
+  Sql extends string,
+  Depth extends unknown[] = [],
+  Before extends string = '',
+> = Sql extends `${infer Token} ${infer Rest}`
+  ? Depth extends []
+    ? IsKeyword<Token, 'from'> extends true
+      ? { before: Trim<Before>; after: Trim<Rest> }
+      : SplitAtFrom<Rest, ApplyParenDelta<Depth, Token>, `${Before} ${Token}`>
+    : SplitAtFrom<Rest, ApplyParenDelta<Depth, Token>, `${Before} ${Token}`>
+  : never;
+
+type MalformedSelect<Sql extends string> = {
+  code: 'MALFORMED_QUERY';
+  message: 'malformed SELECT query';
+  severity: 'fatal';
+  location: { kind: 'statement'; reference: Sql };
+};
+
+type ParseFatal<Sql extends string> = {
+  kind: 'fatal';
+  readonly __value?: SelectQueryIR;
+  diagnostics: [MalformedSelect<Sql>];
+};
+
+type ParseBody<Body extends string, Sql extends string> =
+  SplitAtFrom<Body> extends {
+    before: infer Projection extends string;
+    after: infer Source extends string;
+  }
+    ? Projection extends ''
+      ? ParseFatal<Sql>
+      : [ParseRootSource<Source>] extends [never]
+        ? ParseFatal<Sql>
+        : ParseRootSource<Source> extends infer RootSource extends TableSourceIR
+          ? {
+              kind: 'ok';
+              value: SelectQueryIR<
+                [RootSource],
+                ParseProjectionList<Projection>,
+                [],
+                [],
+                []
+              >;
+              diagnostics: [];
+            }
+          : ParseFatal<Sql>
+    : ParseFatal<Sql>;
+
+type ParseNormalized<Normalized extends string, Sql extends string> =
+  Normalized extends `${infer Select} ${infer Body}`
+    ? IsKeyword<Select, 'select'> extends true
+      ? ParseBody<Body, Sql>
+      : ParseFatal<Sql>
+    : ParseFatal<Sql>;
+
+export type ParseSelectIR<Sql extends string> = ParseNormalized<Normalize<Sql>, Sql>;

--- a/src/language/select/parse-select.ts
+++ b/src/language/select/parse-select.ts
@@ -25,7 +25,8 @@ type MalformedSelect<Sql extends string> = {
   code: 'MALFORMED_QUERY';
   message: 'malformed SELECT query';
   severity: 'fatal';
-  location: { kind: 'statement'; reference: Sql };
+  location: 'statement';
+  reference: Sql;
 };
 
 type ParseFatal<Sql extends string> = {

--- a/src/public/client.ts
+++ b/src/public/client.ts
@@ -3,9 +3,9 @@ import type {
   LegacyInferResult,
   LegacyInferResultStrict,
   QueryTypeError,
-  SchemaLike,
   UsedPlaceholderStyles,
 } from '../compiler/legacy.js';
+import type { SchemaLike } from '../compiler/schema/model.js';
 import { createRuntimeDb } from '../runtime/db.js';
 import type {
   DialectExecutor,

--- a/src/public/query.ts
+++ b/src/public/query.ts
@@ -4,8 +4,8 @@ import type {
   LegacyInferResultStrict,
   LegacyInferRow,
   LegacyInferRowStrict,
-  SchemaLike,
 } from '../compiler/legacy.js';
+import type { SchemaLike } from '../compiler/schema/model.js';
 
 export type {
   LegacyInferParams as InferParams,

--- a/src/public/schema.ts
+++ b/src/public/schema.ts
@@ -1,10 +1,11 @@
-import type { Schema } from '../compiler/legacy.js';
+import type { Schema } from '../compiler/schema/model.js';
 
 export type {
   Schema,
   SchemaLike,
-  FunctionReturnTypes,
-} from '../compiler/legacy.js';
+} from '../compiler/schema/model.js';
+
+export type { FunctionReturnTypes } from '../compiler/legacy.js';
 
 export type { QueryTypeError } from '../compiler/contracts/public-error.js';
 

--- a/src/public/schema.ts
+++ b/src/public/schema.ts
@@ -3,9 +3,10 @@ import type { Schema } from '../compiler/legacy.js';
 export type {
   Schema,
   SchemaLike,
-  QueryTypeError,
   FunctionReturnTypes,
 } from '../compiler/legacy.js';
+
+export type { QueryTypeError } from '../compiler/contracts/public-error.js';
 
 export function defineSchema<const DB extends Schema>(schema: DB): DB {
   return schema;

--- a/tests/next/diagnostics.test-d.ts
+++ b/tests/next/diagnostics.test-d.ts
@@ -1,0 +1,47 @@
+import type {
+  ApplyLoosePolicy,
+  ApplyStrictPolicy,
+  CompileOk,
+} from '../../src/compiler/contracts/compilation.js';
+import type {
+  Diagnostic,
+  QueryDiagnosticCode,
+} from '../../src/compiler/contracts/diagnostic.js';
+import type { QueryTypeError } from '../../src/public/schema.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+type UnknownColumn = Diagnostic<
+  'UNKNOWN_COLUMN',
+  'unknown column: nope',
+  'error',
+  'select',
+  'nope'
+>;
+
+type CodesAreClosed = Expect<
+  Equal<'UNKNOWN_COLUMN' extends QueryDiagnosticCode ? true : false, true>
+>;
+
+type Compilation = CompileOk<{ id: number; nope: unknown }[], [UnknownColumn]>;
+
+type LooseKeepsValue = Expect<
+  Equal<ApplyLoosePolicy<Compilation>, { id: number; nope: unknown }[]>
+>;
+
+type StrictBlocks = Expect<
+  Equal<
+    ApplyStrictPolicy<Compilation>,
+    QueryTypeError<'unknown column: nope'>[]
+  >
+>;
+
+export type DiagnosticContractLock = [
+  CodesAreClosed,
+  LooseKeepsValue,
+  StrictBlocks,
+];

--- a/tests/next/language-select.test-d.ts
+++ b/tests/next/language-select.test-d.ts
@@ -1,6 +1,15 @@
 import type { SelectQueryIR } from '../../src/language/ir/query.js';
 import type { ColumnProjectionIR } from '../../src/language/ir/projection.js';
 import type { TableSourceIR } from '../../src/language/ir/source.js';
+import type { ClassifyStatement } from '../../src/language/lexical/statement.js';
+import type { ParseSelectIR } from '../../src/language/select/parse-select.js';
+import type { CompileOk } from '../../src/compiler/contracts/compilation.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
 
 type Expected = SelectQueryIR<
   [TableSourceIR<'users', 'u', false>],
@@ -12,3 +21,47 @@ type Expected = SelectQueryIR<
 
 declare const expected: Expected;
 void expected;
+
+type _statement = Expect<Equal<ClassifyStatement<' SELECT id FROM users '>, 'select'>>;
+
+type _simple = Expect<
+  Equal<
+    ParseSelectIR<'select id, name from users'>,
+    CompileOk<
+      SelectQueryIR<
+        [TableSourceIR<'users', 'users'>],
+        [
+          ColumnProjectionIR<null, 'id', 'id'>,
+          ColumnProjectionIR<null, 'name', 'name'>,
+        ],
+        [],
+        [],
+        []
+      >
+    >
+  >
+>;
+
+type _qualified = Expect<
+  Equal<
+    ParseSelectIR<'select u.id as user_id from users as u'>,
+    CompileOk<
+      SelectQueryIR<
+        [TableSourceIR<'users', 'u'>],
+        [ColumnProjectionIR<'u', 'id', 'user_id'>],
+        [],
+        [],
+        []
+      >
+    >
+  >
+>;
+
+type _malformed = Expect<
+  ParseSelectIR<'select from users'> extends {
+    kind: 'fatal';
+    diagnostics: [{ code: 'MALFORMED_QUERY' }];
+  }
+    ? true
+    : false
+>;

--- a/tests/next/language-select.test-d.ts
+++ b/tests/next/language-select.test-d.ts
@@ -1,0 +1,14 @@
+import type { SelectQueryIR } from '../../src/language/ir/query.js';
+import type { ColumnProjectionIR } from '../../src/language/ir/projection.js';
+import type { TableSourceIR } from '../../src/language/ir/source.js';
+
+type Expected = SelectQueryIR<
+  [TableSourceIR<'users', 'u', false>],
+  [ColumnProjectionIR<'u', 'id', 'id'>],
+  [],
+  [],
+  []
+>;
+
+declare const expected: Expected;
+void expected;

--- a/tests/next/scope.test-d.ts
+++ b/tests/next/scope.test-d.ts
@@ -1,0 +1,66 @@
+import type { TableSourceIR } from '../../src/language/ir/source.js';
+import type { ResolveColumn } from '../../src/compiler/next/resolve-column.js';
+import type { ResolveBinding } from '../../src/compiler/next/resolve-source.js';
+import type { ChildScope, RootScope } from '../../src/compiler/next/scope.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+type DB = {
+  users: { id: number; name: string };
+  posts: { id: string; author_id: number };
+};
+
+type Users = TableSourceIR<'users', 'u'>;
+type Posts = TableSourceIR<'posts', 'p'>;
+type Root = RootScope<[Users]>;
+
+type _local = Expect<
+  Equal<ResolveBinding<Root, 'u'>, { kind: 'ok'; value: Users }>
+>;
+
+type _qualified = Expect<
+  Equal<ResolveColumn<DB, Root, 'u', 'id'>, { kind: 'ok'; value: number }>
+>;
+
+type _unknownAlias = Expect<
+  ResolveBinding<Root, 'missing'> extends {
+    kind: 'error';
+    diagnostic: { code: 'UNKNOWN_ALIAS'; message: 'unknown alias: missing' };
+  }
+    ? true
+    : false
+>;
+
+type _unknownColumn = Expect<
+  ResolveColumn<DB, Root, null, 'missing'> extends {
+    kind: 'error';
+    diagnostic: { code: 'UNKNOWN_COLUMN'; message: 'unknown column: missing' };
+  }
+    ? true
+    : false
+>;
+
+type _ambiguous = Expect<
+  ResolveColumn<DB, RootScope<[Users, Posts]>, null, 'id'> extends {
+    kind: 'error';
+    diagnostic: { code: 'AMBIGUOUS_COLUMN'; message: 'ambiguous column: id' };
+  }
+    ? true
+    : false
+>;
+
+type Child = ChildScope<[Posts], Root>;
+
+type _correlated = Expect<
+  Equal<ResolveColumn<DB, Child, 'u', 'name'>, { kind: 'ok'; value: string }>
+>;
+
+type Shadow = ChildScope<[TableSourceIR<'posts', 'u'>], Root>;
+
+type _shadow = Expect<
+  Equal<ResolveColumn<DB, Shadow, 'u', 'id'>, { kind: 'ok'; value: string }>
+>;

--- a/tests/next/select-parity.test-d.ts
+++ b/tests/next/select-parity.test-d.ts
@@ -1,0 +1,51 @@
+import type {
+  LegacyInferResult,
+  LegacyInferResultStrict,
+} from '../../src/compiler/legacy.js';
+import type {
+  NextQuery,
+  NextStrictQuery,
+} from '../../src/compiler/next/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+type DB = {
+  users: {
+    id: number;
+    name: string;
+  };
+};
+
+type _simple = Expect<Equal<
+  LegacyInferResult<DB, 'select id, name from users'>,
+  NextQuery<DB, 'select id, name from users'>
+>>;
+
+type _aliased = Expect<Equal<
+  LegacyInferResult<DB, 'select id from users u'>,
+  NextQuery<DB, 'select id from users u'>
+>>;
+
+type _qualified = Expect<Equal<
+  LegacyInferResult<DB, 'select u.id from users as u'>,
+  NextQuery<DB, 'select u.id from users as u'>
+>>;
+
+type _renamed = Expect<Equal<
+  LegacyInferResult<DB, 'select u.id as user_id from users u'>,
+  NextQuery<DB, 'select u.id as user_id from users u'>
+>>;
+
+type _unknownLoose = Expect<Equal<
+  LegacyInferResult<DB, 'select nope from users'>,
+  NextQuery<DB, 'select nope from users'>
+>>;
+
+type _unknownStrict = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select nope from users'>,
+  NextStrictQuery<DB, 'select nope from users'>
+>>;

--- a/tests/perf/select-next.test-d.ts
+++ b/tests/perf/select-next.test-d.ts
@@ -1,0 +1,9 @@
+import type {
+  NextQuery,
+} from '../../src/compiler/next/index.js';
+import type { DB } from './generated/schema.js';
+
+export declare const simple: NextQuery<
+  DB,
+  'select id, name, email, created_at from t_000'
+>;

--- a/tests/perf/tsconfig.json
+++ b/tests/perf/tsconfig.json
@@ -13,5 +13,5 @@
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["generated"]
+  "include": ["generated", "select-next.test-d.ts"]
 }


### PR DESCRIPTION
## Summary

- define compiler diagnostics and the shallow Query IR
- add minimal SELECT parsing and lexical scope resolution
- compile the first SELECT path through the Next compiler without cutting over the public API

## Verification

- `npm test`: 217 passed, 36 skipped
- architecture fitness checks passed
- `npm run test:perf`: 222,936 instantiations, below the 225,000 budget

## Stack

Depends on #358.
