### PR TITLE
refactor: cut SELECT inference over to Next in M3

### DIFF
--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -43,6 +43,7 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PERF_DIR = join(ROOT, 'tests', 'perf');
 const GENERATED_DIR = join(PERF_DIR, 'generated');
 const BASELINE_FILE = join(PERF_DIR, 'baseline.json');
+const NEXT_BASELINE_FILE = join(PERF_DIR, 'select-next-baseline.json');
 
 function tableName(index) {
   return `t_${String(index).padStart(3, '0')}`;
@@ -138,12 +139,12 @@ function readDiagnostic(output, label) {
   return match === null ? null : Number(match[1]);
 }
 
-function compile() {
+function compile(configFile = 'tsconfig.json') {
   const tsc = join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc');
   try {
     const output = execFileSync(
       process.execPath,
-      [tsc, '--noEmit', '--extendedDiagnostics', '-p', join(PERF_DIR, 'tsconfig.json')],
+      [tsc, '--noEmit', '--extendedDiagnostics', '-p', join(PERF_DIR, configFile)],
       { encoding: 'utf8' },
     );
     const instantiations = readDiagnostic(output, 'Instantiations');
@@ -172,16 +173,16 @@ function readTypescriptVersion() {
   return packageJson.version;
 }
 
-function writeBaseline(instantiations) {
+function writeBaseline(file, instantiations) {
   writeFileSync(
-    BASELINE_FILE,
+    file,
     `${JSON.stringify({ typescript: readTypescriptVersion(), instantiations }, null, 2)}\n`,
     'utf8',
   );
 }
 
-function readBaseline() {
-  const baseline = JSON.parse(readFileSync(BASELINE_FILE, 'utf8'));
+function readBaseline(file) {
+  const baseline = JSON.parse(readFileSync(file, 'utf8'));
   if (typeof baseline.instantiations !== 'number' || baseline.instantiations <= 0) {
     throw new Error('The type-instantiation baseline is invalid.');
   }
@@ -191,17 +192,25 @@ function readBaseline() {
 function main() {
   writeFixture();
   const { instantiations, types, checkTime } = compile();
+  const next = compile('tsconfig.next.json');
 
   if (process.argv.includes('--write-baseline')) {
-    writeBaseline(instantiations);
-    process.stdout.write(`Wrote baseline: ${instantiations} instantiations\n`);
+    writeBaseline(BASELINE_FILE, instantiations);
+    writeBaseline(NEXT_BASELINE_FILE, next.instantiations);
+    process.stdout.write(
+      `Wrote baselines: public=${instantiations}, next=${next.instantiations} instantiations\n`,
+    );
     return;
   }
 
-  const baseline = readBaseline();
+  const baseline = readBaseline(BASELINE_FILE);
+  const nextBaseline = readBaseline(NEXT_BASELINE_FILE);
   const delta = instantiations - baseline;
+  const nextDelta = next.instantiations - nextBaseline;
   const deltaPercent = (delta / baseline) * 100;
+  const nextDeltaPercent = (nextDelta / nextBaseline) * 100;
   const deltaSign = delta >= 0 ? '+' : '';
+  const nextDeltaSign = nextDelta >= 0 ? '+' : '';
   const budgetUsed = Math.round((instantiations / MAX_INSTANTIATIONS) * 100);
 
   process.stdout.write(
@@ -213,6 +222,9 @@ function main() {
       `Instantiations: ${instantiations} (${budgetUsed}% of the ${MAX_INSTANTIATIONS} budget)`,
       `Baseline:       ${baseline}`,
       `Delta:          ${deltaSign}${delta} (${deltaSign}${deltaPercent.toFixed(2)}%)`,
+      `Next:           ${next.instantiations}`,
+      `Next baseline:  ${nextBaseline}`,
+      `Next delta:     ${nextDeltaSign}${nextDelta} (${nextDeltaSign}${nextDeltaPercent.toFixed(2)}%)`,
       '',
     ].join('\n'),
   );

--- a/src/compiler/gateway.ts
+++ b/src/compiler/gateway.ts
@@ -1,0 +1,60 @@
+import type { StatementKind } from '../language/lexical/statement.js';
+import type { ApplyLoosePolicy, ApplyStrictPolicy } from './contracts/compilation.js';
+import type { SchemaLike } from './schema/model.js';
+import type {
+  LegacyInferParams,
+  LegacyInferResult,
+  LegacyInferResultStrict,
+  LegacyInferRow,
+  LegacyInferRowStrict,
+} from './legacy.js';
+import type { CompileSelect } from './next/compile-select.js';
+import type { InferNextParams } from './next/infer-params.js';
+
+type NextQuery<DB, Q extends string> =
+  ApplyLoosePolicy<CompileSelect<DB, Q, null, false>>;
+
+type NextStrictQuery<DB, Q extends string> =
+  ApplyStrictPolicy<CompileSelect<DB, Q>>;
+
+type NextRow<DB, Q extends string> = NextQuery<DB, Q> extends infer Result
+  ? Result extends readonly (infer Row)[]
+    ? Row
+    : Result
+  : never;
+
+type NextStrictRow<DB, Q extends string> =
+  NextStrictQuery<DB, Q> extends infer Result
+    ? Result extends readonly (infer Row)[]
+      ? Row
+      : Result
+    : never;
+
+type GatewayKind<Q extends string> = Q extends `select ${string}`
+  ? 'select'
+  : StatementKind<Q>;
+
+export type InferViaGateway<DB extends SchemaLike, Q extends string> =
+  GatewayKind<Q> extends 'select'
+    ? NextQuery<DB, Q>
+    : LegacyInferResult<DB, Q>;
+
+export type InferRowViaGateway<DB extends SchemaLike, Q extends string> =
+  GatewayKind<Q> extends 'select'
+    ? NextRow<DB, Q>
+    : LegacyInferRow<DB, Q>;
+
+export type InferStrictViaGateway<DB extends SchemaLike, Q extends string> =
+  GatewayKind<Q> extends 'select'
+    ? NextStrictQuery<DB, Q>
+    : LegacyInferResultStrict<DB, Q>;
+
+export type InferStrictRowViaGateway<DB extends SchemaLike, Q extends string> =
+  GatewayKind<Q> extends 'select'
+    ? NextStrictRow<DB, Q>
+    : LegacyInferRowStrict<DB, Q>;
+
+export type InferParamsViaGateway<DB extends SchemaLike, Q extends string> =
+  GatewayKind<Q> extends 'select'
+    ? InferNextParams<DB, Q>
+    : LegacyInferParams<DB, Q>;

--- a/src/compiler/next/compile-select.ts
+++ b/src/compiler/next/compile-select.ts
@@ -1,5 +1,8 @@
 import type { PredicateIR } from '../../language/ir/predicate.js';
-import type { ProjectionIR, SelectQueryIR } from '../../language/ir/query.js';
+import type {
+  SelectQueryIR,
+  SetOperationIR,
+} from '../../language/ir/query.js';
 import type {
   DerivedSourceIR,
   JoinKind,
@@ -13,6 +16,7 @@ import type {
 } from '../contracts/compilation.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { InferProjections } from './infer-projection.js';
+import type { InferExpression } from './infer-expression.js';
 import type { RootScope } from './scope.js';
 
 type CompiledSources<
@@ -22,6 +26,140 @@ type CompiledSources<
   sources: Sources;
   diagnostics: Diagnostics;
 };
+
+type StripLeadingPunctuation<Value extends string> =
+  Value extends `(${infer Rest}` ? StripLeadingPunctuation<Rest> : Value;
+
+type StripTrailingPunctuation<Value extends string> =
+  Value extends `${infer Rest})` | `${infer Rest},`
+    ? StripTrailingPunctuation<Rest>
+    : Value;
+
+type CleanPredicateToken<Token extends string> =
+  StripTrailingPunctuation<StripLeadingPunctuation<Token>> extends infer Clean extends string
+    ? Clean extends `${infer Operand}::${string}`
+      ? Operand
+      : Clean
+    : never;
+
+type IgnoredPredicateWord =
+  | ''
+  | 'and'
+  | 'or'
+  | 'not'
+  | 'is'
+  | 'distinct'
+  | 'from'
+  | 'like'
+  | 'ilike'
+  | 'in'
+  | 'between'
+  | 'exists'
+  | 'true'
+  | 'false'
+  | 'null'
+  | 'asc'
+  | 'desc';
+
+type IsIgnoredPredicateToken<Token extends string> =
+  Lowercase<Token> extends IgnoredPredicateWord
+    ? true
+    : Token extends
+          | `${number}`
+          | `'${string}'`
+          | `$${string}`
+          | `@${string}`
+          | `:${string}`
+          | '?'
+          | '='
+          | '<>'
+          | '!='
+          | '<'
+          | '>'
+          | '<='
+          | '>='
+          | '@>'
+          | '<@'
+      ? true
+      : false;
+
+type AnalyzePredicateTokens<
+  DB,
+  CurrentScope,
+  Sql extends string,
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? CleanPredicateToken<Head> extends infer Token extends string
+    ? IsIgnoredPredicateToken<Token> extends true
+      ? AnalyzePredicateTokens<DB, CurrentScope, Tail, Diagnostics>
+      : InferExpression<DB, CurrentScope, Token> extends {
+          diagnostics: infer TokenDiagnostics extends readonly Diagnostic[];
+        }
+        ? AnalyzePredicateTokens<
+            DB,
+            CurrentScope,
+            Tail,
+            [...Diagnostics, ...TokenDiagnostics]
+          >
+        : never
+    : never
+  : CleanPredicateToken<Sql> extends infer Token extends string
+    ? IsIgnoredPredicateToken<Token> extends true
+      ? Diagnostics
+      : InferExpression<DB, CurrentScope, Token> extends {
+          diagnostics: infer TokenDiagnostics extends readonly Diagnostic[];
+        }
+        ? [...Diagnostics, ...TokenDiagnostics]
+        : never
+    : never;
+
+export type AnalyzePredicate<
+  DB,
+  CurrentScope,
+  Predicate extends PredicateIR,
+> = AnalyzePredicateTokens<DB, CurrentScope, Predicate['fragment']>;
+
+type AnalyzePredicates<
+  DB,
+  CurrentScope,
+  Predicates extends readonly PredicateIR[],
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Predicates extends readonly [
+  infer Head extends PredicateIR,
+  ...infer Tail extends PredicateIR[],
+]
+  ? AnalyzePredicate<DB, CurrentScope, Head> extends infer PredicateDiagnostics extends readonly Diagnostic[]
+    ? AnalyzePredicates<
+        DB,
+        CurrentScope,
+        Tail,
+        [...Diagnostics, ...PredicateDiagnostics]
+      >
+    : never
+  : Diagnostics;
+
+type CompileSetOperations<
+  DB,
+  Operations extends readonly SetOperationIR[],
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Operations extends readonly [
+  infer Head extends SetOperationIR,
+  ...infer Tail extends SetOperationIR[],
+]
+  ? Head['query'] extends infer Query extends SelectQueryIR
+    ? CompileIR<DB, Query> extends infer Compiled
+      ? Compiled extends CompileOk<readonly unknown[], infer BranchDiagnostics>
+        ? CompileSetOperations<
+            DB,
+            Tail,
+            [...Diagnostics, ...BranchDiagnostics]
+          >
+        : Compiled extends CompileFatal<unknown[], infer BranchDiagnostics>
+          ? [...Diagnostics, ...BranchDiagnostics]
+          : never
+      : never
+    : CompileSetOperations<DB, Tail, Diagnostics>
+  : Diagnostics;
 
 type CompileSourceList<
   DB,
@@ -67,14 +205,7 @@ type CompileSourceList<
 type CompileIR<
   DB,
   IR extends SelectQueryIR,
-> = IR extends SelectQueryIR<
-  infer Sources extends readonly SourceIR[],
-  infer Projections extends readonly ProjectionIR[],
-  readonly PredicateIR[],
-  readonly [],
-  readonly []
->
-  ? CompileSourceList<DB, Sources> extends infer Compiled
+> = CompileSourceList<DB, IR['sources']> extends infer Compiled
     ? Compiled extends CompiledSources<
         infer ResolvedSources,
         infer SourceDiagnostics
@@ -82,20 +213,35 @@ type CompileIR<
       ? InferProjections<
           DB,
           RootScope<ResolvedSources>,
-          Projections,
+          IR['projections'],
           {},
           SourceDiagnostics
         > extends {
           row: infer Row;
-          diagnostics: infer Diagnostics extends readonly Diagnostic[];
+          diagnostics: infer ProjectionDiagnostics extends readonly Diagnostic[];
         }
-        ? CompileOk<Row[], Diagnostics>
+        ? AnalyzePredicates<
+            DB,
+            RootScope<ResolvedSources>,
+            IR['predicates']
+          > extends infer PredicateDiagnostics extends readonly Diagnostic[]
+          ? CompileSetOperations<DB, IR['setOperations']> extends infer SetDiagnostics extends readonly Diagnostic[]
+            ? CompileOk<
+                Row[],
+                [
+                  ...ProjectionDiagnostics,
+                  ...PredicateDiagnostics,
+                  ...SetDiagnostics,
+                ]
+              >
+            : never
+          : never
         : never
       : Compiled extends CompileFatal<unknown[], infer Diagnostics>
         ? CompileFatal<unknown[], Diagnostics>
         : never
     : never
-  : never;
+  ;
 
 export type CompileSelect<DB, Sql extends string> =
   ParseSelectIR<Sql> extends infer Parsed

--- a/src/compiler/next/compile-select.ts
+++ b/src/compiler/next/compile-select.ts
@@ -1,5 +1,11 @@
+import type { PredicateIR } from '../../language/ir/predicate.js';
 import type { ProjectionIR, SelectQueryIR } from '../../language/ir/query.js';
-import type { SourceIR } from '../../language/ir/source.js';
+import type {
+  DerivedSourceIR,
+  JoinKind,
+  SourceIR,
+  TableSourceIR,
+} from '../../language/ir/source.js';
 import type { ParseSelectIR } from '../../language/select/parse-select.js';
 import type {
   CompileFatal,
@@ -9,21 +15,85 @@ import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { InferProjections } from './infer-projection.js';
 import type { RootScope } from './scope.js';
 
+type CompiledSources<
+  Sources extends readonly SourceIR[],
+  Diagnostics extends readonly Diagnostic[],
+> = {
+  sources: Sources;
+  diagnostics: Diagnostics;
+};
+
+type CompileSourceList<
+  DB,
+  Sources extends readonly SourceIR[],
+  Result extends readonly SourceIR[] = [],
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Sources extends readonly [
+  infer Head extends SourceIR,
+  ...infer Tail extends SourceIR[],
+]
+  ? Head extends DerivedSourceIR<
+      infer Alias,
+      infer Query extends string,
+      infer Nullable,
+      infer Join extends JoinKind
+    >
+    ? CompileSelect<DB, Query> extends infer Nested
+      ? Nested extends CompileOk<infer Rows extends readonly unknown[], infer NestedDiagnostics>
+        ? CompileSourceList<
+            DB,
+            Tail,
+            [
+              ...Result,
+              DerivedSourceIR<Alias, Rows[number], Nullable, Join>,
+            ],
+            [...Diagnostics, ...NestedDiagnostics]
+          >
+        : Nested extends CompileFatal<unknown[], infer NestedDiagnostics>
+          ? CompileFatal<unknown[], [...Diagnostics, ...NestedDiagnostics]>
+          : never
+      : never
+    : Head extends TableSourceIR<
+        string,
+        string,
+        boolean,
+        JoinKind,
+        readonly string[]
+      >
+      ? CompileSourceList<DB, Tail, [...Result, Head], Diagnostics>
+      : never
+  : CompiledSources<Result, Diagnostics>;
+
 type CompileIR<
   DB,
   IR extends SelectQueryIR,
 > = IR extends SelectQueryIR<
   infer Sources extends readonly SourceIR[],
   infer Projections extends readonly ProjectionIR[],
-  readonly [],
+  readonly PredicateIR[],
   readonly [],
   readonly []
 >
-  ? InferProjections<DB, RootScope<Sources>, Projections> extends {
-      row: infer Row;
-      diagnostics: infer Diagnostics extends readonly Diagnostic[];
-    }
-    ? CompileOk<Row[], Diagnostics>
+  ? CompileSourceList<DB, Sources> extends infer Compiled
+    ? Compiled extends CompiledSources<
+        infer ResolvedSources,
+        infer SourceDiagnostics
+      >
+      ? InferProjections<
+          DB,
+          RootScope<ResolvedSources>,
+          Projections,
+          {},
+          SourceDiagnostics
+        > extends {
+          row: infer Row;
+          diagnostics: infer Diagnostics extends readonly Diagnostic[];
+        }
+        ? CompileOk<Row[], Diagnostics>
+        : never
+      : Compiled extends CompileFatal<unknown[], infer Diagnostics>
+        ? CompileFatal<unknown[], Diagnostics>
+        : never
     : never
   : never;
 

--- a/src/compiler/next/compile-select.ts
+++ b/src/compiler/next/compile-select.ts
@@ -17,7 +17,7 @@ import type {
 import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { InferProjections } from './infer-projection.js';
 import type { InferExpression } from './infer-expression.js';
-import type { RootScope } from './scope.js';
+import type { ChildScope, Scope } from './scope.js';
 
 type CompiledSources<
   Sources extends readonly SourceIR[],
@@ -141,29 +141,32 @@ type AnalyzePredicates<
 type CompileSetOperations<
   DB,
   Operations extends readonly SetOperationIR[],
+  ParentScope,
   Diagnostics extends readonly Diagnostic[] = [],
 > = Operations extends readonly [
   infer Head extends SetOperationIR,
   ...infer Tail extends SetOperationIR[],
 ]
   ? Head['query'] extends infer Query extends SelectQueryIR
-    ? CompileIR<DB, Query> extends infer Compiled
+    ? CompileIR<DB, Query, ParentScope> extends infer Compiled
       ? Compiled extends CompileOk<readonly unknown[], infer BranchDiagnostics>
         ? CompileSetOperations<
             DB,
             Tail,
+            ParentScope,
             [...Diagnostics, ...BranchDiagnostics]
           >
         : Compiled extends CompileFatal<unknown[], infer BranchDiagnostics>
           ? [...Diagnostics, ...BranchDiagnostics]
           : never
       : never
-    : CompileSetOperations<DB, Tail, Diagnostics>
+    : CompileSetOperations<DB, Tail, ParentScope, Diagnostics>
   : Diagnostics;
 
 type CompileSourceList<
   DB,
   Sources extends readonly SourceIR[],
+  ParentScope,
   Result extends readonly SourceIR[] = [],
   Diagnostics extends readonly Diagnostic[] = [],
 > = Sources extends readonly [
@@ -172,15 +175,16 @@ type CompileSourceList<
 ]
   ? Head extends DerivedSourceIR<
       infer Alias,
-      infer Query extends string,
+      infer Query extends SelectQueryIR,
       infer Nullable,
       infer Join extends JoinKind
     >
-    ? CompileSelect<DB, Query> extends infer Nested
+    ? CompileIR<DB, Query, ChildScope<Result, ParentScope>> extends infer Nested
       ? Nested extends CompileOk<infer Rows extends readonly unknown[], infer NestedDiagnostics>
         ? CompileSourceList<
             DB,
             Tail,
+            ParentScope,
             [
               ...Result,
               DerivedSourceIR<Alias, Rows[number], Nullable, Join>,
@@ -198,21 +202,22 @@ type CompileSourceList<
         JoinKind,
         readonly string[]
       >
-      ? CompileSourceList<DB, Tail, [...Result, Head], Diagnostics>
+      ? CompileSourceList<DB, Tail, ParentScope, [...Result, Head], Diagnostics>
       : never
   : CompiledSources<Result, Diagnostics>;
 
 type CompileIR<
   DB,
   IR extends SelectQueryIR,
-> = CompileSourceList<DB, IR['sources']> extends infer Compiled
+  ParentScope = null,
+> = CompileSourceList<DB, IR['sources'], ParentScope> extends infer Compiled
     ? Compiled extends CompiledSources<
         infer ResolvedSources,
         infer SourceDiagnostics
       >
       ? InferProjections<
           DB,
-          RootScope<ResolvedSources>,
+          Scope<ResolvedSources, ParentScope>,
           IR['projections'],
           {},
           SourceDiagnostics
@@ -222,10 +227,10 @@ type CompileIR<
         }
         ? AnalyzePredicates<
             DB,
-            RootScope<ResolvedSources>,
+            Scope<ResolvedSources, ParentScope>,
             IR['predicates']
           > extends infer PredicateDiagnostics extends readonly Diagnostic[]
-          ? CompileSetOperations<DB, IR['setOperations']> extends infer SetDiagnostics extends readonly Diagnostic[]
+          ? CompileSetOperations<DB, IR['setOperations'], ParentScope> extends infer SetDiagnostics extends readonly Diagnostic[]
             ? CompileOk<
                 Row[],
                 [
@@ -243,10 +248,10 @@ type CompileIR<
     : never
   ;
 
-export type CompileSelect<DB, Sql extends string> =
+export type CompileSelect<DB, Sql extends string, ParentScope = null> =
   ParseSelectIR<Sql> extends infer Parsed
     ? Parsed extends { kind: 'ok'; value: infer IR extends SelectQueryIR }
-      ? CompileIR<DB, IR>
+      ? CompileIR<DB, IR, ParentScope>
       : Parsed extends CompileFatal<SelectQueryIR, infer Diagnostics>
         ? CompileFatal<unknown[], Diagnostics>
         : never

--- a/src/compiler/next/compile-select.ts
+++ b/src/compiler/next/compile-select.ts
@@ -1,4 +1,5 @@
 import type { PredicateIR } from '../../language/ir/predicate.js';
+import type { IsKeyword, Trim } from '../../string.js';
 import type {
   SelectQueryIR,
   SetOperationIR,
@@ -15,6 +16,7 @@ import type {
   CompileOk,
 } from '../contracts/compilation.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { ResolveKey } from '../schema/model.js';
 import type { InferProjections } from './infer-projection.js';
 import type { InferExpression } from './infer-expression.js';
 import type { ChildScope, Scope } from './scope.js';
@@ -27,6 +29,14 @@ type CompiledSources<
   diagnostics: Diagnostics;
 };
 
+type UnknownTable<Name extends string> = Diagnostic<
+  'UNKNOWN_TABLE',
+  `unknown table: ${Name}`,
+  'error',
+  'from',
+  Name
+>;
+
 type StripLeadingPunctuation<Value extends string> =
   Value extends `(${infer Rest}` ? StripLeadingPunctuation<Rest> : Value;
 
@@ -35,12 +45,35 @@ type StripTrailingPunctuation<Value extends string> =
     ? StripTrailingPunctuation<Rest>
     : Value;
 
+type StripPredicateCast<Token extends string> =
+  Token extends `${infer Operand}::${string}` ? Operand : Token;
+
 type CleanPredicateToken<Token extends string> =
-  StripTrailingPunctuation<StripLeadingPunctuation<Token>> extends infer Clean extends string
-    ? Clean extends `${infer Operand}::${string}`
-      ? Operand
-      : Clean
+  StripLeadingPunctuation<Token> extends infer Leading extends string
+    ? StripPredicateCast<
+        Leading extends `${string}(${string}`
+          ? Leading
+          : StripTrailingPunctuation<Leading>
+      >
     : never;
+
+type BeforeNestedSelect<
+  Sql extends string,
+  Before extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? IsKeyword<CleanPredicateToken<Head>, 'select'> extends true
+    ? Trim<Before>
+    : BeforeNestedSelect<
+        Tail,
+        Before extends '' ? Head : `${Before} ${Head}`
+      >
+  : IsKeyword<CleanPredicateToken<Sql>, 'select'> extends true
+    ? Trim<Before>
+    : never;
+
+type PredicateText<Sql extends string> = [BeforeNestedSelect<Sql>] extends [never]
+  ? Sql
+  : BeforeNestedSelect<Sql>;
 
 type IgnoredPredicateWord =
   | ''
@@ -117,7 +150,7 @@ export type AnalyzePredicate<
   DB,
   CurrentScope,
   Predicate extends PredicateIR,
-> = AnalyzePredicateTokens<DB, CurrentScope, Predicate['fragment']>;
+> = AnalyzePredicateTokens<DB, CurrentScope, PredicateText<Predicate['fragment']>>;
 
 type AnalyzePredicates<
   DB,
@@ -128,45 +161,50 @@ type AnalyzePredicates<
   infer Head extends PredicateIR,
   ...infer Tail extends PredicateIR[],
 ]
-  ? AnalyzePredicate<DB, CurrentScope, Head> extends infer PredicateDiagnostics extends readonly Diagnostic[]
-    ? AnalyzePredicates<
-        DB,
-        CurrentScope,
-        Tail,
-        [...Diagnostics, ...PredicateDiagnostics]
-      >
-    : never
+  ? Head['location'] extends 'having'
+    ? AnalyzePredicates<DB, CurrentScope, Tail, Diagnostics>
+    : AnalyzePredicate<DB, CurrentScope, Head> extends infer PredicateDiagnostics extends readonly Diagnostic[]
+      ? AnalyzePredicates<
+          DB,
+          CurrentScope,
+          Tail,
+          [...Diagnostics, ...PredicateDiagnostics]
+        >
+      : never
   : Diagnostics;
 
 type CompileSetOperations<
   DB,
   Operations extends readonly SetOperationIR[],
   ParentScope,
+  ValidatePredicates extends boolean,
   Diagnostics extends readonly Diagnostic[] = [],
 > = Operations extends readonly [
   infer Head extends SetOperationIR,
   ...infer Tail extends SetOperationIR[],
 ]
   ? Head['query'] extends infer Query extends SelectQueryIR
-    ? CompileIR<DB, Query, ParentScope> extends infer Compiled
+    ? CompileIR<DB, Query, ParentScope, ValidatePredicates> extends infer Compiled
       ? Compiled extends CompileOk<readonly unknown[], infer BranchDiagnostics>
         ? CompileSetOperations<
             DB,
             Tail,
             ParentScope,
+            ValidatePredicates,
             [...Diagnostics, ...BranchDiagnostics]
           >
         : Compiled extends CompileFatal<unknown[], infer BranchDiagnostics>
           ? [...Diagnostics, ...BranchDiagnostics]
           : never
       : never
-    : CompileSetOperations<DB, Tail, ParentScope, Diagnostics>
+    : CompileSetOperations<DB, Tail, ParentScope, ValidatePredicates, Diagnostics>
   : Diagnostics;
 
 type CompileSourceList<
   DB,
   Sources extends readonly SourceIR[],
   ParentScope,
+  ValidatePredicates extends boolean,
   Result extends readonly SourceIR[] = [],
   Diagnostics extends readonly Diagnostic[] = [],
 > = Sources extends readonly [
@@ -179,12 +217,13 @@ type CompileSourceList<
       infer Nullable,
       infer Join extends JoinKind
     >
-    ? CompileIR<DB, Query, ChildScope<Result, ParentScope>> extends infer Nested
+    ? CompileIR<DB, Query, ChildScope<Result, ParentScope>, ValidatePredicates> extends infer Nested
       ? Nested extends CompileOk<infer Rows extends readonly unknown[], infer NestedDiagnostics>
         ? CompileSourceList<
             DB,
             Tail,
             ParentScope,
+            ValidatePredicates,
             [
               ...Result,
               DerivedSourceIR<Alias, Rows[number], Nullable, Join>,
@@ -196,13 +235,24 @@ type CompileSourceList<
           : never
       : never
     : Head extends TableSourceIR<
-        string,
+        infer Name,
         string,
         boolean,
         JoinKind,
         readonly string[]
       >
-      ? CompileSourceList<DB, Tail, ParentScope, [...Result, Head], Diagnostics>
+      ? CompileSourceList<
+          DB,
+          Tail,
+          ParentScope,
+          ValidatePredicates,
+          [...Result, Head],
+          ValidatePredicates extends true
+            ? ResolveKey<DB, Name> extends never
+              ? [...Diagnostics, UnknownTable<Name>]
+              : Diagnostics
+            : Diagnostics
+        >
       : never
   : CompiledSources<Result, Diagnostics>;
 
@@ -210,7 +260,8 @@ type CompileIR<
   DB,
   IR extends SelectQueryIR,
   ParentScope = null,
-> = CompileSourceList<DB, IR['sources'], ParentScope> extends infer Compiled
+  ValidatePredicates extends boolean = true,
+> = CompileSourceList<DB, IR['sources'], ParentScope, ValidatePredicates> extends infer Compiled
     ? Compiled extends CompiledSources<
         infer ResolvedSources,
         infer SourceDiagnostics
@@ -225,12 +276,19 @@ type CompileIR<
           row: infer Row;
           diagnostics: infer ProjectionDiagnostics extends readonly Diagnostic[];
         }
-        ? AnalyzePredicates<
-            DB,
-            Scope<ResolvedSources, ParentScope>,
-            IR['predicates']
-          > extends infer PredicateDiagnostics extends readonly Diagnostic[]
-          ? CompileSetOperations<DB, IR['setOperations'], ParentScope> extends infer SetDiagnostics extends readonly Diagnostic[]
+        ? (ValidatePredicates extends true
+            ? AnalyzePredicates<
+                DB,
+                Scope<ResolvedSources, ParentScope>,
+                IR['predicates']
+              >
+            : []) extends infer PredicateDiagnostics extends readonly Diagnostic[]
+          ? CompileSetOperations<
+              DB,
+              IR['setOperations'],
+              ParentScope,
+              ValidatePredicates
+            > extends infer SetDiagnostics extends readonly Diagnostic[]
             ? CompileOk<
                 Row[],
                 [
@@ -248,10 +306,15 @@ type CompileIR<
     : never
   ;
 
-export type CompileSelect<DB, Sql extends string, ParentScope = null> =
+export type CompileSelect<
+  DB,
+  Sql extends string,
+  ParentScope = null,
+  ValidatePredicates extends boolean = true,
+> =
   ParseSelectIR<Sql> extends infer Parsed
     ? Parsed extends { kind: 'ok'; value: infer IR extends SelectQueryIR }
-      ? CompileIR<DB, IR, ParentScope>
+      ? CompileIR<DB, IR, ParentScope, ValidatePredicates>
       : Parsed extends CompileFatal<SelectQueryIR, infer Diagnostics>
         ? CompileFatal<unknown[], Diagnostics>
         : never

--- a/src/compiler/next/index.ts
+++ b/src/compiler/next/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '../contracts/compilation.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { CompileSelect } from './compile-select.js';
+import type { InferNextParams } from './infer-params.js';
 
 type UnsupportedStatement<Sql extends string> = Diagnostic<
   'UNSUPPORTED_STATEMENT',
@@ -25,3 +26,15 @@ export type NextQuery<DB, Sql extends string> =
 
 export type NextStrictQuery<DB, Sql extends string> =
   ApplyStrictPolicy<CompileNext<DB, Sql>>;
+
+export type NextRow<DB, Sql extends string> =
+  NextQuery<DB, Sql> extends readonly (infer Row)[]
+    ? Row
+    : NextQuery<DB, Sql>;
+
+export type NextStrictRow<DB, Sql extends string> =
+  NextStrictQuery<DB, Sql> extends readonly (infer Row)[]
+    ? Row
+    : NextStrictQuery<DB, Sql>;
+
+export type NextInferParams<DB, Sql extends string> = InferNextParams<DB, Sql>;

--- a/src/compiler/next/index.ts
+++ b/src/compiler/next/index.ts
@@ -16,25 +16,31 @@ type UnsupportedStatement<Sql extends string> = Diagnostic<
   Sql
 >;
 
-export type CompileNext<DB, Sql extends string> =
-  StatementKind<Sql> extends 'select'
+export type CompileNext<
+  DB,
+  Sql extends string,
+> = StatementKind<Sql> extends 'select'
     ? CompileSelect<DB, Sql>
     : CompileFatal<unknown[], [UnsupportedStatement<Sql>]>;
 
 export type NextQuery<DB, Sql extends string> =
-  ApplyLoosePolicy<CompileNext<DB, Sql>>;
+  ApplyLoosePolicy<CompileSelect<DB, Sql, null, false>>;
 
 export type NextStrictQuery<DB, Sql extends string> =
-  ApplyStrictPolicy<CompileNext<DB, Sql>>;
+  ApplyStrictPolicy<CompileSelect<DB, Sql>>;
 
 export type NextRow<DB, Sql extends string> =
-  NextQuery<DB, Sql> extends readonly (infer Row)[]
+  NextQuery<DB, Sql> extends infer Result
+  ? Result extends readonly (infer Row)[]
     ? Row
-    : NextQuery<DB, Sql>;
+    : Result
+  : never;
 
 export type NextStrictRow<DB, Sql extends string> =
-  NextStrictQuery<DB, Sql> extends readonly (infer Row)[]
+  NextStrictQuery<DB, Sql> extends infer Result
+  ? Result extends readonly (infer Row)[]
     ? Row
-    : NextStrictQuery<DB, Sql>;
+    : Result
+  : never;
 
 export type NextInferParams<DB, Sql extends string> = InferNextParams<DB, Sql>;

--- a/src/compiler/next/infer-expression.ts
+++ b/src/compiler/next/infer-expression.ts
@@ -218,7 +218,7 @@ type InferCase<
   before: infer Body extends string;
   last: infer End extends string;
 }
-  ? IsKeyword<End, 'end'> extends true
+  ? IsKeyword<StripTrailingParens<End>, 'end'> extends true
     ? ScanCase<Body, 'when', '', []> extends infer Segments extends readonly CaseSegment[]
       ? InferCaseBranches<DB, CurrentScope, Segments> extends ExpressionResult<
           infer Value,
@@ -323,7 +323,7 @@ export type InferExpression<
     ? IsCaseToken<FirstWord<Value>> extends true
     ? InferCase<DB, CurrentScope, Value>
     : Value extends `${infer Operand}::${string}`
-      ? InferReference<DB, CurrentScope, Trim<Operand>> extends ExpressionResult<
+      ? InferExpression<DB, CurrentScope, Trim<Operand>> extends ExpressionResult<
           unknown,
           infer Diagnostics
         >

--- a/src/compiler/next/infer-expression.ts
+++ b/src/compiler/next/infer-expression.ts
@@ -1,0 +1,284 @@
+import type {
+  DropFirstWord,
+  ExtractParenGroup,
+  FirstWord,
+  IsKeyword,
+  Qualifier,
+  SplitColumnList,
+  StripQualifier,
+  Trim,
+  Unquote,
+} from '../../string.js';
+import type {
+  FunctionReturnType,
+  IsFunctionCall,
+} from '../semantics/functions.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { ResolveColumn } from './resolve-column.js';
+
+export type ExpressionResult<
+  Value,
+  Diagnostics extends readonly Diagnostic[] = [],
+> = {
+  kind: 'ok';
+  value: Value;
+  diagnostics: Diagnostics;
+};
+
+type LiteralType<Expression extends string> = Trim<Expression> extends `'${string}'`
+  ? string
+  : Trim<Expression> extends `${number}`
+    ? number
+    : Lowercase<Trim<Expression>> extends 'true' | 'false'
+      ? boolean
+      : Lowercase<Trim<Expression>> extends 'null'
+        ? null
+        : never;
+
+type Operator = '*' | '+' | '-' | '/' | '%' | '|' | '<' | '>' | '=' | '^';
+
+type IsOperatorExpression<Expression extends string> =
+  Expression extends `${string}"${string}` | `${string}[${string}` | `${string}\`${string}`
+    ? false
+    : Expression extends `${string}${Operator}${string}`
+      ? true
+      : false;
+
+type StripDistinct<Argument extends string> =
+  IsKeyword<FirstWord<Trim<Argument>>, 'distinct'> extends true
+    ? Trim<DropFirstWord<Trim<Argument>>>
+    : Trim<Argument>;
+
+type FunctionArguments<Expression extends string> =
+  Expression extends `${string}(${infer AfterOpen}`
+    ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string }
+      ? SplitColumnList<Inner>
+      : []
+    : [];
+
+type InferArguments<
+  DB,
+  CurrentScope,
+  Arguments extends readonly string[],
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Arguments extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? StripDistinct<Head> extends infer Argument extends string
+    ? Argument extends '' | '*' | `$${string}` | `@${string}` | '?'
+      ? InferArguments<DB, CurrentScope, Tail, Diagnostics>
+      : InferExpression<DB, CurrentScope, Argument> extends ExpressionResult<
+          unknown,
+          infer ArgumentDiagnostics
+        >
+        ? InferArguments<
+            DB,
+            CurrentScope,
+            Tail,
+            [...Diagnostics, ...ArgumentDiagnostics]
+          >
+        : never
+    : never
+  : Diagnostics;
+
+type StripLeadingParens<Value extends string> =
+  Value extends `(${infer Rest}` ? StripLeadingParens<Rest> : Value;
+
+type StripTrailingParens<Value extends string> =
+  Value extends `${infer Rest})` ? StripTrailingParens<Rest> : Value;
+
+type IsCaseToken<Token extends string> = IsKeyword<StripLeadingParens<Token>, 'case'>;
+type IsEndToken<Token extends string> = IsKeyword<StripTrailingParens<Token>, 'end'>;
+
+interface CaseSegment {
+  kind: 'when' | 'then' | 'else';
+  text: string;
+}
+
+type ScanCase<
+  Sql extends string,
+  CurrentKind extends CaseSegment['kind'],
+  CurrentText extends string,
+  Segments extends readonly CaseSegment[],
+  Depth extends unknown[] = [],
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? IsCaseToken<Head> extends true
+    ? ScanCase<
+        Tail,
+        CurrentKind,
+        CurrentText extends '' ? Head : `${CurrentText} ${Head}`,
+        Segments,
+        [...Depth, unknown]
+      >
+    : IsEndToken<Head> extends true
+      ? Depth extends [unknown, ...infer Rest extends unknown[]]
+        ? ScanCase<
+            Tail,
+            CurrentKind,
+            CurrentText extends '' ? Head : `${CurrentText} ${Head}`,
+            Segments,
+            Rest
+          >
+        : ScanCase<Tail, CurrentKind, CurrentText, Segments, Depth>
+      : Depth extends []
+        ? IsKeyword<Head, 'when'> extends true
+          ? ScanCase<
+              Tail,
+              'when',
+              '',
+              [...Segments, { kind: CurrentKind; text: Trim<CurrentText> }]
+            >
+          : IsKeyword<Head, 'then'> extends true
+            ? ScanCase<
+                Tail,
+                'then',
+                '',
+                [...Segments, { kind: CurrentKind; text: Trim<CurrentText> }]
+              >
+            : IsKeyword<Head, 'else'> extends true
+              ? ScanCase<
+                  Tail,
+                  'else',
+                  '',
+                  [...Segments, { kind: CurrentKind; text: Trim<CurrentText> }]
+                >
+              : ScanCase<
+                  Tail,
+                  CurrentKind,
+                  CurrentText extends '' ? Head : `${CurrentText} ${Head}`,
+                  Segments,
+                  Depth
+                >
+        : ScanCase<
+            Tail,
+            CurrentKind,
+            CurrentText extends '' ? Head : `${CurrentText} ${Head}`,
+            Segments,
+            Depth
+          >
+  : [
+      ...Segments,
+      {
+        kind: CurrentKind;
+        text: Trim<CurrentText extends '' ? Sql : `${CurrentText} ${Sql}`>;
+      },
+    ];
+
+type HasElse<Segments extends readonly CaseSegment[]> =
+  Segments extends readonly [
+    infer Head extends CaseSegment,
+    ...infer Tail extends CaseSegment[],
+  ]
+    ? Head['kind'] extends 'else'
+      ? true
+      : HasElse<Tail>
+    : false;
+
+type InferCaseBranches<
+  DB,
+  CurrentScope,
+  Segments extends readonly CaseSegment[],
+  Values = never,
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Segments extends readonly [
+  infer Head extends CaseSegment,
+  ...infer Tail extends CaseSegment[],
+]
+  ? Head['kind'] extends 'then' | 'else'
+    ? InferExpression<DB, CurrentScope, Head['text']> extends ExpressionResult<
+        infer Value,
+        infer BranchDiagnostics
+      >
+      ? InferCaseBranches<
+          DB,
+          CurrentScope,
+          Tail,
+          Values | Value,
+          [...Diagnostics, ...BranchDiagnostics]
+        >
+      : never
+    : InferCaseBranches<DB, CurrentScope, Tail, Values, Diagnostics>
+  : ExpressionResult<Values, Diagnostics>;
+
+type SplitLastWord<
+  Sql extends string,
+  Before extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? SplitLastWord<Tail, Before extends '' ? Head : `${Before} ${Head}`>
+  : { before: Before; last: Sql };
+
+type InferCase<
+  DB,
+  CurrentScope,
+  Expression extends string,
+> = SplitLastWord<DropFirstWord<Trim<Expression>>> extends {
+  before: infer Body extends string;
+  last: infer End extends string;
+}
+  ? IsKeyword<End, 'end'> extends true
+    ? ScanCase<Body, 'when', '', []> extends infer Segments extends readonly CaseSegment[]
+      ? InferCaseBranches<DB, CurrentScope, Segments> extends ExpressionResult<
+          infer Value,
+          infer Diagnostics
+        >
+        ? ExpressionResult<HasElse<Segments> extends true ? Value : Value | null, Diagnostics>
+        : never
+      : never
+    : ExpressionResult<unknown>
+  : ExpressionResult<unknown>;
+
+type InferReference<
+  DB,
+  CurrentScope,
+  Expression extends string,
+> = ResolveColumn<
+  DB,
+  CurrentScope,
+  Qualifier<Expression> extends '' ? null : Unquote<Qualifier<Expression>>,
+  Unquote<StripQualifier<Expression>>
+> extends infer Resolution
+  ? Resolution extends { kind: 'ok'; value: infer Value }
+    ? ExpressionResult<Value>
+    : Resolution extends {
+        kind: 'error';
+        diagnostic: infer Error extends Diagnostic;
+      }
+      ? ExpressionResult<unknown, [Error]>
+      : never
+  : never;
+
+type InferFunction<
+  DB,
+  CurrentScope,
+  Expression extends string,
+> = InferArguments<
+  DB,
+  CurrentScope,
+  FunctionArguments<Expression>
+> extends infer Diagnostics extends readonly Diagnostic[]
+  ? ExpressionResult<FunctionReturnType<Expression>, Diagnostics>
+  : never;
+
+export type InferExpression<
+  DB,
+  CurrentScope,
+  Expression extends string,
+> = Trim<Expression> extends infer Value extends string
+  ? IsCaseToken<FirstWord<Value>> extends true
+    ? InferCase<DB, CurrentScope, Value>
+    : Value extends `${infer Operand}::${string}`
+      ? InferReference<DB, CurrentScope, Trim<Operand>> extends ExpressionResult<
+          unknown,
+          infer Diagnostics
+        >
+        ? ExpressionResult<unknown, Diagnostics>
+        : never
+      : IsFunctionCall<Value> extends true
+        ? InferFunction<DB, CurrentScope, Value>
+        : [LiteralType<Value>] extends [never]
+          ? IsOperatorExpression<Value> extends true
+            ? ExpressionResult<unknown>
+            : InferReference<DB, CurrentScope, Value>
+          : ExpressionResult<LiteralType<Value>>
+  : never;

--- a/src/compiler/next/infer-expression.ts
+++ b/src/compiler/next/infer-expression.ts
@@ -14,6 +14,8 @@ import type {
   IsFunctionCall,
 } from '../semantics/functions.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { CompileFatal, CompileOk } from '../contracts/compilation.js';
+import type { CompileSelect } from './compile-select.js';
 import type { ResolveColumn } from './resolve-column.js';
 
 export type ExpressionResult<
@@ -260,12 +262,65 @@ type InferFunction<
   ? ExpressionResult<FunctionReturnType<Expression>, Diagnostics>
   : never;
 
+type ScalarSubqueryInner<Expression extends string> =
+  Trim<Expression> extends `(${infer AfterOpen}`
+    ? ExtractParenGroup<AfterOpen> extends {
+        inner: infer Inner extends string;
+        rest: infer Rest extends string;
+      }
+      ? Trim<Rest> extends ''
+        ? IsKeyword<FirstWord<Trim<Inner>>, 'select'> extends true
+          ? Trim<Inner>
+          : never
+        : never
+      : never
+    : never;
+
+type IsUnion<Value, Whole = Value> =
+  Value extends Whole ? ([Whole] extends [Value] ? false : true) : never;
+
+type IsCountQuery<Query extends string> = Lowercase<
+  FirstWord<DropFirstWord<Query>>
+> extends `count(${string}`
+  ? true
+  : false;
+
+type InvalidScalarSubquery = Diagnostic<
+  'INVALID_SCALAR_SUBQUERY',
+  'scalar subquery must select exactly one column',
+  'error',
+  'select',
+  'subquery'
+>;
+
+type InferScalarSubquery<
+  DB,
+  CurrentScope,
+  Query extends string,
+> = CompileSelect<DB, Query, CurrentScope> extends infer Compiled
+  ? Compiled extends CompileOk<infer Rows extends readonly unknown[], infer Diagnostics>
+    ? Rows[number] extends infer Row
+      ? IsUnion<keyof Row> extends true
+        ? ExpressionResult<unknown, [...Diagnostics, InvalidScalarSubquery]>
+        : ExpressionResult<
+            IsCountQuery<Query> extends true
+              ? Row[keyof Row]
+              : Row[keyof Row] | null,
+            Diagnostics
+          >
+      : ExpressionResult<unknown, Diagnostics>
+    : Compiled extends CompileFatal<unknown[], infer Diagnostics>
+      ? ExpressionResult<unknown, Diagnostics>
+      : never
+  : never;
+
 export type InferExpression<
   DB,
   CurrentScope,
   Expression extends string,
 > = Trim<Expression> extends infer Value extends string
-  ? IsCaseToken<FirstWord<Value>> extends true
+  ? [ScalarSubqueryInner<Value>] extends [never]
+    ? IsCaseToken<FirstWord<Value>> extends true
     ? InferCase<DB, CurrentScope, Value>
     : Value extends `${infer Operand}::${string}`
       ? InferReference<DB, CurrentScope, Trim<Operand>> extends ExpressionResult<
@@ -281,4 +336,5 @@ export type InferExpression<
             ? ExpressionResult<unknown>
             : InferReference<DB, CurrentScope, Value>
           : ExpressionResult<LiteralType<Value>>
+    : InferScalarSubquery<DB, CurrentScope, ScalarSubqueryInner<Value>>
   : never;

--- a/src/compiler/next/infer-params.ts
+++ b/src/compiler/next/infer-params.ts
@@ -257,11 +257,17 @@ type FunctionName<Token extends string> =
   Token extends `${infer Name}(${string}` ? Lowercase<Name> : '';
 
 type ContextValue<DB, CurrentScope, Expression extends string> =
-  Expression extends `${string}(${string}`
-    ? InferExpression<DB, CurrentScope, Expression> extends { value: infer Value }
-      ? Value
-      : unknown
-    : ColumnType<DB, CurrentScope, Expression>;
+  Expression extends `'${string}'`
+    ? string
+    : Expression extends `${number}`
+      ? number
+      : Lowercase<Expression> extends 'true' | 'false'
+        ? boolean
+        : Expression extends `${string}(${string}`
+          ? InferExpression<DB, CurrentScope, Expression> extends { value: infer Value }
+            ? Value
+            : unknown
+          : ColumnType<DB, CurrentScope, Expression>;
 
 type ParamValue<
   DB,
@@ -449,4 +455,9 @@ export type InferNextParams<DB, Sql extends string> =
     ? InferParamsFromIR<DB, IR> extends infer State extends AnyParamState
       ? [...State['indexed'], ...State['sequential']]
       : unknown[]
-    : unknown[];
+    : ParseSelectIR<Sql> extends {
+        kind: 'fatal';
+        diagnostics: readonly [infer Error extends { message: string }, ...unknown[]];
+      }
+      ? [QueryTypeError<Error['message']>]
+      : unknown[];

--- a/src/compiler/next/infer-params.ts
+++ b/src/compiler/next/infer-params.ts
@@ -1,0 +1,452 @@
+import type {
+  Digit,
+  Qualifier,
+  StartsWithIdentifierChar,
+  StripQualifier,
+  Trim,
+  Unquote,
+} from '../../string.js';
+import type { PredicateIR } from '../../language/ir/predicate.js';
+import type {
+  ProjectionIR,
+  SelectQueryIR,
+  SetOperationIR,
+} from '../../language/ir/query.js';
+import type { ExpressionProjectionIR } from '../../language/ir/projection.js';
+import type { ParseSelectIR } from '../../language/select/parse-select.js';
+import type { QueryTypeError } from '../contracts/public-error.js';
+import type { InferExpression } from './infer-expression.js';
+import type { ResolveColumn } from './resolve-column.js';
+import type { RootScope } from './scope.js';
+
+type Operator = '=' | '<>' | '!=' | '<' | '>' | '<=' | '>=' | '@>' | '<@';
+type WordOperator = 'like' | 'ilike' | 'in' | 'between' | 'distinct';
+
+type IsOperator<Token extends string> = Token extends Operator
+  ? true
+  : Lowercase<Token> extends WordOperator
+    ? true
+    : false;
+
+type IsTransparent<Token extends string> = Token extends '(' | ')' | ','
+  ? true
+  : Lowercase<Token> extends 'and' | 'or' | 'not' | 'is' | 'from'
+    ? true
+    : false;
+
+type StripLeadingParens<Value extends string> =
+  Value extends `(${infer Rest}` ? StripLeadingParens<Rest> : Value;
+
+type StripTrailingPunctuation<Value extends string> =
+  Value extends `${infer Rest})` | `${infer Rest},`
+    ? StripTrailingPunctuation<Rest>
+    : Value;
+
+type StripCast<Value extends string> =
+  Value extends `${infer Before}::${string}` ? Before : Value;
+
+type AfterLastOpenParen<Value extends string> =
+  Value extends `${string}(${infer Rest}`
+    ? Rest extends `${string}(${string}`
+      ? AfterLastOpenParen<Rest>
+      : Rest
+    : Value;
+
+type StripCallWrapper<Value extends string> =
+  Value extends `${string}(${string}`
+    ? AfterLastOpenParen<Value> extends infer Inner extends string
+      ? Inner extends `${string},${string}`
+        ? Value
+        : Inner
+      : Value
+    : Value;
+
+type CleanScanToken<Token extends string> = StripCast<
+  StripCallWrapper<StripTrailingPunctuation<StripLeadingParens<Token>>>
+>;
+
+type CleanColumnToken<Token extends string> =
+  StripLeadingParens<Token> extends infer Clean extends string
+    ? Clean extends `${string}(${string}`
+      ? Clean
+      : StripTrailingPunctuation<Clean>
+    : never;
+
+type IsPlaceholder<Token extends string> =
+  CleanScanToken<Token> extends `${string},${string}`
+    ? false
+    : CleanScanToken<Token> extends '?'
+      ? true
+      : Lowercase<CleanScanToken<Token>> extends '$action'
+        ? false
+        : CleanScanToken<Token> extends `$$${string}` | `@@${string}`
+          ? false
+          : CleanScanToken<Token> extends `$${infer Body}`
+            ? StartsWithIdentifierChar<Body>
+            : CleanScanToken<Token> extends `@${infer Body}` | `:${infer Body}`
+              ? StartsWithIdentifierChar<Body>
+              : false;
+
+interface DigitCounters {
+  '0': [];
+  '1': [unknown];
+  '2': [unknown, unknown];
+  '3': [unknown, unknown, unknown];
+  '4': [unknown, unknown, unknown, unknown];
+  '5': [unknown, unknown, unknown, unknown, unknown];
+  '6': [unknown, unknown, unknown, unknown, unknown, unknown];
+  '7': [unknown, unknown, unknown, unknown, unknown, unknown, unknown];
+  '8': [unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown];
+  '9': [unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown, unknown];
+}
+
+type TimesTen<Counter extends unknown[]> = [
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+  ...Counter,
+];
+
+type DigitsToCounter<
+  Value extends string,
+  Counter extends unknown[] = [],
+> = Value extends `${infer Head}${infer Rest}`
+  ? Head extends Digit
+    ? DigitsToCounter<
+        Rest,
+        [...TimesTen<Counter>, ...DigitCounters[Head & keyof DigitCounters]]
+      >
+    : never
+  : Counter;
+
+type PlaceholderPosition<Token extends string> =
+  CleanScanToken<Token> extends `$${infer Digits}`
+    ? [DigitsToCounter<Digits>] extends [never]
+      ? never
+      : DigitsToCounter<Digits> extends [
+          unknown,
+          ...infer Position extends unknown[],
+        ]
+        ? Position
+        : never
+    : never;
+
+type PlaceholderName<Token extends string> =
+  CleanScanToken<Token> extends '?' ? never : CleanScanToken<Token>;
+
+type FindNameIndex<
+  Names extends readonly string[],
+  Name extends string,
+  Position extends unknown[] = [],
+> = Names extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? Head extends Name
+    ? Position
+    : FindNameIndex<Tail, Name, [...Position, unknown]>
+  : never;
+
+type MergeSlot<Current, Value, Label extends string> =
+  Current extends QueryTypeError<string>
+    ? Current
+    : [Current & Value] extends [never]
+      ? QueryTypeError<`conflicting types for ${Label}`>
+      : Current & Value;
+
+type SetSlot<
+  Values extends readonly unknown[],
+  Position extends readonly unknown[],
+  Value,
+  Label extends string,
+> = Position extends readonly [unknown, ...infer PositionTail]
+  ? Values extends readonly [infer Head, ...infer ValueTail]
+    ? [Head, ...SetSlot<ValueTail, PositionTail, Value, Label>]
+    : [unknown, ...SetSlot<[], PositionTail, Value, Label>]
+  : Values extends readonly [infer Head, ...infer Tail]
+    ? [MergeSlot<Head, Value, Label>, ...Tail]
+    : [Value];
+
+interface ParamState<
+  Indexed extends readonly unknown[] = [],
+  Sequential extends readonly unknown[] = [],
+  Names extends readonly string[] = [],
+> {
+  indexed: Indexed;
+  sequential: Sequential;
+  names: Names;
+}
+
+type AnyParamState = ParamState<
+  readonly unknown[],
+  readonly unknown[],
+  readonly string[]
+>;
+
+type EmptyParamState = ParamState<[], [], []>;
+
+type AddParam<
+  Token extends string,
+  Value,
+  State extends AnyParamState,
+> = PlaceholderPosition<Token> extends infer Position
+  ? [Position] extends [never]
+    ? [PlaceholderName<Token>] extends [never]
+      ? ParamState<
+          State['indexed'],
+          [...State['sequential'], Value],
+          [...State['names'], '?']
+        >
+      : FindNameIndex<
+            State['names'],
+            PlaceholderName<Token>
+          > extends infer Existing
+        ? [Existing] extends [never]
+          ? ParamState<
+              State['indexed'],
+              [...State['sequential'], Value],
+              [...State['names'], PlaceholderName<Token>]
+            >
+          : Existing extends unknown[]
+            ? ParamState<
+                State['indexed'],
+                SetSlot<
+                  State['sequential'],
+                  Existing,
+                  Value,
+                  CleanScanToken<Token>
+                >,
+                State['names']
+              >
+            : never
+        : never
+    : Position extends unknown[]
+      ? ParamState<
+          SetSlot<
+            State['indexed'],
+            Position,
+            Value,
+            CleanScanToken<Token>
+          >,
+          State['sequential'],
+          State['names']
+        >
+      : never
+  : never;
+
+type ColumnType<
+  DB,
+  CurrentScope,
+  Column extends string,
+> = ResolveColumn<
+  DB,
+  CurrentScope,
+  Qualifier<Column> extends '' ? null : Unquote<Qualifier<Column>>,
+  Unquote<StripQualifier<Column>>
+> extends { kind: 'ok'; value: infer Value }
+  ? Value
+  : unknown;
+
+type FunctionName<Token extends string> =
+  Token extends `${infer Name}(${string}` ? Lowercase<Name> : '';
+
+type ContextValue<DB, CurrentScope, Expression extends string> =
+  Expression extends `${string}(${string}`
+    ? InferExpression<DB, CurrentScope, Expression> extends { value: infer Value }
+      ? Value
+      : unknown
+    : ColumnType<DB, CurrentScope, Expression>;
+
+type ParamValue<
+  DB,
+  CurrentScope,
+  Column extends string,
+  OperatorToken extends string,
+  Token extends string,
+> = Lowercase<OperatorToken> extends 'limit' | 'offset'
+  ? number
+  : IsOperator<OperatorToken> extends true
+    ? FunctionName<Token> extends 'any' | 'all' | 'some'
+      ? NonNullable<ColumnType<DB, CurrentScope, Column>>[]
+      : Lowercase<OperatorToken> extends 'distinct'
+        ? ContextValue<DB, CurrentScope, Column>
+        : unknown extends ContextValue<DB, CurrentScope, Column>
+          ? unknown
+          : NonNullable<ContextValue<DB, CurrentScope, Column>>
+    : unknown;
+
+type ScanFragment<
+  DB,
+  CurrentScope,
+  Sql extends string,
+  State extends AnyParamState,
+  PreviousPrevious extends string = '',
+  Previous extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? IsPlaceholder<Head> extends true
+    ? AddParam<
+        Head,
+        ParamValue<
+          DB,
+          CurrentScope,
+          PreviousPrevious,
+          Previous,
+          Head
+        >,
+        State
+      > extends infer Next extends AnyParamState
+      ? ScanFragment<
+          DB,
+          CurrentScope,
+          Tail,
+          Next,
+          PreviousPrevious,
+          Previous
+        >
+      : never
+    : IsTransparent<Head> extends true
+      ? ScanFragment<
+          DB,
+          CurrentScope,
+          Tail,
+          State,
+          PreviousPrevious,
+          Previous
+        >
+      : ScanFragment<
+          DB,
+          CurrentScope,
+          Tail,
+          State,
+          Previous,
+          CleanColumnToken<Head>
+        >
+  : Sql extends ''
+    ? State
+    : IsPlaceholder<Sql> extends true
+      ? AddParam<
+          Sql,
+          ParamValue<
+            DB,
+            CurrentScope,
+            PreviousPrevious,
+            Previous,
+            Sql
+          >,
+          State
+        >
+      : State;
+
+type ScanPredicates<
+  DB,
+  CurrentScope,
+  Predicates extends readonly PredicateIR[],
+  State extends AnyParamState,
+> = Predicates extends readonly [
+  infer Head extends PredicateIR,
+  ...infer Tail extends PredicateIR[],
+]
+  ? ScanFragment<
+      DB,
+      CurrentScope,
+      Head['fragment'],
+      State
+    > extends infer Next extends AnyParamState
+    ? ScanPredicates<DB, CurrentScope, Tail, Next>
+    : never
+  : State;
+
+type ScanProjections<
+  DB,
+  CurrentScope,
+  Projections extends readonly ProjectionIR[],
+  State extends AnyParamState,
+> = Projections extends readonly [
+  infer Head extends ProjectionIR,
+  ...infer Tail extends ProjectionIR[],
+]
+  ? Head extends ExpressionProjectionIR<infer Fragment, string>
+    ? ScanFragment<
+        DB,
+        CurrentScope,
+        Fragment,
+        State
+      > extends infer Next extends AnyParamState
+      ? ScanProjections<DB, CurrentScope, Tail, Next>
+      : never
+    : ScanProjections<DB, CurrentScope, Tail, State>
+  : State;
+
+type ScanForcedNumber<
+  DB,
+  CurrentScope,
+  Fragment extends string,
+  Keyword extends 'limit' | 'offset',
+  State extends AnyParamState,
+> = Fragment extends ''
+  ? State
+  : ScanFragment<DB, CurrentScope, Fragment, State, '', Keyword>;
+
+type InferSetParams<
+  DB,
+  Operations extends readonly SetOperationIR[],
+  State extends AnyParamState,
+> = Operations extends readonly [
+  infer Head extends SetOperationIR,
+  ...infer Tail extends SetOperationIR[],
+]
+  ? Head['query'] extends infer Query extends SelectQueryIR
+    ? InferParamsFromIR<DB, Query, State> extends infer Next extends AnyParamState
+      ? InferSetParams<DB, Tail, Next>
+      : never
+    : InferSetParams<DB, Tail, State>
+  : State;
+
+type InferParamsFromIR<
+  DB,
+  IR extends SelectQueryIR,
+  State extends AnyParamState = EmptyParamState,
+> = ScanProjections<
+      DB,
+      RootScope<IR['sources']>,
+      IR['projections'],
+      State
+    > extends infer ProjectionState extends AnyParamState
+    ? ScanPredicates<
+        DB,
+        RootScope<IR['sources']>,
+        IR['predicates'],
+        ProjectionState
+      > extends infer PredicateState extends AnyParamState
+      ? ScanForcedNumber<
+          DB,
+          RootScope<IR['sources']>,
+          IR['clauses']['limit'],
+          'limit',
+          PredicateState
+        > extends infer LimitState extends AnyParamState
+        ? ScanForcedNumber<
+            DB,
+            RootScope<IR['sources']>,
+            IR['clauses']['offset'],
+            'offset',
+            LimitState
+          > extends infer OffsetState extends AnyParamState
+          ? InferSetParams<DB, IR['setOperations'], OffsetState>
+          : never
+        : never
+      : never
+    : never;
+
+export type InferNextParams<DB, Sql extends string> =
+  ParseSelectIR<Sql> extends { kind: 'ok'; value: infer IR extends SelectQueryIR }
+    ? InferParamsFromIR<DB, IR> extends infer State extends AnyParamState
+      ? [...State['indexed'], ...State['sequential']]
+      : unknown[]
+    : unknown[];

--- a/src/compiler/next/infer-projection.ts
+++ b/src/compiler/next/infer-projection.ts
@@ -11,7 +11,7 @@ import type {
   TableSourceIR,
 } from '../../language/ir/source.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
-import type { ResolveKey, TableRow } from '../schema/model.js';
+import type { ResolveKey } from '../schema/model.js';
 import type { InferExpression } from './infer-expression.js';
 import type { ResolveColumn } from './resolve-column.js';
 import type { ResolveBinding } from './resolve-source.js';
@@ -50,7 +50,9 @@ type SourceColumns<DB, Source extends SourceIR> =
   >
     ? ResolveKey<DB, Name> extends never
       ? ProjectionResult<{}, [UnknownTable<Name>]>
-      : ProjectionResult<Nullify<TableRow<DB, Name>, Nullable>, []>
+      : ResolveKey<DB, Name> extends infer Key extends keyof DB
+        ? ProjectionResult<Nullify<DB[Key], Nullable>, []>
+        : never
     : Source extends DerivedSourceIR<
           string,
           infer Row,
@@ -136,9 +138,10 @@ type InferColumn<
     : Resolution extends {
           kind: 'error';
           diagnostic: infer Error extends Diagnostic;
+          value: infer Value;
         }
       ? ProjectionResult<
-          AddProperty<Row, Projection['outputName'], unknown>,
+          AddProperty<Row, Projection['outputName'], Value>,
           [...Diagnostics, Error]
         >
       : never

--- a/src/compiler/next/infer-projection.ts
+++ b/src/compiler/next/infer-projection.ts
@@ -4,16 +4,18 @@ import type {
   ExpressionProjectionIR,
   StarProjectionIR,
 } from '../../language/ir/projection.js';
+import type {
+  DerivedSourceIR,
+  JoinKind,
+  SourceIR,
+  TableSourceIR,
+} from '../../language/ir/source.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { ResolveKey, TableRow } from '../schema/model.js';
+import type { InferExpression } from './infer-expression.js';
 import type { ResolveColumn } from './resolve-column.js';
-
-type UnsupportedExpression<Fragment extends string> = Diagnostic<
-  'UNSUPPORTED_EXPRESSION',
-  `unsupported expression: ${Fragment}`,
-  'error',
-  'select',
-  Fragment
->;
+import type { ResolveBinding } from './resolve-source.js';
+import type { Scope } from './scope.js';
 
 type AddProperty<Row, Name extends string, Value> = Row & {
   [Key in Name]: Value;
@@ -25,6 +27,94 @@ type ProjectionResult<Row, Diagnostics extends readonly Diagnostic[]> = {
   row: Row;
   diagnostics: Diagnostics;
 };
+
+type UnknownTable<Name extends string> = Diagnostic<
+  'UNKNOWN_TABLE',
+  `unknown table: ${Name}`,
+  'error',
+  'from',
+  Name
+>;
+
+type Nullify<Row, Nullable extends boolean> = Nullable extends true
+  ? { [Key in keyof Row]: Row[Key] | null }
+  : Row;
+
+type SourceColumns<DB, Source extends SourceIR> =
+  Source extends TableSourceIR<
+    infer Name,
+    string,
+    infer Nullable,
+    JoinKind,
+    readonly string[]
+  >
+    ? ResolveKey<DB, Name> extends never
+      ? ProjectionResult<{}, [UnknownTable<Name>]>
+      : ProjectionResult<Nullify<TableRow<DB, Name>, Nullable>, []>
+    : Source extends DerivedSourceIR<
+          string,
+          infer Row,
+          infer Nullable,
+          JoinKind
+        >
+      ? ProjectionResult<Nullify<Row, Nullable>, []>
+      : ProjectionResult<{}, []>;
+
+type ExpandSources<
+  DB,
+  Sources extends readonly SourceIR[],
+  Row = {},
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Sources extends readonly [
+  infer Head extends SourceIR,
+  ...infer Tail extends SourceIR[],
+]
+  ? SourceColumns<DB, Head> extends ProjectionResult<
+      infer Columns,
+      infer SourceDiagnostics
+    >
+    ? ExpandSources<
+        DB,
+        Tail,
+        Row & Columns,
+        [...Diagnostics, ...SourceDiagnostics]
+      >
+    : never
+  : ProjectionResult<Row, Diagnostics>;
+
+type InferStar<
+  DB,
+  CurrentScope,
+  Qualifier extends string | null,
+  Row,
+  Diagnostics extends readonly Diagnostic[],
+> = CurrentScope extends Scope<infer Sources, unknown>
+  ? Qualifier extends string
+    ? ResolveBinding<CurrentScope, Qualifier> extends infer Binding
+      ? Binding extends { kind: 'ok'; value: infer Source extends SourceIR }
+        ? SourceColumns<DB, Source> extends ProjectionResult<
+            infer Columns,
+            infer StarDiagnostics
+          >
+          ? ProjectionResult<
+              Row & Columns,
+              [...Diagnostics, ...StarDiagnostics]
+            >
+          : never
+        : Binding extends {
+            kind: 'error';
+            diagnostic: infer Error extends Diagnostic;
+          }
+          ? ProjectionResult<Row, [...Diagnostics, Error]>
+          : never
+      : never
+    : ExpandSources<DB, Sources> extends ProjectionResult<
+        infer Columns,
+        infer StarDiagnostics
+      >
+      ? ProjectionResult<Row & Columns, [...Diagnostics, ...StarDiagnostics]>
+      : never
+  : never;
 
 type InferColumn<
   DB,
@@ -63,12 +153,27 @@ type InferOne<
 > = Projection extends ColumnProjectionIR
   ? InferColumn<DB, CurrentScope, Projection, Row, Diagnostics>
   : Projection extends ExpressionProjectionIR
-    ? ProjectionResult<
-        AddProperty<Row, Projection['outputName'], unknown>,
-        [...Diagnostics, UnsupportedExpression<Projection['fragment']>]
-      >
-    : Projection extends StarProjectionIR
-      ? ProjectionResult<Row, [...Diagnostics, UnsupportedExpression<'*'>]>
+    ? InferExpression<
+        DB,
+        CurrentScope,
+        Projection['fragment']
+      > extends {
+        value: infer Value;
+        diagnostics: infer ExpressionDiagnostics extends readonly Diagnostic[];
+      }
+      ? ProjectionResult<
+          AddProperty<Row, Projection['outputName'], Value>,
+          [...Diagnostics, ...ExpressionDiagnostics]
+        >
+      : never
+    : Projection extends StarProjectionIR<string | null>
+      ? InferStar<
+          DB,
+          CurrentScope,
+          Projection['qualifier'],
+          Row,
+          Diagnostics
+        >
       : never;
 
 export type InferProjections<

--- a/src/compiler/next/resolve-column.ts
+++ b/src/compiler/next/resolve-column.ts
@@ -4,7 +4,7 @@ import type {
   SourceIR,
   TableSourceIR,
 } from '../../language/ir/source.js';
-import type { ColumnValue, ResolveKey, TableRow } from '../schema/model.js';
+import type { ColumnValue, ResolveKey } from '../schema/model.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { Scope } from './scope.js';
 import type {
@@ -46,14 +46,15 @@ type ResolveTableColumn<
   Column extends string,
 > = ResolveKey<DB, Source['name']> extends never
   ? ResolveError<UnknownTable<Source['name']>>
-  : ResolveKey<TableRow<DB, Source['name']>, Column> extends never
-    ? ResolveError<UnknownColumn<Column>>
-    : ResolveOk<
-        WithNullability<
-          ColumnValue<TableRow<DB, Source['name']>, Column>,
-          Source['nullable']
-        >
-      >;
+  : ResolveKey<DB, Source['name']> extends infer Table extends keyof DB
+    ? ResolveKey<DB[Table], Column> extends infer Key
+      ? [Key] extends [never]
+        ? ResolveError<UnknownColumn<Column>>
+        : Key extends keyof DB[Table]
+          ? ResolveOk<WithNullability<DB[Table][Key], Source['nullable']>>
+          : never
+      : never
+    : never;
 
 type ResolveDerivedColumn<
   Source extends DerivedSourceIR<string, unknown, boolean, JoinKind>,
@@ -143,8 +144,8 @@ type ResolveUnqualified<
   ? LocalColumnMatches<DB, Sources, Column> extends infer Matches extends unknown[]
     ? Matches extends [infer Value]
       ? ResolveOk<Value>
-      : Matches extends [unknown, unknown, ...unknown[]]
-        ? ResolveError<AmbiguousColumn<Column>>
+      : Matches extends [infer First, unknown, ...unknown[]]
+        ? ResolveError<AmbiguousColumn<Column>, First>
         : Parent extends Scope<readonly SourceIR[], unknown>
           ? ResolveUnqualified<DB, Parent, Column>
           : ResolveError<UnknownColumn<Column>>

--- a/src/compiler/next/resolve-column.ts
+++ b/src/compiler/next/resolve-column.ts
@@ -1,4 +1,9 @@
-import type { SourceIR, TableSourceIR } from '../../language/ir/source.js';
+import type {
+  DerivedSourceIR,
+  JoinKind,
+  SourceIR,
+  TableSourceIR,
+} from '../../language/ir/source.js';
 import type { ColumnValue, ResolveKey, TableRow } from '../schema/model.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { Scope } from './scope.js';
@@ -37,7 +42,7 @@ type WithNullability<Value, Nullable extends boolean> =
 
 type ResolveTableColumn<
   DB,
-  Source extends TableSourceIR,
+  Source extends TableSourceIR<string, string, boolean, JoinKind, readonly string[]>,
   Column extends string,
 > = ResolveKey<DB, Source['name']> extends never
   ? ResolveError<UnknownTable<Source['name']>>
@@ -50,16 +55,67 @@ type ResolveTableColumn<
         >
       >;
 
+type ResolveDerivedColumn<
+  Source extends DerivedSourceIR<string, unknown, boolean, JoinKind>,
+  Column extends string,
+> = ResolveKey<Source['query'], Column> extends never
+  ? ResolveError<UnknownColumn<Column>>
+  : ResolveOk<
+      WithNullability<
+        ColumnValue<Source['query'], Column>,
+        Source['nullable']
+      >
+    >;
+
+type ResolveSourceColumn<
+  DB,
+  Source extends SourceIR,
+  Column extends string,
+> = Source extends TableSourceIR<
+  string,
+  string,
+  boolean,
+  JoinKind,
+  readonly string[]
+>
+  ? ResolveTableColumn<DB, Source, Column>
+  : Source extends DerivedSourceIR<string, unknown, boolean, JoinKind>
+    ? ResolveDerivedColumn<Source, Column>
+    : never;
+
 type ResolveQualified<
   DB,
   CurrentScope,
   Qualifier extends string,
   Column extends string,
 > = ResolveBinding<CurrentScope, Qualifier> extends infer Binding
-  ? Binding extends ResolveOk<infer Source extends TableSourceIR>
-    ? ResolveTableColumn<DB, Source, Column>
+  ? Binding extends ResolveOk<infer Source extends SourceIR>
+    ? ResolveSourceColumn<DB, Source, Column>
     : Binding
   : never;
+
+type Includes<
+  Values extends readonly string[],
+  Name extends string,
+> = Values extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? Lowercase<Head> extends Lowercase<Name>
+    ? true
+    : Includes<Tail, Name>
+  : false;
+
+type IsMerged<Source extends SourceIR, Column extends string> =
+  Source extends TableSourceIR<
+    string,
+    string,
+    boolean,
+    JoinKind,
+    infer Merged
+  >
+    ? Includes<Merged, Column>
+    : false;
 
 type LocalColumnMatches<
   DB,
@@ -70,24 +126,13 @@ type LocalColumnMatches<
   infer Head extends SourceIR,
   ...infer Tail extends SourceIR[],
 ]
-  ? Head extends TableSourceIR
-    ? ResolveKey<DB, Head['name']> extends never
-      ? LocalColumnMatches<DB, Tail, Column, Matches>
-      : ResolveKey<TableRow<DB, Head['name']>, Column> extends never
+  ? ResolveSourceColumn<DB, Head, Column> extends infer Resolution
+    ? Resolution extends ResolveOk<infer Value>
+      ? IsMerged<Head, Column> extends true
         ? LocalColumnMatches<DB, Tail, Column, Matches>
-        : LocalColumnMatches<
-            DB,
-            Tail,
-            Column,
-            [
-              ...Matches,
-              WithNullability<
-                ColumnValue<TableRow<DB, Head['name']>, Column>,
-                Head['nullable']
-              >,
-            ]
-          >
-    : LocalColumnMatches<DB, Tail, Column, Matches>
+        : LocalColumnMatches<DB, Tail, Column, [...Matches, Value]>
+      : LocalColumnMatches<DB, Tail, Column, Matches>
+    : never
   : Matches;
 
 type ResolveUnqualified<

--- a/src/compiler/next/resolve-source.ts
+++ b/src/compiler/next/resolve-source.ts
@@ -4,9 +4,10 @@ import type { Scope } from './scope.js';
 
 export type ResolveOk<Value> = { kind: 'ok'; value: Value };
 
-export type ResolveError<Error extends Diagnostic> = {
+export type ResolveError<Error extends Diagnostic, Value = unknown> = {
   kind: 'error';
   diagnostic: Error;
+  value: Value;
 };
 
 type Matches<Source extends SourceIR, Name extends string> =

--- a/src/compiler/semantics/functions.ts
+++ b/src/compiler/semantics/functions.ts
@@ -1,0 +1,59 @@
+import type { Trim } from '../../string.js';
+
+export interface FunctionReturnTypes {
+  count: number;
+  sum: number;
+  avg: number;
+  min: number;
+  max: number;
+  length: number;
+  char_length: number;
+  octet_length: number;
+  abs: number;
+  ceil: number;
+  floor: number;
+  round: number;
+  power: number;
+  mod: number;
+  greatest: number;
+  least: number;
+  lower: string;
+  upper: string;
+  trim: string;
+  ltrim: string;
+  rtrim: string;
+  concat: string;
+  coalesce: unknown;
+  nullif: unknown;
+  now: Date;
+  current_timestamp: Date;
+  current_date: Date;
+  row_number: number;
+  rank: number;
+  dense_rank: number;
+  ntile: number;
+  percent_rank: number;
+  cume_dist: number;
+  lag: unknown;
+  lead: unknown;
+  first_value: unknown;
+  last_value: unknown;
+  nth_value: unknown;
+}
+
+export type FunctionName<Expression extends string> =
+  Expression extends `${infer Name}(${string}` ? Trim<Name> : Expression;
+
+export type IsFunctionCall<Expression extends string> =
+  Expression extends `${string}(${string})`
+    ? Trim<FunctionName<Expression>> extends ''
+      ? false
+      : true
+    : false;
+
+export type FunctionOutputName<Expression extends string> = FunctionName<Expression>;
+
+export type FunctionReturnType<Expression extends string> =
+  Lowercase<FunctionName<Expression>> extends keyof FunctionReturnTypes
+    ? FunctionReturnTypes[Lowercase<FunctionName<Expression>>]
+    : unknown;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,64 +1,7 @@
-import type { Trim } from './string.js';
-
-export interface FunctionReturnTypes {
-  count: number;
-  sum: number;
-  avg: number;
-  min: number;
-  max: number;
-  length: number;
-  char_length: number;
-  octet_length: number;
-  abs: number;
-  ceil: number;
-  floor: number;
-  round: number;
-  power: number;
-  mod: number;
-  greatest: number;
-  least: number;
-  lower: string;
-  upper: string;
-  trim: string;
-  ltrim: string;
-  rtrim: string;
-  concat: string;
-  coalesce: unknown;
-  nullif: unknown;
-  now: Date;
-  current_timestamp: Date;
-  current_date: Date;
-  row_number: number;
-  rank: number;
-  dense_rank: number;
-  ntile: number;
-  percent_rank: number;
-  cume_dist: number;
-  lag: unknown;
-  lead: unknown;
-  first_value: unknown;
-  last_value: unknown;
-  nth_value: unknown;
-}
-
-// The name has to be there. `${string}` happily matches the empty string, so
-// `(id)` - a column in parentheses, which is valid everywhere and something
-// people write around an expression - was read as a call to a function named
-// `''` and typed `unknown`, in strict mode too, after the column had already
-// resolved (issue #288).
-export type IsFunctionCall<Expr extends string> = Expr extends `${string}(${string})`
-  ? Trim<FunctionName<Expr>> extends ''
-    ? false
-    : true
-  : false;
-
-export type FunctionName<Expr extends string> = Expr extends `${infer Name}(${string}`
-  ? Trim<Name>
-  : Expr;
-
-export type FunctionOutputName<Expr extends string> = FunctionName<Expr>;
-
-export type FunctionReturnType<Expr extends string> =
-  Lowercase<FunctionName<Expr>> extends keyof FunctionReturnTypes
-    ? FunctionReturnTypes[Lowercase<FunctionName<Expr>>]
-    : unknown;
+export type {
+  FunctionName,
+  FunctionOutputName,
+  FunctionReturnType,
+  FunctionReturnTypes,
+  IsFunctionCall,
+} from './compiler/semantics/functions.js';

--- a/src/language/dialect/common.ts
+++ b/src/language/dialect/common.ts
@@ -1,0 +1,68 @@
+import type {
+  DropFirstWord,
+  ExtractParenGroup,
+  FirstWord,
+  IsKeyword,
+  Trim,
+} from '../../string.js';
+
+export interface DialectCapabilities {
+  top: boolean;
+  distinctOn: boolean;
+  returning: boolean;
+  output: boolean;
+  placeholder: 'dollar' | 'question' | 'at' | 'mixed';
+  quote: 'double' | 'backtick' | 'bracket' | 'mixed';
+}
+
+type StripTopCount<Sql extends string> = Trim<Sql> extends `(${infer Rest}`
+  ? ExtractParenGroup<Rest> extends { rest: infer Tail extends string }
+    ? Trim<Tail>
+    : Trim<Sql>
+  : DropFirstWord<Trim<Sql>>;
+
+type StripWithTies<Sql extends string> = IsKeyword<FirstWord<Sql>, 'with'> extends true
+  ? IsKeyword<FirstWord<DropFirstWord<Sql>>, 'ties'> extends true
+    ? Trim<DropFirstWord<DropFirstWord<Sql>>>
+    : Sql
+  : Sql;
+
+type HasTopCount<Sql extends string> = Trim<Sql> extends `(${string}`
+  ? true
+  : FirstWord<Trim<Sql>> extends `${number}`
+    ? true
+    : false;
+
+type StripTop<Sql extends string> = IsKeyword<FirstWord<Trim<Sql>>, 'top'> extends true
+  ? HasTopCount<DropFirstWord<Trim<Sql>>> extends true
+    ? StripTopCount<DropFirstWord<Trim<Sql>>> extends infer Tail extends string
+      ? IsKeyword<FirstWord<Tail>, 'percent'> extends true
+        ? StripWithTies<Trim<DropFirstWord<Tail>>>
+        : StripWithTies<Tail>
+      : Sql
+    : Sql
+  : Sql;
+
+type AfterDistinctOn<Sql extends string> = IsKeyword<FirstWord<Sql>, 'on'> extends true
+  ? Trim<DropFirstWord<Sql>>
+  : Trim<Sql> extends `${infer Head}(${infer Rest}`
+    ? IsKeyword<Head, 'on'> extends true
+      ? `(${Rest}`
+      : never
+    : never;
+
+type StripDistinctOn<Sql extends string> = [AfterDistinctOn<Sql>] extends [never]
+  ? Sql
+  : AfterDistinctOn<Sql> extends `(${infer Rest}`
+    ? ExtractParenGroup<Rest> extends { rest: infer Tail extends string }
+      ? Trim<Tail>
+      : Sql
+    : Sql;
+
+type StripDistinct<Sql extends string> = IsKeyword<FirstWord<Trim<Sql>>, 'distinct'> extends true
+  ? StripDistinctOn<Trim<DropFirstWord<Trim<Sql>>>>
+  : IsKeyword<FirstWord<Trim<Sql>>, 'all'> extends true
+    ? Trim<DropFirstWord<Trim<Sql>>>
+    : Sql;
+
+export type StripSelectModifiers<Sql extends string> = StripTop<StripDistinct<Sql>>;

--- a/src/language/dialect/common.ts
+++ b/src/language/dialect/common.ts
@@ -65,4 +65,9 @@ type StripDistinct<Sql extends string> = IsKeyword<FirstWord<Trim<Sql>>, 'distin
     ? Trim<DropFirstWord<Trim<Sql>>>
     : Sql;
 
-export type StripSelectModifiers<Sql extends string> = StripTop<StripDistinct<Sql>>;
+export type StripSelectModifiers<Sql extends string> = Lowercase<FirstWord<Trim<Sql>>> extends
+  | 'top'
+  | 'distinct'
+  | 'all'
+  ? StripTop<StripDistinct<Sql>>
+  : Sql;

--- a/src/language/dialect/mssql.ts
+++ b/src/language/dialect/mssql.ts
@@ -1,0 +1,10 @@
+import type { DialectCapabilities } from './common.js';
+
+export interface MssqlCapabilities extends DialectCapabilities {
+  top: true;
+  distinctOn: false;
+  returning: false;
+  output: true;
+  placeholder: 'at';
+  quote: 'bracket';
+}

--- a/src/language/dialect/mysql.ts
+++ b/src/language/dialect/mysql.ts
@@ -1,0 +1,10 @@
+import type { DialectCapabilities } from './common.js';
+
+export interface MysqlCapabilities extends DialectCapabilities {
+  top: false;
+  distinctOn: false;
+  returning: false;
+  output: false;
+  placeholder: 'question';
+  quote: 'backtick';
+}

--- a/src/language/dialect/postgres.ts
+++ b/src/language/dialect/postgres.ts
@@ -1,0 +1,10 @@
+import type { DialectCapabilities } from './common.js';
+
+export interface PostgresCapabilities extends DialectCapabilities {
+  top: false;
+  distinctOn: true;
+  returning: true;
+  output: false;
+  placeholder: 'dollar';
+  quote: 'double';
+}

--- a/src/language/dialect/sqlite.ts
+++ b/src/language/dialect/sqlite.ts
@@ -1,0 +1,10 @@
+import type { DialectCapabilities } from './common.js';
+
+export interface SqliteCapabilities extends DialectCapabilities {
+  top: false;
+  distinctOn: false;
+  returning: true;
+  output: false;
+  placeholder: 'mixed';
+  quote: 'mixed';
+}

--- a/src/language/ir/predicate.ts
+++ b/src/language/ir/predicate.ts
@@ -1,5 +1,5 @@
 export interface PredicateIR<
-  Location extends 'join-on' | 'where' | 'having' = 'where',
+  Location extends 'join-on' | 'where' | 'having' = 'join-on' | 'where' | 'having',
   Fragment extends string = string,
 > {
   kind: 'predicate';

--- a/src/language/ir/query.ts
+++ b/src/language/ir/query.ts
@@ -13,12 +13,46 @@ export type ProjectionIR =
   | ExpressionProjectionIR
   | StarProjectionIR<string | null>;
 
+export interface SelectClausesIR<
+  GroupBy extends string = '',
+  OrderBy extends string = '',
+  Limit extends string = '',
+  Offset extends string = '',
+  Window extends string = '',
+> {
+  groupBy: GroupBy;
+  orderBy: OrderBy;
+  limit: Limit;
+  offset: Offset;
+  window: Window;
+}
+
+export interface SetOperationIR<
+  Kind extends 'union' | 'union-all' | 'intersect' | 'except' =
+    | 'union'
+    | 'union-all'
+    | 'intersect'
+    | 'except',
+  Query = unknown,
+> {
+  kind: Kind;
+  query: Query;
+}
+
 export interface SelectQueryIR<
   Sources extends readonly SourceIR[] = readonly SourceIR[],
   Projections extends readonly ProjectionIR[] = readonly ProjectionIR[],
   Predicates extends readonly PredicateIR[] = readonly PredicateIR[],
   Parameters extends readonly ParameterIR[] = readonly ParameterIR[],
   Ctes extends readonly CteIR[] = readonly CteIR[],
+  Clauses extends SelectClausesIR<
+    string,
+    string,
+    string,
+    string,
+    string
+  > = SelectClausesIR<string, string, string, string, string>,
+  SetOperations extends readonly SetOperationIR[] = readonly SetOperationIR[],
 > {
   kind: 'select';
   sources: Sources;
@@ -26,4 +60,6 @@ export interface SelectQueryIR<
   predicates: Predicates;
   parameters: Parameters;
   ctes: Ctes;
+  clauses: Clauses;
+  setOperations: SetOperations;
 }

--- a/src/language/ir/query.ts
+++ b/src/language/ir/query.ts
@@ -11,7 +11,7 @@ import type { SourceIR } from './source.js';
 export type ProjectionIR =
   | ColumnProjectionIR
   | ExpressionProjectionIR
-  | StarProjectionIR;
+  | StarProjectionIR<string | null>;
 
 export interface SelectQueryIR<
   Sources extends readonly SourceIR[] = readonly SourceIR[],

--- a/src/language/ir/source.ts
+++ b/src/language/ir/source.ts
@@ -28,4 +28,6 @@ export interface DerivedSourceIR<
   nullable: Nullable;
 }
 
-export type SourceIR = TableSourceIR | DerivedSourceIR;
+export type SourceIR =
+  | TableSourceIR<string, string, boolean, JoinKind, readonly string[]>
+  | DerivedSourceIR<string, unknown, boolean, JoinKind>;

--- a/src/language/lexical/statement.ts
+++ b/src/language/lexical/statement.ts
@@ -1,4 +1,4 @@
-import type { FirstWord, IsKeyword, Normalize } from '../../string.js';
+import type { FirstWord, IsKeyword, Normalize, Trim } from '../../string.js';
 
 type StatementKindName =
   | 'select'
@@ -18,6 +18,10 @@ type KindOf<Token extends string> =
   : IsKeyword<Token, 'merge'> extends true ? 'merge'
   : 'unknown';
 
-export type StatementKind<Sql extends string> = KindOf<FirstWord<Normalize<Sql>>>;
+export type StatementKind<Sql extends string> = KindOf<FirstWord<Trim<Sql>>> extends infer Direct extends StatementKindName
+  ? Direct extends 'unknown'
+    ? KindOf<FirstWord<Normalize<Sql>>>
+    : Direct
+  : never;
 
 export type ClassifyStatement<Sql extends string> = StatementKind<Sql>;

--- a/src/language/select/parse-from.ts
+++ b/src/language/select/parse-from.ts
@@ -64,6 +64,45 @@ type SplitFromBoundary<
       : { clause: Trim<Before extends '' ? Sql : `${Before} ${Sql}`>; rest: '' }
     : { clause: Trim<Before extends '' ? Sql : `${Before} ${Sql}`>; rest: '' };
 
+type HasBoundary<Sql extends string> = Lowercase<Sql> extends
+  | `${string} where ${string}`
+  | `${string} group ${string}`
+  | `${string} having ${string}`
+  | `${string} order ${string}`
+  | `${string} limit ${string}`
+  | `${string} offset ${string}`
+  | `${string} fetch ${string}`
+  | `${string} window ${string}`
+  | `${string} union ${string}`
+  | `${string} except ${string}`
+  | `${string} intersect ${string}`
+  | `${string} for ${string}`
+  | `${string} returning ${string}`
+  | `${string} output ${string}`
+  ? true
+  : false;
+
+type FastBoundary<Sql extends string> =
+  Sql extends `${infer Clause} where ${infer Rest}`
+    ? { clause: Trim<Clause>; rest: `where ${Rest}` }
+    : Sql extends `${infer Clause} group ${infer Rest}`
+      ? { clause: Trim<Clause>; rest: `group ${Rest}` }
+      : Sql extends `${infer Clause} having ${infer Rest}`
+        ? { clause: Trim<Clause>; rest: `having ${Rest}` }
+        : Sql extends `${infer Clause} order ${infer Rest}`
+          ? { clause: Trim<Clause>; rest: `order ${Rest}` }
+          : Sql extends `${infer Clause} limit ${infer Rest}`
+            ? { clause: Trim<Clause>; rest: `limit ${Rest}` }
+            : Sql extends `${infer Clause} offset ${infer Rest}`
+              ? { clause: Trim<Clause>; rest: `offset ${Rest}` }
+              : SplitFromBoundary<Sql>;
+
+type FromBoundary<Sql extends string> = HasBoundary<Sql> extends false
+  ? { clause: Trim<Sql>; rest: '' }
+  : Lowercase<Sql> extends `${string}(select ${string}`
+    ? SplitFromBoundary<Sql>
+    : FastBoundary<Sql>;
+
 type JoinAfterOuter<
   Tail extends string,
   Kind extends JoinKind,
@@ -150,14 +189,18 @@ type StripLateral<Segment extends string> = Trim<Segment> extends `${infer Head}
     : Trim<Segment>
   : Trim<Segment>;
 
-type UsingColumns<Segment extends string> = Segment extends `${infer Head} ${infer Tail}`
+type ScanUsingColumns<Segment extends string> = Segment extends `${infer Head} ${infer Tail}`
   ? IsKeyword<Head, 'using'> extends true
     ? Trim<Tail> extends `(${infer AfterOpen}`
       ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string }
         ? SplitColumnList<Inner>
         : []
       : []
-    : UsingColumns<Tail>
+    : ScanUsingColumns<Tail>
+  : [];
+
+type UsingColumns<Segment extends string> = Lowercase<Segment> extends `${string} using ${string}`
+  ? ScanUsingColumns<Segment>
   : [];
 
 type IsNullable<Kind extends JoinKind> = Kind extends 'left' | 'full'
@@ -203,10 +246,17 @@ type SegmentSource<
   ? DerivedSource<Segment, Kind>
   : TableSource<Segment, Kind>;
 
+type SourceParts<Segment extends string> = Segment extends
+  | `${string},${string}`
+  | `${string}(${string}`
+  | `${string})${string}`
+  ? SplitColumnList<Segment>
+  : [Trim<Segment>];
+
 type SegmentSources<
   Segment extends string,
   Kind extends JoinKind,
-  Parts extends readonly string[] = SplitColumnList<Segment>,
+  Parts extends readonly string[] = SourceParts<Segment>,
 > = Parts extends readonly [
   infer Head extends string,
   ...infer Tail extends string[],
@@ -258,13 +308,22 @@ type NullablePrevious<
   Sources extends readonly SourceIR[],
 > = Kind extends 'right' | 'full' ? MarkNullable<Sources> : Sources;
 
+type HasJoin<Sql extends string> = Lowercase<Sql> extends `${string} join ${string}`
+  ? true
+  : false;
+
 type CollectJoined<
   Sql extends string,
   CurrentKind extends JoinKind,
   Sources extends readonly SourceIR[],
   Predicates extends readonly PredicateIR[],
-> = SplitAtJoin<Sql> extends infer Split
-  ? [Split] extends [never]
+> = HasJoin<Sql> extends false
+  ? {
+      sources: [...Sources, ...SegmentSources<Sql, CurrentKind>];
+      predicates: [...Predicates, ...SegmentPredicates<Sql>];
+    }
+  : SplitAtJoin<Sql> extends infer Split
+    ? [Split] extends [never]
     ? {
         sources: [...Sources, ...SegmentSources<Sql, CurrentKind>];
         predicates: [...Predicates, ...SegmentPredicates<Sql>];
@@ -284,27 +343,29 @@ type CollectJoined<
           [...Predicates, ...SegmentPredicates<Before>]
         >
       : never
-  : never;
+    : never;
 
-type ParseClause<Clause extends string> = SplitAtJoin<Clause> extends infer Split
-  ? [Split] extends [never]
-    ? { sources: SegmentSources<Clause, 'root'>; predicates: [] }
-    : Split extends {
+type ParseClause<Clause extends string> = HasJoin<Clause> extends false
+  ? { sources: SegmentSources<Clause, 'root'>; predicates: [] }
+  : SplitAtJoin<Clause> extends infer Split
+    ? [Split] extends [never]
+      ? { sources: SegmentSources<Clause, 'root'>; predicates: [] }
+      : Split extends {
           before: infer Before extends string;
           kind: infer Kind extends JoinKind;
           after: infer After extends string;
         }
-      ? CollectJoined<
-          After,
-          Kind,
-          NullablePrevious<Kind, SegmentSources<Before, 'root'>>,
-          []
-        >
-      : never
-  : never;
+        ? CollectJoined<
+            After,
+            Kind,
+            NullablePrevious<Kind, SegmentSources<Before, 'root'>>,
+            []
+          >
+        : never
+    : never;
 
 type ParseNormalized<Sql extends string> =
-  SplitFromBoundary<Sql> extends {
+  FromBoundary<Sql> extends {
     clause: infer Clause extends string;
     rest: infer Rest extends string;
   }

--- a/src/language/select/parse-from.ts
+++ b/src/language/select/parse-from.ts
@@ -1,19 +1,319 @@
-import type { IsKeyword, Normalize, Unquote } from '../../string.js';
-import type { TableSourceIR } from '../ir/source.js';
+import type {
+  ApplyParenDelta,
+  DropFirstWord,
+  ExtractParenGroup,
+  FirstWord,
+  IsKeyword,
+  Normalize,
+  SplitColumnList,
+  StripQualifier,
+  Trim,
+  Unquote,
+} from '../../string.js';
+import type { PredicateIR } from '../ir/predicate.js';
+import type {
+  DerivedSourceIR,
+  JoinKind,
+  SourceIR,
+  TableSourceIR,
+} from '../ir/source.js';
 
-type ParseWords<Sql extends string> =
-  Normalize<Sql> extends `${infer Name} ${infer As} ${infer Alias}`
-    ? Alias extends `${string} ${string}`
-      ? never
-      : IsKeyword<As, 'as'> extends true
-        ? TableSourceIR<Unquote<Name>, Unquote<Alias>>
+type ClauseBoundary =
+  | 'where'
+  | 'group'
+  | 'order'
+  | 'limit'
+  | 'having'
+  | 'offset'
+  | 'fetch'
+  | 'window'
+  | 'union'
+  | 'except'
+  | 'intersect'
+  | 'for'
+  | 'returning'
+  | 'output';
+
+type IsBoundary<Word extends string> = Lowercase<Word> extends ClauseBoundary
+  ? true
+  : false;
+
+type SplitFromBoundary<
+  Sql extends string,
+  Depth extends unknown[] = [],
+  Before extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? IsBoundary<Head> extends true
+      ? { clause: Trim<Before>; rest: Trim<`${Head} ${Tail}`> }
+      : SplitFromBoundary<
+          Tail,
+          ApplyParenDelta<Depth, Head>,
+          Before extends '' ? Head : `${Before} ${Head}`
+        >
+    : SplitFromBoundary<
+        Tail,
+        ApplyParenDelta<Depth, Head>,
+        Before extends '' ? Head : `${Before} ${Head}`
+      >
+  : Depth extends []
+    ? IsBoundary<Sql> extends true
+      ? { clause: Trim<Before>; rest: Trim<Sql> }
+      : { clause: Trim<Before extends '' ? Sql : `${Before} ${Sql}`>; rest: '' }
+    : { clause: Trim<Before extends '' ? Sql : `${Before} ${Sql}`>; rest: '' };
+
+type JoinAfterOuter<
+  Tail extends string,
+  Kind extends JoinKind,
+> = IsKeyword<FirstWord<Tail>, 'join'> extends true
+  ? { kind: Kind; rest: DropFirstWord<Tail> }
+  : IsKeyword<FirstWord<Tail>, 'outer'> extends true
+    ? IsKeyword<FirstWord<DropFirstWord<Tail>>, 'join'> extends true
+      ? { kind: Kind; rest: DropFirstWord<DropFirstWord<Tail>> }
+      : never
+    : never;
+
+type JoinPhrase<Head extends string, Tail extends string> =
+  IsKeyword<Head, 'join'> extends true
+    ? { kind: 'inner'; rest: Tail }
+    : IsKeyword<Head, 'inner'> extends true
+      ? IsKeyword<FirstWord<Tail>, 'join'> extends true
+        ? { kind: 'inner'; rest: DropFirstWord<Tail> }
         : never
-    : Normalize<Sql> extends `${infer Name} ${infer Alias}`
-      ? TableSourceIR<Unquote<Name>, Unquote<Alias>>
-      : Normalize<Sql> extends infer Name extends string
-        ? Name extends ''
-          ? never
-          : TableSourceIR<Unquote<Name>, Unquote<Name>>
-        : never;
+      : IsKeyword<Head, 'cross'> extends true
+        ? IsKeyword<FirstWord<Tail>, 'join'> extends true
+          ? { kind: 'cross'; rest: DropFirstWord<Tail> }
+          : never
+        : IsKeyword<Head, 'left'> extends true
+          ? JoinAfterOuter<Tail, 'left'>
+          : IsKeyword<Head, 'right'> extends true
+            ? JoinAfterOuter<Tail, 'right'>
+            : IsKeyword<Head, 'full'> extends true
+              ? JoinAfterOuter<Tail, 'full'>
+              : never;
 
-export type ParseRootSource<Sql extends string> = ParseWords<Sql>;
+type SplitAtJoin<
+  Sql extends string,
+  Depth extends unknown[] = [],
+  Before extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? JoinPhrase<Head, Tail> extends infer Phrase
+      ? [Phrase] extends [never]
+        ? SplitAtJoin<
+            Tail,
+            ApplyParenDelta<Depth, Head>,
+            Before extends '' ? Head : `${Before} ${Head}`
+          >
+        : Phrase extends {
+              kind: infer Kind extends JoinKind;
+              rest: infer Rest extends string;
+            }
+          ? { before: Trim<Before>; kind: Kind; after: Rest }
+          : never
+      : never
+    : SplitAtJoin<
+        Tail,
+        ApplyParenDelta<Depth, Head>,
+        Before extends '' ? Head : `${Before} ${Head}`
+      >
+  : never;
+
+type AliasOf<Segment extends string, Table extends string> =
+  DropFirstWord<Segment> extends ''
+    ? Table
+    : FirstWord<DropFirstWord<Segment>> extends infer Next extends string
+      ? IsKeyword<Next, 'on' | 'using'> extends true
+        ? Table
+        : IsKeyword<Next, 'as'> extends true
+          ? FirstWord<DropFirstWord<DropFirstWord<Segment>>> extends infer Alias extends string
+            ? Alias extends ''
+              ? Table
+              : Alias
+            : Table
+          : Next
+      : Table;
+
+type DerivedAlias<Rest extends string> = Trim<Rest> extends ''
+  ? never
+  : IsKeyword<FirstWord<Trim<Rest>>, 'as'> extends true
+    ? FirstWord<DropFirstWord<Trim<Rest>>>
+    : IsKeyword<FirstWord<Trim<Rest>>, 'on'> extends true
+      ? never
+      : FirstWord<Trim<Rest>>;
+
+type StripLateral<Segment extends string> = Trim<Segment> extends `${infer Head} ${infer Rest}`
+  ? IsKeyword<Head, 'lateral'> extends true
+    ? Trim<Rest>
+    : Trim<Segment>
+  : Trim<Segment>;
+
+type UsingColumns<Segment extends string> = Segment extends `${infer Head} ${infer Tail}`
+  ? IsKeyword<Head, 'using'> extends true
+    ? Trim<Tail> extends `(${infer AfterOpen}`
+      ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string }
+        ? SplitColumnList<Inner>
+        : []
+      : []
+    : UsingColumns<Tail>
+  : [];
+
+type IsNullable<Kind extends JoinKind> = Kind extends 'left' | 'full'
+  ? true
+  : false;
+
+type DerivedSource<
+  Segment extends string,
+  Kind extends JoinKind,
+> = StripLateral<Segment> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends {
+      inner: infer Query extends string;
+      rest: infer Rest extends string;
+    }
+    ? DerivedAlias<Rest> extends infer Alias extends string
+      ? DerivedSourceIR<Unquote<Alias>, Trim<Query>, IsNullable<Kind>, Kind>
+      : never
+    : never
+  : never;
+
+type TableSource<
+  Segment extends string,
+  Kind extends JoinKind,
+> = Unquote<StripQualifier<FirstWord<Segment>>> extends infer Table extends string
+  ? TableSourceIR<
+      Table,
+      Unquote<AliasOf<Segment, Table>>,
+      IsNullable<Kind>,
+      Kind,
+      UsingColumns<Segment>
+    >
+  : never;
+
+type SegmentSource<
+  Segment extends string,
+  Kind extends JoinKind,
+> = StripLateral<Segment> extends `(${string}`
+  ? DerivedSource<Segment, Kind>
+  : TableSource<Segment, Kind>;
+
+type SegmentSources<
+  Segment extends string,
+  Kind extends JoinKind,
+  Parts extends readonly string[] = SplitColumnList<Segment>,
+> = Parts extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? [SegmentSource<Head, Kind>, ...SegmentSources<Segment, Kind, Tail>]
+  : [];
+
+type SplitAtOn<
+  Sql extends string,
+  Depth extends unknown[] = [],
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? IsKeyword<Head, 'on'> extends true
+      ? Trim<Tail>
+      : SplitAtOn<Tail, ApplyParenDelta<Depth, Head>>
+    : SplitAtOn<Tail, ApplyParenDelta<Depth, Head>>
+  : never;
+
+type SegmentPredicates<Segment extends string> =
+  SplitAtOn<Segment> extends infer Fragment
+    ? [Fragment] extends [never]
+      ? []
+      : Fragment extends string
+        ? [PredicateIR<'join-on', Fragment>]
+        : []
+    : [];
+
+type MarkNullable<Sources extends readonly SourceIR[]> = {
+  [Index in keyof Sources]: Sources[Index] extends TableSourceIR<
+    infer Name,
+    infer Alias,
+    boolean,
+    infer Join,
+    infer Merged
+  >
+    ? TableSourceIR<Name, Alias, true, Join, Merged>
+    : Sources[Index] extends DerivedSourceIR<
+          infer Alias,
+          infer Query,
+          boolean,
+          infer Join
+        >
+      ? DerivedSourceIR<Alias, Query, true, Join>
+      : never;
+};
+
+type NullablePrevious<
+  Kind extends JoinKind,
+  Sources extends readonly SourceIR[],
+> = Kind extends 'right' | 'full' ? MarkNullable<Sources> : Sources;
+
+type CollectJoined<
+  Sql extends string,
+  CurrentKind extends JoinKind,
+  Sources extends readonly SourceIR[],
+  Predicates extends readonly PredicateIR[],
+> = SplitAtJoin<Sql> extends infer Split
+  ? [Split] extends [never]
+    ? {
+        sources: [...Sources, ...SegmentSources<Sql, CurrentKind>];
+        predicates: [...Predicates, ...SegmentPredicates<Sql>];
+      }
+    : Split extends {
+          before: infer Before extends string;
+          kind: infer NextKind extends JoinKind;
+          after: infer After extends string;
+        }
+      ? CollectJoined<
+          After,
+          NextKind,
+          NullablePrevious<
+            NextKind,
+            [...Sources, ...SegmentSources<Before, CurrentKind>]
+          >,
+          [...Predicates, ...SegmentPredicates<Before>]
+        >
+      : never
+  : never;
+
+type ParseClause<Clause extends string> = SplitAtJoin<Clause> extends infer Split
+  ? [Split] extends [never]
+    ? { sources: SegmentSources<Clause, 'root'>; predicates: [] }
+    : Split extends {
+          before: infer Before extends string;
+          kind: infer Kind extends JoinKind;
+          after: infer After extends string;
+        }
+      ? CollectJoined<
+          After,
+          Kind,
+          NullablePrevious<Kind, SegmentSources<Before, 'root'>>,
+          []
+        >
+      : never
+  : never;
+
+type ParseNormalized<Sql extends string> =
+  SplitFromBoundary<Sql> extends {
+    clause: infer Clause extends string;
+    rest: infer Rest extends string;
+  }
+    ? ParseClause<Clause> extends {
+        sources: infer Sources extends readonly SourceIR[];
+        predicates: infer Predicates extends readonly PredicateIR[];
+      }
+      ? { sources: Sources; predicates: Predicates; rest: Rest }
+      : never
+    : never;
+
+export type ParseFromSources<Sql extends string> = ParseNormalized<Normalize<Sql>>;
+
+export type ParseNormalizedFromSources<Sql extends string> = ParseNormalized<Sql>;
+
+export type ParseRootSource<Sql extends string> =
+  ParseFromSources<Sql>['sources'] extends readonly [infer Root extends SourceIR]
+    ? Root
+    : never;

--- a/src/language/select/parse-from.ts
+++ b/src/language/select/parse-from.ts
@@ -11,12 +11,14 @@ import type {
   Unquote,
 } from '../../string.js';
 import type { PredicateIR } from '../ir/predicate.js';
+import type { SelectQueryIR } from '../ir/query.js';
 import type {
   DerivedSourceIR,
   JoinKind,
   SourceIR,
   TableSourceIR,
 } from '../ir/source.js';
+import type { ParseSelectIR } from './parse-select.js';
 
 type ClauseBoundary =
   | 'where'
@@ -171,7 +173,12 @@ type DerivedSource<
       rest: infer Rest extends string;
     }
     ? DerivedAlias<Rest> extends infer Alias extends string
-      ? DerivedSourceIR<Unquote<Alias>, Trim<Query>, IsNullable<Kind>, Kind>
+      ? ParseSelectIR<Trim<Query>> extends {
+          kind: 'ok';
+          value: infer Nested extends SelectQueryIR;
+        }
+        ? DerivedSourceIR<Unquote<Alias>, Nested, IsNullable<Kind>, Kind>
+        : never
       : never
     : never
   : never;

--- a/src/language/select/parse-predicate.ts
+++ b/src/language/select/parse-predicate.ts
@@ -42,6 +42,23 @@ type TakeClauseBody<
       >
   : { body: Trim<Body extends '' ? Sql : `${Body} ${Sql}`>; rest: '' };
 
+type HasFollowingClause<Sql extends string> = Lowercase<Sql> extends
+  | `${string} where ${string}`
+  | `${string} group ${string}`
+  | `${string} having ${string}`
+  | `${string} order ${string}`
+  | `${string} limit ${string}`
+  | `${string} offset ${string}`
+  | `${string} window ${string}`
+  | `${string} fetch ${string}`
+  | `${string} for ${string}`
+  ? true
+  : false;
+
+type ClauseBody<Sql extends string> = HasFollowingClause<Sql> extends false
+  ? { body: Trim<Sql>; rest: '' }
+  : TakeClauseBody<Sql>;
+
 type ParsedClauses<
   Predicates extends readonly PredicateIR[],
   Clauses extends SelectClausesIR<string, string, string, string, string>,
@@ -64,7 +81,7 @@ type ParseTail<
       SelectClausesIR<GroupBy, OrderBy, Limit, Offset, Window>
     >
   : FirstWord<Trim<Sql>> extends infer Keyword extends string
-    ? TakeClauseBody<DropFirstWord<Trim<Sql>>> extends {
+    ? ClauseBody<DropFirstWord<Trim<Sql>>> extends {
         body: infer Body extends string;
         rest: infer Rest extends string;
       }

--- a/src/language/select/parse-predicate.ts
+++ b/src/language/select/parse-predicate.ts
@@ -1,0 +1,125 @@
+import type {
+  ApplyParenDelta,
+  DropFirstWord,
+  FirstWord,
+  IsKeyword,
+  Trim,
+} from '../../string.js';
+import type { PredicateIR } from '../ir/predicate.js';
+import type { SelectClausesIR } from '../ir/query.js';
+
+type ClauseKeyword =
+  | 'where'
+  | 'group'
+  | 'having'
+  | 'order'
+  | 'limit'
+  | 'offset'
+  | 'window'
+  | 'fetch'
+  | 'for';
+
+type IsClauseKeyword<Token extends string> =
+  Lowercase<Token> extends ClauseKeyword ? true : false;
+
+type TakeClauseBody<
+  Sql extends string,
+  Depth extends unknown[] = [],
+  Body extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? IsClauseKeyword<Head> extends true
+      ? { body: Trim<Body>; rest: Trim<`${Head} ${Tail}`> }
+      : TakeClauseBody<
+          Tail,
+          ApplyParenDelta<Depth, Head>,
+          Body extends '' ? Head : `${Body} ${Head}`
+        >
+    : TakeClauseBody<
+        Tail,
+        ApplyParenDelta<Depth, Head>,
+        Body extends '' ? Head : `${Body} ${Head}`
+      >
+  : { body: Trim<Body extends '' ? Sql : `${Body} ${Sql}`>; rest: '' };
+
+type ParsedClauses<
+  Predicates extends readonly PredicateIR[],
+  Clauses extends SelectClausesIR<string, string, string, string, string>,
+> = {
+  predicates: Predicates;
+  clauses: Clauses;
+};
+
+type ParseTail<
+  Sql extends string,
+  Predicates extends readonly PredicateIR[] = [],
+  GroupBy extends string = '',
+  OrderBy extends string = '',
+  Limit extends string = '',
+  Offset extends string = '',
+  Window extends string = '',
+> = Trim<Sql> extends ''
+  ? ParsedClauses<
+      Predicates,
+      SelectClausesIR<GroupBy, OrderBy, Limit, Offset, Window>
+    >
+  : FirstWord<Trim<Sql>> extends infer Keyword extends string
+    ? TakeClauseBody<DropFirstWord<Trim<Sql>>> extends {
+        body: infer Body extends string;
+        rest: infer Rest extends string;
+      }
+      ? IsKeyword<Keyword, 'where'> extends true
+        ? ParseTail<
+            Rest,
+            [...Predicates, PredicateIR<'where', Body>],
+            GroupBy,
+            OrderBy,
+            Limit,
+            Offset,
+            Window
+          >
+        : IsKeyword<Keyword, 'having'> extends true
+          ? ParseTail<
+              Rest,
+              [...Predicates, PredicateIR<'having', Body>],
+              GroupBy,
+              OrderBy,
+              Limit,
+              Offset,
+              Window
+            >
+          : IsKeyword<Keyword, 'group'> extends true
+            ? ParseTail<
+                Rest,
+                Predicates,
+                IsKeyword<FirstWord<Body>, 'by'> extends true
+                  ? Trim<DropFirstWord<Body>>
+                  : Body,
+                OrderBy,
+                Limit,
+                Offset,
+                Window
+              >
+            : IsKeyword<Keyword, 'order'> extends true
+              ? ParseTail<
+                  Rest,
+                  Predicates,
+                  GroupBy,
+                  IsKeyword<FirstWord<Body>, 'by'> extends true
+                    ? Trim<DropFirstWord<Body>>
+                    : Body,
+                  Limit,
+                  Offset,
+                  Window
+                >
+              : IsKeyword<Keyword, 'limit'> extends true
+                ? ParseTail<Rest, Predicates, GroupBy, OrderBy, Body, Offset, Window>
+                : IsKeyword<Keyword, 'offset'> extends true
+                  ? ParseTail<Rest, Predicates, GroupBy, OrderBy, Limit, Body, Window>
+                  : IsKeyword<Keyword, 'window'> extends true
+                    ? ParseTail<Rest, Predicates, GroupBy, OrderBy, Limit, Offset, Body>
+                    : ParseTail<Rest, Predicates, GroupBy, OrderBy, Limit, Offset, Window>
+      : never
+    : never;
+
+export type ParseSelectTail<Sql extends string> = ParseTail<Sql>;

--- a/src/language/select/parse-projection.ts
+++ b/src/language/select/parse-projection.ts
@@ -179,7 +179,7 @@ type UnwrapParens<Expression extends string> = Expression extends `(${infer Inne
       : Trim<Inner>
   : Expression;
 
-type ParseEntry<Entry extends string> =
+type ParseComplexEntry<Entry extends string> =
   IsCaseToken<FirstWord<Trim<Entry>>> extends true
     ? SplitCase<Entry>
     : [SplitWindow<Entry>] extends [never]
@@ -210,12 +210,14 @@ type ParseEntry<Entry extends string> =
             : IsKeyword<FirstWord<After>, 'as'> extends true
               ? [UnwrapParens<Expression>, Unquote<Trim<DropFirstWord<After>>>]
               : IsOperatorExpression<After> extends true
-                ? FindTopLevelAs<Entry> extends {
-                    expression: infer FullExpression extends string;
-                    alias: infer Alias extends string;
-                  }
-                  ? [FullExpression, Unquote<Trim<Alias>>]
-                  : [Trim<Entry>, Trim<Entry>]
+                ? [FindTopLevelAs<Entry>] extends [never]
+                  ? [Trim<Entry>, Trim<Entry>]
+                  : FindTopLevelAs<Entry> extends {
+                      expression: infer FullExpression extends string;
+                      alias: infer Alias extends string;
+                    }
+                    ? [FullExpression, Unquote<Trim<Alias>>]
+                    : [Trim<Entry>, Trim<Entry>]
                 : [UnwrapParens<Expression>, Unquote<Trim<After>>]
           : [Trim<Entry>, OutputName<Trim<Entry>>]
       : SplitWindow<Entry> extends [
@@ -228,6 +230,12 @@ type ParseEntry<Entry extends string> =
             ? [Expression, Unquote<Trim<DropFirstWord<After>>>]
             : [Expression, Unquote<Trim<After>>]
         : [Trim<Entry>, OutputName<Trim<Entry>>];
+
+type ParseEntry<Entry extends string> = Trim<Entry> extends infer Value extends string
+  ? Value extends `${string} ${string}` | `(${string}`
+    ? ParseComplexEntry<Value>
+    : [Value, OutputName<Value>]
+  : never;
 
 type IsColumn<Expression extends string> =
   Expression extends `${string} ${string}`

--- a/src/language/select/parse-projection.ts
+++ b/src/language/select/parse-projection.ts
@@ -1,55 +1,276 @@
-import type { SplitColumnList, Trim, Unquote } from '../../string.js';
+import type {
+  ApplyParenDelta,
+  DropFirstWord,
+  ExtractParenGroup,
+  FirstWord,
+  IsKeyword,
+  SplitColumnList,
+  StripQualifier,
+  Trim,
+  Unquote,
+} from '../../string.js';
 import type {
   ColumnProjectionIR,
   ExpressionProjectionIR,
   StarProjectionIR,
 } from '../ir/projection.js';
 
-type SplitAlias<Fragment extends string> =
-  Fragment extends `${infer Expression} as ${infer Alias}` ? [Expression, Alias]
-  : Fragment extends `${infer Expression} AS ${infer Alias}` ? [Expression, Alias]
-  : Fragment extends `${infer Expression} As ${infer Alias}` ? [Expression, Alias]
-  : Fragment extends `${infer Expression} aS ${infer Alias}` ? [Expression, Alias]
-  : [Fragment, null];
+type FunctionName<Expression extends string> =
+  Expression extends `${infer Name}(${string}` ? Trim<Name> : Expression;
 
-type OutputName<Name extends string, Alias extends string | null> =
-  Alias extends string ? Unquote<Trim<Alias>> : Unquote<Name>;
+type IsFunctionCall<Expression extends string> =
+  Expression extends `${string}(${string})`
+    ? FunctionName<Expression> extends ''
+      ? false
+      : true
+    : false;
 
-type ParseProjectionExpression<
-  Expression extends string,
-  Alias extends string | null,
-> = Trim<Expression> extends infer Value extends string
-  ? Value extends '*'
-    ? StarProjectionIR
-    : Value extends `${infer Qualifier}.*`
-      ? StarProjectionIR<Unquote<Trim<Qualifier>>>
-      : Value extends `${infer Qualifier}.${infer Name}`
-        ? ColumnProjectionIR<
-            Unquote<Trim<Qualifier>>,
-            Unquote<Trim<Name>>,
-            OutputName<Unquote<Trim<Name>>, Alias>
-          >
-        : Value extends `${string} ${string}` | `${string}(${string}` | `${string})${string}`
-          ? ExpressionProjectionIR<Value, Alias extends string ? Unquote<Trim<Alias>> : Value>
-          : ColumnProjectionIR<null, Unquote<Value>, OutputName<Unquote<Value>, Alias>>
-  : never;
+type OutputName<Expression extends string> =
+  IsFunctionCall<Expression> extends true
+    ? FunctionName<Expression>
+    : Unquote<StripQualifier<Expression>>;
 
-type ParseProjection<Fragment extends string> =
-  SplitAlias<Trim<Fragment>> extends [
-    infer Expression extends string,
-    infer Alias extends string | null,
-  ]
-    ? ParseProjectionExpression<Expression, Alias>
+type StripLeadingParens<Value extends string> =
+  Value extends `(${infer Rest}` ? StripLeadingParens<Rest> : Value;
+
+type StripTrailingParens<Value extends string> =
+  Value extends `${infer Rest})` ? StripTrailingParens<Rest> : Value;
+
+type IsCaseToken<Token extends string> = IsKeyword<StripLeadingParens<Token>, 'case'>;
+type IsEndToken<Token extends string> = IsKeyword<StripTrailingParens<Token>, 'end'>;
+
+type FindCaseEnd<
+  Sql extends string,
+  Depth extends unknown[] = [],
+  Body extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? IsCaseToken<Head> extends true
+    ? FindCaseEnd<Tail, [...Depth, unknown], Body extends '' ? Head : `${Body} ${Head}`>
+    : IsEndToken<Head> extends true
+      ? Depth extends [unknown, ...infer Rest extends unknown[]]
+        ? FindCaseEnd<Tail, Rest, Body extends '' ? Head : `${Body} ${Head}`>
+        : { body: Trim<Body>; rest: Trim<Tail> }
+      : FindCaseEnd<Tail, Depth, Body extends '' ? Head : `${Body} ${Head}`>
+  : IsEndToken<Sql> extends true
+    ? Depth extends []
+      ? { body: Trim<Body>; rest: '' }
+      : never
     : never;
 
-type ParseProjectionItems<
+type SplitCase<Entry extends string> =
+  DropFirstWord<Trim<Entry>> extends infer AfterCase extends string
+    ? FindCaseEnd<AfterCase> extends {
+        body: infer Body extends string;
+        rest: infer Rest extends string;
+      }
+      ? Rest extends ''
+        ? [`case ${Body} end`, 'case']
+        : IsKeyword<FirstWord<Rest>, 'as'> extends true
+          ? [`case ${Body} end`, Unquote<Trim<DropFirstWord<Rest>>>]
+          : [`case ${Body} end`, Unquote<Trim<Rest>>]
+      : [Trim<Entry>, OutputName<Trim<Entry>>]
+    : [Trim<Entry>, OutputName<Trim<Entry>>];
+
+type OverAttachedParen<Token extends string> =
+  Token extends `${infer Word}(${infer Rest}`
+    ? IsKeyword<Word, 'over'> extends true
+      ? Rest
+      : never
+    : never;
+
+type FindOver<
+  Sql extends string,
+  Before extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? IsKeyword<Head, 'over'> extends true
+    ? IsFunctionCall<Trim<Before>> extends true
+      ? { expression: Trim<Before>; rest: Tail }
+      : FindOver<Tail, Before extends '' ? Head : `${Before} ${Head}`>
+    : OverAttachedParen<Head> extends infer Rest extends string
+      ? [Rest] extends [never]
+        ? FindOver<Tail, Before extends '' ? Head : `${Before} ${Head}`>
+        : IsFunctionCall<Trim<Before>> extends true
+          ? { expression: Trim<Before>; rest: `(${Rest} ${Tail}` }
+          : FindOver<Tail, Before extends '' ? Head : `${Before} ${Head}`>
+      : never
+  : OverAttachedParen<Sql> extends infer Rest extends string
+    ? [Rest] extends [never]
+      ? never
+      : IsFunctionCall<Trim<Before>> extends true
+        ? { expression: Trim<Before>; rest: `(${Rest}` }
+        : never
+    : never;
+
+type SplitWindow<Entry extends string> = [FindOver<Entry>] extends [never]
+  ? never
+  : FindOver<Entry> extends {
+      expression: infer Expression extends string;
+      rest: infer Rest extends string;
+    }
+    ? Trim<Rest> extends `(${infer AfterOpen}`
+      ? ExtractParenGroup<AfterOpen> extends { rest: infer After extends string }
+        ? [Expression, Trim<After>]
+        : never
+      : Trim<Rest> extends ''
+        ? never
+        : [Expression, Trim<DropFirstWord<Trim<Rest>>>]
+    : never;
+
+type SplitParenthesized<Entry extends string> =
+  Trim<Entry> extends `(${infer AfterOpen}`
+    ? ExtractParenGroup<AfterOpen> extends {
+        inner: infer Inner extends string;
+        rest: infer After extends string;
+      }
+      ? [`(${Inner})`, Trim<After>]
+      : never
+    : never;
+
+type FindTopLevelAs<
+  Sql extends string,
+  Depth extends unknown[] = [],
+  Before extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? IsKeyword<Head, 'as'> extends true
+      ? { expression: Trim<Before>; alias: Tail }
+      : FindTopLevelAs<
+          Tail,
+          ApplyParenDelta<Depth, Head>,
+          Before extends '' ? Head : `${Before} ${Head}`
+        >
+    : FindTopLevelAs<
+        Tail,
+        ApplyParenDelta<Depth, Head>,
+        Before extends '' ? Head : `${Before} ${Head}`
+      >
+  : never;
+
+type SplitTopLevelSpace<
+  Sql extends string,
+  Depth extends unknown[] = [],
+  Before extends string = '',
+> = Sql extends `${infer Head} ${infer Tail}`
+  ? ApplyParenDelta<Depth, Head> extends infer NextDepth extends unknown[]
+    ? NextDepth extends []
+      ? { expression: Before extends '' ? Head : `${Before} ${Head}`; alias: Tail }
+      : SplitTopLevelSpace<
+          Tail,
+          NextDepth,
+          Before extends '' ? Head : `${Before} ${Head}`
+        >
+    : never
+  : never;
+
+type Operator = '*' | '+' | '-' | '/' | '%' | '|' | '<' | '>' | '=' | '^';
+
+type IsOperatorExpression<Sql extends string> =
+  Sql extends `${string}"${string}` | `${string}[${string}` | `${string}\`${string}`
+    ? false
+    : Sql extends `${string}${Operator}${string}`
+      ? true
+      : false;
+
+type UnwrapParens<Expression extends string> = Expression extends `(${infer Inner})`
+  ? Inner extends `${string})${string}`
+    ? Expression
+    : IsKeyword<FirstWord<Trim<Inner>>, 'select'> extends true
+      ? Expression
+      : Trim<Inner>
+  : Expression;
+
+type ParseEntry<Entry extends string> =
+  IsCaseToken<FirstWord<Trim<Entry>>> extends true
+    ? SplitCase<Entry>
+    : [SplitWindow<Entry>] extends [never]
+      ? [SplitParenthesized<Entry>] extends [never]
+        ? [FindTopLevelAs<Entry>] extends [never]
+          ? [SplitTopLevelSpace<Entry>] extends [never]
+            ? [Trim<Entry>, OutputName<Trim<Entry>>]
+            : SplitTopLevelSpace<Entry> extends {
+                expression: infer Expression extends string;
+                alias: infer Alias extends string;
+              }
+              ? IsOperatorExpression<Alias> extends true
+                ? [Trim<Entry>, OutputName<Trim<Entry>>]
+                : [Trim<Expression>, Unquote<Trim<Alias>>]
+              : [Trim<Entry>, OutputName<Trim<Entry>>]
+          : FindTopLevelAs<Entry> extends {
+              expression: infer Expression extends string;
+              alias: infer Alias extends string;
+            }
+            ? [Expression, Unquote<Trim<Alias>>]
+            : [Trim<Entry>, OutputName<Trim<Entry>>]
+        : SplitParenthesized<Entry> extends [
+            infer Expression extends string,
+            infer After extends string,
+          ]
+          ? After extends ''
+            ? [UnwrapParens<Expression>, Trim<Entry>]
+            : IsKeyword<FirstWord<After>, 'as'> extends true
+              ? [UnwrapParens<Expression>, Unquote<Trim<DropFirstWord<After>>>]
+              : IsOperatorExpression<After> extends true
+                ? FindTopLevelAs<Entry> extends {
+                    expression: infer FullExpression extends string;
+                    alias: infer Alias extends string;
+                  }
+                  ? [FullExpression, Unquote<Trim<Alias>>]
+                  : [Trim<Entry>, Trim<Entry>]
+                : [UnwrapParens<Expression>, Unquote<Trim<After>>]
+          : [Trim<Entry>, OutputName<Trim<Entry>>]
+      : SplitWindow<Entry> extends [
+          infer Expression extends string,
+          infer After extends string,
+        ]
+        ? After extends ''
+          ? [Expression, OutputName<Expression>]
+          : IsKeyword<FirstWord<After>, 'as'> extends true
+            ? [Expression, Unquote<Trim<DropFirstWord<After>>>]
+            : [Expression, Unquote<Trim<After>>]
+        : [Trim<Entry>, OutputName<Trim<Entry>>];
+
+type IsColumn<Expression extends string> =
+  Expression extends `${string} ${string}`
+    ? false
+    : Expression extends `${string}(${string}` | `${string})${string}`
+      ? false
+      : Expression extends `${string}::${string}`
+        ? false
+        : IsOperatorExpression<Expression> extends true
+          ? false
+          : Expression extends `${number}` | `'${string}'`
+            ? false
+            : Lowercase<Expression> extends 'true' | 'false' | 'null'
+              ? false
+              : true;
+
+type ToProjection<Entry extends string> = ParseEntry<Entry> extends [
+  infer Expression extends string,
+  infer Name extends string,
+]
+  ? Expression extends '*'
+    ? StarProjectionIR
+    : Expression extends `${infer Qualifier}.*`
+      ? StarProjectionIR<Unquote<Trim<Qualifier>>>
+      : IsColumn<Expression> extends true
+        ? Expression extends `${infer Qualifier}.${infer Column}`
+          ? ColumnProjectionIR<
+              Unquote<Trim<Qualifier>>,
+              Unquote<Trim<Column>>,
+              Name
+            >
+          : ColumnProjectionIR<null, Unquote<Trim<Expression>>, Name>
+        : ExpressionProjectionIR<Expression, Name>
+  : never;
+
+type ParseItems<
   Items extends readonly string[],
   Result extends unknown[] = [],
 > = Items extends readonly [
   infer Head extends string,
   ...infer Tail extends string[],
 ]
-  ? ParseProjectionItems<Tail, [...Result, ParseProjection<Head>]>
+  ? ParseItems<Tail, [...Result, ToProjection<Head>]>
   : Result;
 
-export type ParseProjectionList<Sql extends string> = ParseProjectionItems<SplitColumnList<Sql>>;
+export type ParseProjectionList<Sql extends string> = ParseItems<SplitColumnList<Sql>>;

--- a/src/language/select/parse-select.ts
+++ b/src/language/select/parse-select.ts
@@ -2,9 +2,12 @@ import type {
   ApplyParenDelta,
   DropFirstWord,
   FirstWord,
+  HasNonTrailingSemicolon,
   IsKeyword,
   Normalize,
+  StripQualifier,
   Trim,
+  Unquote,
 } from '../../string.js';
 import type {
   SelectClausesIR,
@@ -12,7 +15,7 @@ import type {
   SetOperationIR,
 } from '../ir/query.js';
 import type { PredicateIR } from '../ir/predicate.js';
-import type { SourceIR } from '../ir/source.js';
+import type { SourceIR, TableSourceIR } from '../ir/source.js';
 import type { StripSelectModifiers } from '../dialect/common.js';
 import type { ParseNormalizedFromSources } from './parse-from.js';
 import type { ParseProjectionList } from './parse-projection.js';
@@ -29,6 +32,16 @@ type SplitAtFrom<
       : SplitAtFrom<Rest, ApplyParenDelta<Depth, Token>, `${Before} ${Token}`>
     : SplitAtFrom<Rest, ApplyParenDelta<Depth, Token>, `${Before} ${Token}`>
   : never;
+
+type SelectFromSplit<Sql extends string> =
+  Lowercase<Sql> extends
+    | `${string}(select ${string}`
+    | `${string}extract(${string} from ${string}`
+    | `${string}trim(${string} from ${string}`
+    ? SplitAtFrom<Sql>
+    : Sql extends `${infer Before} from ${infer After}`
+      ? { before: Trim<Before>; after: Trim<After> }
+      : SplitAtFrom<Sql>;
 
 type IsSelectClause<Token extends string> = Lowercase<Token> extends
   | 'where'
@@ -115,62 +128,104 @@ type ParseFatal<Sql extends string> = {
   diagnostics: [MalformedSelect<Sql>];
 };
 
-type BuildSelect<
+type MultipleStatements<Sql extends string> = {
+  code: 'MULTIPLE_STATEMENTS';
+  message: 'multiple statements are not supported: found a semicolon before the end of the query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type ParseMultipleStatements<Sql extends string> = {
+  kind: 'fatal';
+  readonly __value?: SelectQueryIR;
+  diagnostics: [MultipleStatements<Sql>];
+};
+
+type BuiltSelect<
   Sources extends readonly SourceIR[],
   Projection extends string,
   Predicates extends readonly PredicateIR[],
-  Tail extends string,
-> = ParseSelectTail<Tail> extends {
-  predicates: infer TailPredicates extends readonly PredicateIR[];
-  clauses: infer Clauses extends SelectClausesIR<
+  TailPredicates extends readonly PredicateIR[],
+  Clauses extends SelectClausesIR<
     string,
     string,
     string,
     string,
     string
+  >,
+> = {
+  kind: 'ok';
+  value: SelectQueryIR<
+    Sources,
+    ParseProjectionList<Projection>,
+    [...Predicates, ...TailPredicates],
+    [],
+    [],
+    Clauses,
+    []
   >;
-}
-  ? {
-      kind: 'ok';
-      value: SelectQueryIR<
-        Sources,
-        ParseProjectionList<Projection>,
-        [...Predicates, ...TailPredicates],
-        [],
-        [],
-        Clauses,
-        []
+  diagnostics: [];
+};
+
+type BuildSelect<
+  Sources extends readonly SourceIR[],
+  Projection extends string,
+  Predicates extends readonly PredicateIR[],
+  Tail extends string,
+> = Tail extends ''
+  ? BuiltSelect<Sources, Projection, Predicates, [], SelectClausesIR>
+  : ParseSelectTail<Tail> extends {
+      predicates: infer TailPredicates extends readonly PredicateIR[];
+      clauses: infer Clauses extends SelectClausesIR<
+        string,
+        string,
+        string,
+        string,
+        string
       >;
-      diagnostics: [];
     }
-  : never;
+    ? BuiltSelect<Sources, Projection, Predicates, TailPredicates, Clauses>
+    : never;
+
+type BuildFrom<
+  Projection extends string,
+  Source extends string,
+  Sql extends string,
+> = Source extends `${string} ${string}` | `${string},${string}` | `${string}(${string}`
+  ? ParseNormalizedFromSources<Source> extends {
+      sources: infer Sources extends readonly SourceIR[];
+      predicates: infer Predicates extends readonly PredicateIR[];
+      rest: infer Tail extends string;
+    }
+    ? Sources extends readonly []
+      ? ParseFatal<Sql>
+      : BuildSelect<Sources, Projection, Predicates, Tail>
+    : ParseFatal<Sql>
+  : Unquote<StripQualifier<Source>> extends infer Name extends string
+    ? BuildSelect<[TableSourceIR<Name>], Projection, [], ''>
+    : never;
 
 type ParseBody<Body extends string, Sql extends string> =
-  [SplitAtFrom<Body>] extends [never]
-    ? SplitProjectionTail<Body> extends {
-        projection: infer Projection extends string;
-        rest: infer Tail extends string;
-      }
-      ? Projection extends ''
-        ? ParseFatal<Sql>
-        : BuildSelect<[], Projection, [], Tail>
-      : ParseFatal<Sql>
-    : SplitAtFrom<Body> extends {
-        before: infer Projection extends string;
-        after: infer Source extends string;
-      }
-      ? Projection extends ''
-      ? ParseFatal<Sql>
-        : ParseNormalizedFromSources<Source> extends {
-            sources: infer Sources extends readonly SourceIR[];
-            predicates: infer Predicates extends readonly PredicateIR[];
-            rest: infer Tail extends string;
-          }
-          ? Sources extends readonly []
-            ? ParseFatal<Sql>
-            : BuildSelect<Sources, Projection, Predicates, Tail>
-          : ParseFatal<Sql>
-      : ParseFatal<Sql>;
+  SelectFromSplit<Body> extends infer From
+    ? [From] extends [never]
+      ? SplitProjectionTail<Body> extends {
+          projection: infer Projection extends string;
+          rest: infer Tail extends string;
+        }
+        ? Projection extends ''
+          ? ParseFatal<Sql>
+          : BuildSelect<[], Projection, [], Tail>
+        : ParseFatal<Sql>
+      : From extends {
+          before: infer Projection extends string;
+          after: infer Source extends string;
+        }
+        ? Projection extends ''
+          ? ParseFatal<Sql>
+          : BuildFrom<Projection, Source, Sql>
+        : ParseFatal<Sql>
+    : never;
 
 type AddSetOperation<
   Parsed,
@@ -205,20 +260,31 @@ type AddSetOperation<
     : Branch
   : Parsed;
 
+type HasSetOperation<Sql extends string> = Lowercase<Sql> extends
+  | `${string} union ${string}`
+  | `${string} intersect ${string}`
+  | `${string} except ${string}`
+  ? true
+  : false;
+
 type ParseSetBody<Body extends string, Sql extends string> =
-  [SplitAtSet<Body>] extends [never]
+  HasSetOperation<Body> extends false
     ? ParseBody<Body, Sql>
-    : SplitAtSet<Body> extends {
-        primary: infer Primary extends string;
-        kind: infer Kind extends SetOperationIR['kind'];
-        branch: infer Branch extends string;
-      }
-      ? AddSetOperation<
-          ParseBody<Primary, Sql>,
-          Kind,
-          ParseNormalized<Branch, Branch>
-        >
-      : ParseFatal<Sql>;
+    : SplitAtSet<Body> extends infer Set
+      ? [Set] extends [never]
+        ? ParseBody<Body, Sql>
+        : Set extends {
+            primary: infer Primary extends string;
+            kind: infer Kind extends SetOperationIR['kind'];
+            branch: infer Branch extends string;
+          }
+          ? AddSetOperation<
+              ParseBody<Primary, Sql>,
+              Kind,
+              ParseNormalized<Branch, Branch>
+            >
+          : ParseFatal<Sql>
+      : never;
 
 type ParseNormalized<Normalized extends string, Sql extends string> =
   Normalized extends `${infer Select} ${infer Body}`
@@ -227,4 +293,6 @@ type ParseNormalized<Normalized extends string, Sql extends string> =
       : ParseFatal<Sql>
     : ParseFatal<Sql>;
 
-export type ParseSelectIR<Sql extends string> = ParseNormalized<Normalize<Sql>, Sql>;
+export type ParseSelectIR<Sql extends string> = HasNonTrailingSemicolon<Sql> extends true
+  ? ParseMultipleStatements<Sql>
+  : ParseNormalized<Normalize<Sql>, Sql>;

--- a/src/language/select/parse-select.ts
+++ b/src/language/select/parse-select.ts
@@ -1,14 +1,21 @@
 import type {
   ApplyParenDelta,
+  DropFirstWord,
+  FirstWord,
   IsKeyword,
   Normalize,
   Trim,
 } from '../../string.js';
-import type { SelectQueryIR } from '../ir/query.js';
+import type {
+  SelectClausesIR,
+  SelectQueryIR,
+  SetOperationIR,
+} from '../ir/query.js';
 import type { PredicateIR } from '../ir/predicate.js';
 import type { SourceIR } from '../ir/source.js';
 import type { ParseNormalizedFromSources } from './parse-from.js';
 import type { ParseProjectionList } from './parse-projection.js';
+import type { ParseSelectTail } from './parse-predicate.js';
 
 type SplitAtFrom<
   Sql extends string,
@@ -20,6 +27,77 @@ type SplitAtFrom<
       ? { before: Trim<Before>; after: Trim<Rest> }
       : SplitAtFrom<Rest, ApplyParenDelta<Depth, Token>, `${Before} ${Token}`>
     : SplitAtFrom<Rest, ApplyParenDelta<Depth, Token>, `${Before} ${Token}`>
+  : never;
+
+type IsSelectClause<Token extends string> = Lowercase<Token> extends
+  | 'where'
+  | 'group'
+  | 'having'
+  | 'order'
+  | 'limit'
+  | 'offset'
+  | 'window'
+  ? true
+  : false;
+
+type SplitProjectionTail<
+  Sql extends string,
+  Depth extends unknown[] = [],
+  Before extends string = '',
+> = Sql extends `${infer Token} ${infer Rest}`
+  ? Depth extends []
+    ? IsSelectClause<Token> extends true
+      ? { projection: Trim<Before>; rest: Trim<`${Token} ${Rest}`> }
+      : SplitProjectionTail<
+          Rest,
+          ApplyParenDelta<Depth, Token>,
+          Before extends '' ? Token : `${Before} ${Token}`
+        >
+    : SplitProjectionTail<
+        Rest,
+        ApplyParenDelta<Depth, Token>,
+        Before extends '' ? Token : `${Before} ${Token}`
+      >
+  : { projection: Trim<Before extends '' ? Sql : `${Before} ${Sql}`>; rest: '' };
+
+type SetKind<Token extends string> = Lowercase<Token> extends 'union'
+  ? 'union'
+  : Lowercase<Token> extends 'intersect'
+    ? 'intersect'
+    : Lowercase<Token> extends 'except'
+      ? 'except'
+      : never;
+
+type SplitAtSet<
+  Sql extends string,
+  Depth extends unknown[] = [],
+  Before extends string = '',
+> = Sql extends `${infer Token} ${infer Rest}`
+  ? Depth extends []
+    ? SetKind<Token> extends infer Kind
+      ? [Kind] extends [never]
+        ? SplitAtSet<
+            Rest,
+            ApplyParenDelta<Depth, Token>,
+            Before extends '' ? Token : `${Before} ${Token}`
+          >
+        : Kind extends 'union'
+          ? IsKeyword<FirstWord<Rest>, 'all'> extends true
+            ? {
+                primary: Trim<Before>;
+                kind: 'union-all';
+                branch: Trim<DropFirstWord<Rest>>;
+              }
+            : { primary: Trim<Before>; kind: Kind; branch: Trim<Rest> }
+          : Kind extends 'intersect' | 'except'
+            ? { primary: Trim<Before>; kind: Kind; branch: Trim<Rest> }
+            : never
+      : never
+    : SplitAtSet<
+        Rest,
+        ApplyParenDelta<Depth, Token>,
+        Before extends '' ? Token : `${Before} ${Token}`
+      >
   : never;
 
 type MalformedSelect<Sql extends string> = {
@@ -36,45 +114,115 @@ type ParseFatal<Sql extends string> = {
   diagnostics: [MalformedSelect<Sql>];
 };
 
+type BuildSelect<
+  Sources extends readonly SourceIR[],
+  Projection extends string,
+  Predicates extends readonly PredicateIR[],
+  Tail extends string,
+> = ParseSelectTail<Tail> extends {
+  predicates: infer TailPredicates extends readonly PredicateIR[];
+  clauses: infer Clauses extends SelectClausesIR<
+    string,
+    string,
+    string,
+    string,
+    string
+  >;
+}
+  ? {
+      kind: 'ok';
+      value: SelectQueryIR<
+        Sources,
+        ParseProjectionList<Projection>,
+        [...Predicates, ...TailPredicates],
+        [],
+        [],
+        Clauses,
+        []
+      >;
+      diagnostics: [];
+    }
+  : never;
+
 type ParseBody<Body extends string, Sql extends string> =
   [SplitAtFrom<Body>] extends [never]
-    ? Trim<Body> extends ''
-      ? ParseFatal<Sql>
-      : {
-          kind: 'ok';
-          value: SelectQueryIR<[], ParseProjectionList<Body>, [], [], []>;
-          diagnostics: [];
-        }
+    ? SplitProjectionTail<Body> extends {
+        projection: infer Projection extends string;
+        rest: infer Tail extends string;
+      }
+      ? Projection extends ''
+        ? ParseFatal<Sql>
+        : BuildSelect<[], Projection, [], Tail>
+      : ParseFatal<Sql>
     : SplitAtFrom<Body> extends {
-    before: infer Projection extends string;
-    after: infer Source extends string;
-  }
-    ? Projection extends ''
+        before: infer Projection extends string;
+        after: infer Source extends string;
+      }
+      ? Projection extends ''
       ? ParseFatal<Sql>
-      : ParseNormalizedFromSources<Source> extends {
-          sources: infer Sources extends readonly SourceIR[];
-          predicates: infer Predicates extends readonly PredicateIR[];
-        }
-        ? Sources extends readonly []
-          ? ParseFatal<Sql>
-          : {
-              kind: 'ok';
-              value: SelectQueryIR<
-                Sources,
-                ParseProjectionList<Projection>,
-                Predicates,
-                [],
-                []
-              >;
-              diagnostics: [];
-            }
-        : ParseFatal<Sql>
+        : ParseNormalizedFromSources<Source> extends {
+            sources: infer Sources extends readonly SourceIR[];
+            predicates: infer Predicates extends readonly PredicateIR[];
+            rest: infer Tail extends string;
+          }
+          ? Sources extends readonly []
+            ? ParseFatal<Sql>
+            : BuildSelect<Sources, Projection, Predicates, Tail>
+          : ParseFatal<Sql>
+      : ParseFatal<Sql>;
+
+type AddSetOperation<
+  Parsed,
+  Kind extends SetOperationIR['kind'],
+  Branch,
+> = Parsed extends {
+  kind: 'ok';
+  value: SelectQueryIR<
+    infer Sources,
+    infer Projections,
+    infer Predicates,
+    infer Parameters,
+    infer Ctes,
+    infer Clauses,
+    infer SetOperations
+  >;
+}
+  ? Branch extends { kind: 'ok'; value: infer BranchIR extends SelectQueryIR }
+    ? {
+        kind: 'ok';
+        value: SelectQueryIR<
+          Sources,
+          Projections,
+          Predicates,
+          Parameters,
+          Ctes,
+          Clauses,
+          [...SetOperations, SetOperationIR<Kind, BranchIR>]
+        >;
+        diagnostics: [];
+      }
+    : Branch
+  : Parsed;
+
+type ParseSetBody<Body extends string, Sql extends string> =
+  [SplitAtSet<Body>] extends [never]
+    ? ParseBody<Body, Sql>
+    : SplitAtSet<Body> extends {
+        primary: infer Primary extends string;
+        kind: infer Kind extends SetOperationIR['kind'];
+        branch: infer Branch extends string;
+      }
+      ? AddSetOperation<
+          ParseBody<Primary, Sql>,
+          Kind,
+          ParseNormalized<Branch, Branch>
+        >
       : ParseFatal<Sql>;
 
 type ParseNormalized<Normalized extends string, Sql extends string> =
   Normalized extends `${infer Select} ${infer Body}`
     ? IsKeyword<Select, 'select'> extends true
-      ? ParseBody<Body, Sql>
+      ? ParseSetBody<Body, Sql>
       : ParseFatal<Sql>
     : ParseFatal<Sql>;
 

--- a/src/language/select/parse-select.ts
+++ b/src/language/select/parse-select.ts
@@ -37,7 +37,15 @@ type ParseFatal<Sql extends string> = {
 };
 
 type ParseBody<Body extends string, Sql extends string> =
-  SplitAtFrom<Body> extends {
+  [SplitAtFrom<Body>] extends [never]
+    ? Trim<Body> extends ''
+      ? ParseFatal<Sql>
+      : {
+          kind: 'ok';
+          value: SelectQueryIR<[], ParseProjectionList<Body>, [], [], []>;
+          diagnostics: [];
+        }
+    : SplitAtFrom<Body> extends {
     before: infer Projection extends string;
     after: infer Source extends string;
   }
@@ -61,7 +69,7 @@ type ParseBody<Body extends string, Sql extends string> =
               diagnostics: [];
             }
         : ParseFatal<Sql>
-    : ParseFatal<Sql>;
+      : ParseFatal<Sql>;
 
 type ParseNormalized<Normalized extends string, Sql extends string> =
   Normalized extends `${infer Select} ${infer Body}`

--- a/src/language/select/parse-select.ts
+++ b/src/language/select/parse-select.ts
@@ -13,6 +13,7 @@ import type {
 } from '../ir/query.js';
 import type { PredicateIR } from '../ir/predicate.js';
 import type { SourceIR } from '../ir/source.js';
+import type { StripSelectModifiers } from '../dialect/common.js';
 import type { ParseNormalizedFromSources } from './parse-from.js';
 import type { ParseProjectionList } from './parse-projection.js';
 import type { ParseSelectTail } from './parse-predicate.js';
@@ -222,7 +223,7 @@ type ParseSetBody<Body extends string, Sql extends string> =
 type ParseNormalized<Normalized extends string, Sql extends string> =
   Normalized extends `${infer Select} ${infer Body}`
     ? IsKeyword<Select, 'select'> extends true
-      ? ParseSetBody<Body, Sql>
+      ? ParseSetBody<StripSelectModifiers<Body>, Sql>
       : ParseFatal<Sql>
     : ParseFatal<Sql>;
 

--- a/src/language/select/parse-select.ts
+++ b/src/language/select/parse-select.ts
@@ -5,8 +5,9 @@ import type {
   Trim,
 } from '../../string.js';
 import type { SelectQueryIR } from '../ir/query.js';
-import type { TableSourceIR } from '../ir/source.js';
-import type { ParseRootSource } from './parse-from.js';
+import type { PredicateIR } from '../ir/predicate.js';
+import type { SourceIR } from '../ir/source.js';
+import type { ParseNormalizedFromSources } from './parse-from.js';
 import type { ParseProjectionList } from './parse-projection.js';
 
 type SplitAtFrom<
@@ -42,21 +43,24 @@ type ParseBody<Body extends string, Sql extends string> =
   }
     ? Projection extends ''
       ? ParseFatal<Sql>
-      : [ParseRootSource<Source>] extends [never]
-        ? ParseFatal<Sql>
-        : ParseRootSource<Source> extends infer RootSource extends TableSourceIR
-          ? {
+      : ParseNormalizedFromSources<Source> extends {
+          sources: infer Sources extends readonly SourceIR[];
+          predicates: infer Predicates extends readonly PredicateIR[];
+        }
+        ? Sources extends readonly []
+          ? ParseFatal<Sql>
+          : {
               kind: 'ok';
               value: SelectQueryIR<
-                [RootSource],
+                Sources,
                 ParseProjectionList<Projection>,
-                [],
+                Predicates,
                 [],
                 []
               >;
               diagnostics: [];
             }
-          : ParseFatal<Sql>
+        : ParseFatal<Sql>
     : ParseFatal<Sql>;
 
 type ParseNormalized<Normalized extends string, Sql extends string> =

--- a/src/public/client.ts
+++ b/src/public/client.ts
@@ -1,10 +1,12 @@
 import type {
-  LegacyInferParams,
-  LegacyInferResult,
-  LegacyInferResultStrict,
   QueryTypeError,
   UsedPlaceholderStyles,
 } from '../compiler/legacy.js';
+import type {
+  InferParamsViaGateway,
+  InferStrictViaGateway,
+  InferViaGateway,
+} from '../compiler/gateway.js';
 import type { SchemaLike } from '../compiler/schema/model.js';
 import { createRuntimeDb } from '../runtime/db.js';
 import type {
@@ -55,12 +57,12 @@ export interface TypedDb<
   readonly __owlsqlTypedDb?: true;
   query<Q extends string>(
     sql: Q & ValidatePlaceholderStyle<Q, Style>,
-    ...params: LegacyInferParams<DB, Q>
+    ...params: InferParamsViaGateway<DB, Q>
   ): Promise<
     Result<
       Strict extends true
-        ? LegacyInferResultStrict<DB, Q>
-        : LegacyInferResult<DB, Q>,
+        ? InferStrictViaGateway<DB, Q>
+        : InferViaGateway<DB, Q>,
       QueryError
     >
   >;

--- a/src/public/query.ts
+++ b/src/public/query.ts
@@ -1,27 +1,27 @@
 import type {
-  LegacyInferParams,
-  LegacyInferResult,
-  LegacyInferResultStrict,
-  LegacyInferRow,
-  LegacyInferRowStrict,
-} from '../compiler/legacy.js';
+  InferParamsViaGateway,
+  InferRowViaGateway,
+  InferStrictRowViaGateway,
+  InferStrictViaGateway,
+  InferViaGateway,
+} from '../compiler/gateway.js';
 import type { SchemaLike } from '../compiler/schema/model.js';
 
 export type {
-  LegacyInferParams as InferParams,
-  LegacyInferResult as InferResult,
-  LegacyInferResultStrict as InferResultStrict,
-  LegacyInferRow as InferRow,
-  LegacyInferRowStrict as InferRowStrict,
-} from '../compiler/legacy.js';
+  InferParamsViaGateway as InferParams,
+  InferRowViaGateway as InferRow,
+  InferStrictRowViaGateway as InferRowStrict,
+  InferStrictViaGateway as InferResultStrict,
+  InferViaGateway as InferResult,
+} from '../compiler/gateway.js';
 
-export type Query<DB extends SchemaLike, Q extends string> = LegacyInferResult<DB, Q>;
+export type Query<DB extends SchemaLike, Q extends string> = InferViaGateway<DB, Q>;
 
-export type Row<DB extends SchemaLike, Q extends string> = LegacyInferRow<DB, Q>;
+export type Row<DB extends SchemaLike, Q extends string> = InferRowViaGateway<DB, Q>;
 
 export type StrictQuery<DB extends SchemaLike, Q extends string> =
-  LegacyInferResultStrict<DB, Q>;
+  InferStrictViaGateway<DB, Q>;
 
-export type StrictRow<DB extends SchemaLike, Q extends string> = LegacyInferRowStrict<DB, Q>;
+export type StrictRow<DB extends SchemaLike, Q extends string> = InferStrictRowViaGateway<DB, Q>;
 
-export type Params<DB extends SchemaLike, Q extends string> = LegacyInferParams<DB, Q>;
+export type Params<DB extends SchemaLike, Q extends string> = InferParamsViaGateway<DB, Q>;

--- a/src/string.ts
+++ b/src/string.ts
@@ -267,11 +267,58 @@ type EscapeQuotedSpaces<S extends string> = HasQuoteChar<S> extends false
       '"'
     >;
 
-export type Normalize<S extends string> = Trim<
+type HasNonSpaceWhitespace<S extends string> = S extends `${string}\t${string}`
+  ? true
+  : S extends `${string}\n${string}`
+    ? true
+    : S extends `${string}\r${string}`
+      ? true
+      : S extends `${string}\f${string}`
+        ? true
+        : S extends `${string}\v${string}`
+          ? true
+          : false;
+
+type HasSensitiveQuotedBody<S extends string> =
+  S extends `${infer Before}'${infer Body}'${infer After}`
+    ? Body extends
+        | `${string} ${string}`
+        | `${string},${string}`
+        | `${string}(${string}`
+        | `${string})${string}`
+        | `${string};${string}`
+        | `${string}$${string}`
+        | `${string}@${string}`
+        | `${string}?${string}`
+        | `${string}:${string}`
+      ? true
+      : HasSensitiveQuotedBody<`${Before}${After}`>
+    : false;
+
+type NeedsFullNormalize<S extends string> = HasNonSpaceWhitespace<S> extends true
+  ? true
+  : S extends
+      | `${string}  ${string}`
+      | `${string}--${string}`
+      | `${string}/*${string}`
+      | `${string};${string}`
+      | `${string}"${string}`
+      | `${string}\`${string}`
+      | `${string}[${string}`
+      | `${string}\\${string}`
+      | `${string}$${string}$${string}`
+    ? true
+    : HasSensitiveQuotedBody<S>;
+
+type FullNormalize<S extends string> = Trim<
   CollapseSpaces<
     EscapeQuotedSpaces<WhitespaceToSpace<RemoveTrailingSemicolons<StripCommentsAndMaskLiterals<S>>>>
   >
 >;
+
+export type Normalize<S extends string> = NeedsFullNormalize<S> extends true
+  ? FullNormalize<S>
+  : Trim<S>;
 
 type UnescapeSpaces<S extends string> = S extends `${infer Before}${QuotedSpace}${infer After}`
   ? UnescapeSpaces<`${Before} ${After}`>
@@ -311,10 +358,12 @@ export type MaskQuotedIdentifiers<S extends string, Accumulated extends string =
 // never mistaken for a separator) with quoted identifiers blanked on top of
 // it, since a column may legally be named `"a;b"`.
 export type HasNonTrailingSemicolon<S extends string> =
-  Trim<MaskQuotedIdentifiers<StripCommentsAndMaskLiterals<S>>> extends `${string};${infer After}`
-    ? Trim<After> extends ''
-      ? false
-      : true
+  S extends `${string};${string}`
+    ? Trim<MaskQuotedIdentifiers<StripCommentsAndMaskLiterals<S>>> extends `${string};${infer After}`
+      ? Trim<After> extends ''
+        ? false
+        : true
+      : false
     : false;
 
 export type Unquote<S extends string> = S extends `"${infer Inner}"`

--- a/tests/next/language-select.test-d.ts
+++ b/tests/next/language-select.test-d.ts
@@ -1,4 +1,4 @@
-import type { SelectQueryIR } from '../../src/language/ir/query.js';
+import type { SelectClausesIR, SelectQueryIR } from '../../src/language/ir/query.js';
 import type { ColumnProjectionIR } from '../../src/language/ir/projection.js';
 import type { TableSourceIR } from '../../src/language/ir/source.js';
 import type { ClassifyStatement } from '../../src/language/lexical/statement.js';
@@ -36,6 +36,8 @@ type _simple = Expect<
         ],
         [],
         [],
+        [],
+        SelectClausesIR,
         []
       >
     >
@@ -51,6 +53,8 @@ type _qualified = Expect<
         [ColumnProjectionIR<'u', 'id', 'user_id'>],
         [],
         [],
+        [],
+        SelectClausesIR,
         []
       >
     >

--- a/tests/next/select-parity.test-d.ts
+++ b/tests/next/select-parity.test-d.ts
@@ -249,3 +249,48 @@ type _setRow = Expect<Equal<
   NextRow<DB, 'select 1 as value union select 2'>,
   { value: number }
 >>;
+
+type _scalarSubquery = Expect<Equal<
+  LegacyInferResult<DB, 'select (select count(*) from posts where posts.user_id = users.id) as post_count from users'>,
+  NextQuery<DB, 'select (select count(*) from posts where posts.user_id = users.id) as post_count from users'>
+>>;
+
+type _scalarNullable = Expect<Equal<
+  LegacyInferResult<DB, 'select id, (select user_id from posts) as author from users'>,
+  NextQuery<DB, 'select id, (select user_id from posts) as author from users'>
+>>;
+
+type _lateralCorrelated = Expect<Equal<
+  LegacyInferResult<DB, 'select u.name, p.top_id from users u join lateral (select max(id) as top_id from posts where posts.user_id = u.id) p on true'>,
+  NextQuery<DB, 'select u.name, p.top_id from users u join lateral (select max(id) as top_id from posts where posts.user_id = u.id) p on true'>
+>>;
+
+type _derivedCorrelated = Expect<Equal<
+  LegacyInferResult<DB, 'select u.name, p.top_id from users u join (select max(id) as top_id from posts where posts.user_id = u.id) p on true'>,
+  NextQuery<DB, 'select u.name, p.top_id from users u join (select max(id) as top_id from posts where posts.user_id = u.id) p on true'>
+>>;
+
+type _scalarInnerTypo = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select (select count(*) from posts where posts.nope = users.id) as value from users'>,
+  NextStrictQuery<DB, 'select (select count(*) from posts where posts.nope = users.id) as value from users'>
+>>;
+
+type _derivedInnerTypo = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select u.name, p.top_id from users u join (select max(id) as top_id from posts where posts.nope = u.id) p on true'>,
+  NextStrictQuery<DB, 'select u.name, p.top_id from users u join (select max(id) as top_id from posts where posts.nope = u.id) p on true'>
+>>;
+
+type _noOuterScope = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select max(id) as top_id from posts where posts.user_id = u.id'>,
+  NextStrictQuery<DB, 'select max(id) as top_id from posts where posts.user_id = u.id'>
+>>;
+
+type _uncorrelatedScalar = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select (select count(*) from posts) as total from users'>,
+  NextStrictQuery<DB, 'select (select count(*) from posts) as total from users'>
+>>;
+
+type _invalidScalar = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select (select id, user_id from posts) as invalid from users'>,
+  NextStrictQuery<DB, 'select (select id, user_id from posts) as invalid from users'>
+>>;

--- a/tests/next/select-parity.test-d.ts
+++ b/tests/next/select-parity.test-d.ts
@@ -17,6 +17,8 @@ type DB = {
   users: {
     id: number;
     name: string;
+    active: boolean;
+    age: number;
   };
   posts: {
     id: number;
@@ -88,4 +90,84 @@ type _onAmbiguity = Expect<Equal<
 type _derived = Expect<Equal<
   LegacyInferResult<DB, 'select recent.id from (select id from users) recent'>,
   NextQuery<DB, 'select recent.id from (select id from users) recent'>
+>>;
+
+type _star = Expect<Equal<
+  LegacyInferResult<DB, 'select * from users'>,
+  NextQuery<DB, 'select * from users'>
+>>;
+
+type _qualifiedStar = Expect<Equal<
+  LegacyInferResult<DB, 'select u.* from users u'>,
+  NextQuery<DB, 'select u.* from users u'>
+>>;
+
+type _aggregates = Expect<Equal<
+  LegacyInferResult<DB, 'select count(*) as total, max(age) as oldest from users'>,
+  NextQuery<DB, 'select count(*) as total, max(age) as oldest from users'>
+>>;
+
+type _function = Expect<Equal<
+  LegacyInferResult<DB, 'select lower(name) as handle from users'>,
+  NextQuery<DB, 'select lower(name) as handle from users'>
+>>;
+
+type _case = Expect<Equal<
+  LegacyInferResult<DB, "select case when active then 'yes' else 'no' end as status from users">,
+  NextQuery<DB, "select case when active then 'yes' else 'no' end as status from users">
+>>;
+
+type _cast = Expect<Equal<
+  LegacyInferResult<DB, 'select id::text as id_text from users'>,
+  NextQuery<DB, 'select id::text as id_text from users'>
+>>;
+
+type _literal = Expect<Equal<
+  LegacyInferResult<DB, "select 1 as one, 'x' as tag, true as flag, null as nothing">,
+  NextQuery<DB, "select 1 as one, 'x' as tag, true as flag, null as nothing">
+>>;
+
+type _unsupportedExpression = Expect<Equal<
+  LegacyInferResult<DB, 'select id * 2 as doubled from users'>,
+  NextQuery<DB, 'select id * 2 as doubled from users'>
+>>;
+
+type _strictFunctionError = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select max(naem) as oldest from users'>,
+  NextStrictQuery<DB, 'select max(naem) as oldest from users'>
+>>;
+
+type _commonFunctions = Expect<Equal<
+  LegacyInferResult<DB, 'select concat(name, name) as full_name, now() as created from users'>,
+  NextQuery<DB, 'select concat(name, name) as full_name, now() as created from users'>
+>>;
+
+type _unaliasedFunction = Expect<Equal<
+  LegacyInferResult<DB, 'select count(*) from users'>,
+  NextQuery<DB, 'select count(*) from users'>
+>>;
+
+type _nestedCase = Expect<Equal<
+  LegacyInferResult<DB, "select case when active then case when age < 18 then 'minor' else 'adult' end else 'inactive' end as status from users">,
+  NextQuery<DB, "select case when active then case when age < 18 then 'minor' else 'adult' end else 'inactive' end as status from users">
+>>;
+
+type _parenthesizedColumn = Expect<Equal<
+  LegacyInferResult<DB, 'select (u.name) as handle from users u'>,
+  NextQuery<DB, 'select (u.name) as handle from users u'>
+>>;
+
+type _window = Expect<Equal<
+  LegacyInferResult<DB, 'select row_number() over (order by id) as rn from users'>,
+  NextQuery<DB, 'select row_number() over (order by id) as rn from users'>
+>>;
+
+type _strictCastError = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select naem::text as value from users'>,
+  NextStrictQuery<DB, 'select naem::text as value from users'>
+>>;
+
+type _leftJoinStar = Expect<Equal<
+  LegacyInferResult<DB, 'select * from users u left join posts p on u.id = p.user_id'>,
+  NextQuery<DB, 'select * from users u left join posts p on u.id = p.user_id'>
 >>;

--- a/tests/next/select-parity.test-d.ts
+++ b/tests/next/select-parity.test-d.ts
@@ -294,3 +294,33 @@ type _invalidScalar = Expect<Equal<
   LegacyInferResultStrict<DB, 'select (select id, user_id from posts) as invalid from users'>,
   NextStrictQuery<DB, 'select (select id, user_id from posts) as invalid from users'>
 >>;
+
+type _postgresDistinctOn = Expect<Equal<
+  LegacyInferResult<DB, 'select distinct on (active) id, name from users'>,
+  NextQuery<DB, 'select distinct on (active) id, name from users'>
+>>;
+
+type _postgresCastParam = Expect<Equal<
+  LegacyInferParams<DB, 'select id::text from users where id = $1'>,
+  NextInferParams<DB, 'select id::text from users where id = $1'>
+>>;
+
+type _mssqlTop = Expect<Equal<
+  LegacyInferResult<DB, 'select top 10 with ties id, name from users order by name'>,
+  NextQuery<DB, 'select top 10 with ties id, name from users order by name'>
+>>;
+
+type _mssqlBrackets = Expect<Equal<
+  LegacyInferResult<DB, 'select [id], [name] from [users]'>,
+  NextQuery<DB, 'select [id], [name] from [users]'>
+>>;
+
+type _mysqlQuotes = Expect<Equal<
+  LegacyInferResult<DB, 'select `id`, `name` from `users`'>,
+  NextQuery<DB, 'select `id`, `name` from `users`'>
+>>;
+
+type _questionPlaceholder = Expect<Equal<
+  LegacyInferParams<DB, 'select id from users where id = ? and active = ?'>,
+  NextInferParams<DB, 'select id from users where id = ? and active = ?'>
+>>;

--- a/tests/next/select-parity.test-d.ts
+++ b/tests/next/select-parity.test-d.ts
@@ -1,9 +1,12 @@
 import type {
+  LegacyInferParams,
   LegacyInferResult,
   LegacyInferResultStrict,
 } from '../../src/compiler/legacy.js';
 import type {
   NextQuery,
+  NextInferParams,
+  NextRow,
   NextStrictQuery,
 } from '../../src/compiler/next/index.js';
 
@@ -170,4 +173,79 @@ type _strictCastError = Expect<Equal<
 type _leftJoinStar = Expect<Equal<
   LegacyInferResult<DB, 'select * from users u left join posts p on u.id = p.user_id'>,
   NextQuery<DB, 'select * from users u left join posts p on u.id = p.user_id'>
+>>;
+
+type _where = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select id from users where age > 18 and active = true'>,
+  NextStrictQuery<DB, 'select id from users where age > 18 and active = true'>
+>>;
+
+type _whereTypo = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select id from users where naem = $1'>,
+  NextStrictQuery<DB, 'select id from users where naem = $1'>
+>>;
+
+type _comparisonParams = Expect<Equal<
+  LegacyInferParams<DB, 'select id from users where id = $1 and name = $2'>,
+  NextInferParams<DB, 'select id from users where id = $1 and name = $2'>
+>>;
+
+type _predicateParams = Expect<Equal<
+  LegacyInferParams<DB, 'select id from users where name like $1 or name ilike $2 or id in ($3)'>,
+  NextInferParams<DB, 'select id from users where name like $1 or name ilike $2 or id in ($3)'>
+>>;
+
+type _betweenParams = Expect<Equal<
+  LegacyInferParams<DB, 'select id from users where age between $1 and $2'>,
+  NextInferParams<DB, 'select id from users where age between $1 and $2'>
+>>;
+
+type _arrayParam = Expect<Equal<
+  LegacyInferParams<DB, 'select id from users where id = any($1)'>,
+  NextInferParams<DB, 'select id from users where id = any($1)'>
+>>;
+
+type _namedParams = Expect<Equal<
+  LegacyInferParams<DB, 'select id from users where id = @id or name = :name'>,
+  NextInferParams<DB, 'select id from users where id = @id or name = :name'>
+>>;
+
+type _questionParams = Expect<Equal<
+  LegacyInferParams<DB, 'select id from users where id = ? and active = ?'>,
+  NextInferParams<DB, 'select id from users where id = ? and active = ?'>
+>>;
+
+type _conflictingParams = Expect<Equal<
+  LegacyInferParams<DB, 'select id from users where id = $1 or name = $1'>,
+  NextInferParams<DB, 'select id from users where id = $1 or name = $1'>
+>>;
+
+type _limitOffsetParams = Expect<Equal<
+  LegacyInferParams<DB, 'select id from users limit $1 offset $2'>,
+  NextInferParams<DB, 'select id from users limit $1 offset $2'>
+>>;
+
+type _groupHaving = Expect<Equal<
+  LegacyInferResult<DB, 'select active, count(*) as total from users group by active having count(*) > 1 order by active'>,
+  NextQuery<DB, 'select active, count(*) as total from users group by active having count(*) > 1 order by active'>
+>>;
+
+type _havingParams = Expect<Equal<
+  LegacyInferParams<DB, 'select active from users group by active having count(*) > $1'>,
+  NextInferParams<DB, 'select active from users group by active having count(*) > $1'>
+>>;
+
+type _union = Expect<Equal<
+  LegacyInferResult<DB, 'select id from users union all select user_id as id from posts'>,
+  NextQuery<DB, 'select id from users union all select user_id as id from posts'>
+>>;
+
+type _literalSetOperations = Expect<Equal<
+  LegacyInferResult<DB, 'select 1 as value intersect select 1 except select 2'>,
+  NextQuery<DB, 'select 1 as value intersect select 1 except select 2'>
+>>;
+
+type _setRow = Expect<Equal<
+  NextRow<DB, 'select 1 as value union select 2'>,
+  { value: number }
 >>;

--- a/tests/next/select-parity.test-d.ts
+++ b/tests/next/select-parity.test-d.ts
@@ -18,6 +18,11 @@ type DB = {
     id: number;
     name: string;
   };
+  posts: {
+    id: number;
+    user_id: number;
+    title: string;
+  };
 };
 
 type _simple = Expect<Equal<
@@ -48,4 +53,39 @@ type _unknownLoose = Expect<Equal<
 type _unknownStrict = Expect<Equal<
   LegacyInferResultStrict<DB, 'select nope from users'>,
   NextStrictQuery<DB, 'select nope from users'>
+>>;
+
+type _innerJoin = Expect<Equal<
+  LegacyInferResult<DB, 'select u.id, p.title from users u join posts p on u.id = p.user_id'>,
+  NextQuery<DB, 'select u.id, p.title from users u join posts p on u.id = p.user_id'>
+>>;
+
+type _leftJoin = Expect<Equal<
+  LegacyInferResult<DB, 'select u.name, p.title from users u left join posts p on u.id = p.user_id'>,
+  NextQuery<DB, 'select u.name, p.title from users u left join posts p on u.id = p.user_id'>
+>>;
+
+type _rightJoin = Expect<Equal<
+  LegacyInferResult<DB, 'select u.name, p.title from users u right join posts p on u.id = p.user_id'>,
+  NextQuery<DB, 'select u.name, p.title from users u right join posts p on u.id = p.user_id'>
+>>;
+
+type _fullJoin = Expect<Equal<
+  LegacyInferResult<DB, 'select u.name, p.title from users u full join posts p on u.id = p.user_id'>,
+  NextQuery<DB, 'select u.name, p.title from users u full join posts p on u.id = p.user_id'>
+>>;
+
+type _using = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select id from users join posts using (id)'>,
+  NextStrictQuery<DB, 'select id from users join posts using (id)'>
+>>;
+
+type _onAmbiguity = Expect<Equal<
+  LegacyInferResultStrict<DB, 'select id from users join posts on users.id = posts.id'>,
+  NextStrictQuery<DB, 'select id from users join posts on users.id = posts.id'>
+>>;
+
+type _derived = Expect<Equal<
+  LegacyInferResult<DB, 'select recent.id from (select id from users) recent'>,
+  NextQuery<DB, 'select recent.id from (select id from users) recent'>
 >>;

--- a/tests/perf/select-next-baseline.json
+++ b/tests/perf/select-next-baseline.json
@@ -1,0 +1,4 @@
+{
+  "typescript": "5.9.3",
+  "instantiations": 21435
+}

--- a/tests/perf/tsconfig.json
+++ b/tests/perf/tsconfig.json
@@ -13,5 +13,5 @@
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["generated", "select-next.test-d.ts"]
+  "include": ["generated"]
 }

--- a/tests/perf/tsconfig.next.json
+++ b/tests/perf/tsconfig.next.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["select-next.test-d.ts"]
+}


### PR DESCRIPTION
## Summary

- migrate SELECT sources, joins, expressions, predicates, parameters, and subquery scopes
- isolate SELECT dialect capabilities
- route supported SELECT inference through the Next compiler

## Verification

- `npm test`: 217 passed, 36 skipped
- architecture fitness checks passed
- `npm run test:perf`: 223,663 instantiations, below the 225,000 budget

## Stack

Depends on #359.
