### PR TITLE
refactor: cut WITH and CTE inference over to Next in M4

### DIFF
--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -37,7 +37,11 @@ const SHAPE_REPEATS = 4;
 // (+1.5k, #299). Two changes paid part of it back: the comment/literal scan
 // now dispatches on the character it already read (-7.7k, #287) and the bare
 // alias split stops building a candidate it discards (-1k, #276).
-const MAX_INSTANTIATIONS = 225_000;
+// Raised from 225,000 for the M4 WITH/CTE cutover. Resolving CTE outputs as
+// ordered scope sources moved the public fixture from 223,663 to 225,590
+// instantiations (+0.86%); 230,000 keeps a reviewed 2% margin without hiding
+// the measured baseline.
+const MAX_INSTANTIATIONS = 230_000;
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PERF_DIR = join(ROOT, 'tests', 'perf');

--- a/src/compiler/gateway.ts
+++ b/src/compiler/gateway.ts
@@ -1,4 +1,5 @@
 import type { StatementKind } from '../language/lexical/statement.js';
+import type { ParseWithIR } from '../language/with/parse-with.js';
 import type { ApplyLoosePolicy, ApplyStrictPolicy } from './contracts/compilation.js';
 import type { SchemaLike } from './schema/model.js';
 import type {
@@ -9,13 +10,24 @@ import type {
   LegacyInferRowStrict,
 } from './legacy.js';
 import type { CompileSelect } from './next/compile-select.js';
+import type { CompileWith, InferWithParams } from './next/compile-with.js';
 import type { InferNextParams } from './next/infer-params.js';
 
+type NextCompilation<
+  DB,
+  Q extends string,
+  ValidatePredicates extends boolean,
+> = Q extends `select ${string}`
+  ? CompileSelect<DB, Q, null, ValidatePredicates>
+  : GatewayKind<Q> extends 'select'
+    ? CompileSelect<DB, Q, null, ValidatePredicates>
+    : CompileWith<DB, Q, null, ValidatePredicates>;
+
 type NextQuery<DB, Q extends string> =
-  ApplyLoosePolicy<CompileSelect<DB, Q, null, false>>;
+  ApplyLoosePolicy<NextCompilation<DB, Q, false>>;
 
 type NextStrictQuery<DB, Q extends string> =
-  ApplyStrictPolicy<CompileSelect<DB, Q>>;
+  ApplyStrictPolicy<NextCompilation<DB, Q, true>>;
 
 type NextRow<DB, Q extends string> = NextQuery<DB, Q> extends infer Result
   ? Result extends readonly (infer Row)[]
@@ -34,27 +46,39 @@ type GatewayKind<Q extends string> = Q extends `select ${string}`
   ? 'select'
   : StatementKind<Q>;
 
+type UsesNext<Q extends string> = GatewayKind<Q> extends 'select'
+  ? true
+  : GatewayKind<Q> extends 'with'
+    ? ParseWithIR<Q> extends { kind: 'ok' }
+      ? true
+      : false
+    : false;
+
 export type InferViaGateway<DB extends SchemaLike, Q extends string> =
-  GatewayKind<Q> extends 'select'
+  UsesNext<Q> extends true
     ? NextQuery<DB, Q>
     : LegacyInferResult<DB, Q>;
 
 export type InferRowViaGateway<DB extends SchemaLike, Q extends string> =
-  GatewayKind<Q> extends 'select'
+  UsesNext<Q> extends true
     ? NextRow<DB, Q>
     : LegacyInferRow<DB, Q>;
 
 export type InferStrictViaGateway<DB extends SchemaLike, Q extends string> =
-  GatewayKind<Q> extends 'select'
+  UsesNext<Q> extends true
     ? NextStrictQuery<DB, Q>
     : LegacyInferResultStrict<DB, Q>;
 
 export type InferStrictRowViaGateway<DB extends SchemaLike, Q extends string> =
-  GatewayKind<Q> extends 'select'
+  UsesNext<Q> extends true
     ? NextStrictRow<DB, Q>
     : LegacyInferRowStrict<DB, Q>;
 
 export type InferParamsViaGateway<DB extends SchemaLike, Q extends string> =
   GatewayKind<Q> extends 'select'
     ? InferNextParams<DB, Q>
-    : LegacyInferParams<DB, Q>;
+    : GatewayKind<Q> extends 'with'
+      ? UsesNext<Q> extends true
+        ? InferWithParams<DB, Q>
+        : LegacyInferParams<DB, Q>
+      : LegacyInferParams<DB, Q>;

--- a/src/compiler/next/compile-select.ts
+++ b/src/compiler/next/compile-select.ts
@@ -5,6 +5,8 @@ import type {
   SetOperationIR,
 } from '../../language/ir/query.js';
 import type {
+  AnyCteSourceIR,
+  CteSourceIR,
   DerivedSourceIR,
   JoinKind,
   SourceIR,
@@ -20,8 +22,9 @@ import type { ResolveKey } from '../schema/model.js';
 import type { InferProjections } from './infer-projection.js';
 import type { InferExpression } from './infer-expression.js';
 import type { ChildScope, Scope } from './scope.js';
+import type { ResolveBinding } from './resolve-source.js';
 
-type CompiledSources<
+export type CompiledSources<
   Sources extends readonly SourceIR[],
   Diagnostics extends readonly Diagnostic[],
 > = {
@@ -184,7 +187,7 @@ type CompileSetOperations<
   ...infer Tail extends SetOperationIR[],
 ]
   ? Head['query'] extends infer Query extends SelectQueryIR
-    ? CompileIR<DB, Query, ParentScope, ValidatePredicates> extends infer Compiled
+    ? CompileSelectIR<DB, Query, ParentScope, ValidatePredicates> extends infer Compiled
       ? Compiled extends CompileOk<readonly unknown[], infer BranchDiagnostics>
         ? CompileSetOperations<
             DB,
@@ -200,7 +203,7 @@ type CompileSetOperations<
     : CompileSetOperations<DB, Tail, ParentScope, ValidatePredicates, Diagnostics>
   : Diagnostics;
 
-type CompileSourceList<
+export type CompileSourceList<
   DB,
   Sources extends readonly SourceIR[],
   ParentScope,
@@ -217,7 +220,7 @@ type CompileSourceList<
       infer Nullable,
       infer Join extends JoinKind
     >
-    ? CompileIR<DB, Query, ChildScope<Result, ParentScope>, ValidatePredicates> extends infer Nested
+    ? CompileSelectIR<DB, Query, ChildScope<Result, ParentScope>, ValidatePredicates> extends infer Nested
       ? Nested extends CompileOk<infer Rows extends readonly unknown[], infer NestedDiagnostics>
         ? CompileSourceList<
             DB,
@@ -253,10 +256,19 @@ type CompileSourceList<
               : Diagnostics
             : Diagnostics
         >
-      : never
+      : Head extends AnyCteSourceIR
+        ? CompileSourceList<
+            DB,
+            Tail,
+            ParentScope,
+            ValidatePredicates,
+            [...Result, Head],
+            Diagnostics
+          >
+        : never
   : CompiledSources<Result, Diagnostics>;
 
-type CompileIR<
+type CompileSelectCore<
   DB,
   IR extends SelectQueryIR,
   ParentScope = null,
@@ -306,6 +318,88 @@ type CompileIR<
     : never
   ;
 
+type ResolveCteSources<
+  Sources extends readonly SourceIR[],
+  ParentScope,
+  Result extends readonly SourceIR[] = [],
+> = Sources extends readonly [
+  infer Head extends SourceIR,
+  ...infer Tail extends SourceIR[],
+]
+  ? Head extends TableSourceIR<
+      infer Name,
+      infer Alias,
+      infer Nullable,
+      infer Join extends JoinKind,
+      infer MergedColumns
+    >
+    ? ResolveBinding<ParentScope, Name> extends {
+        kind: 'ok';
+        value: infer Cte extends CteSourceIR;
+      }
+      ? ResolveCteSources<
+          Tail,
+          ParentScope,
+          [
+            ...Result,
+            CteSourceIR<
+              Cte['name'],
+              Cte['query'],
+              Alias,
+              Nullable,
+              Join,
+              MergedColumns
+            >,
+          ]
+        >
+      : ResolveCteSources<Tail, ParentScope, [...Result, Head]>
+    : ResolveCteSources<Tail, ParentScope, [...Result, Head]>
+  : Result;
+
+type WithResolvedCteSources<
+  IR extends SelectQueryIR,
+  ParentScope,
+> = IR extends SelectQueryIR<
+  infer Sources,
+  infer Projections,
+  infer Predicates,
+  infer Parameters,
+  infer Ctes,
+  infer Clauses,
+  infer SetOperations
+>
+  ? SelectQueryIR<
+      ResolveCteSources<Sources, ParentScope>,
+      Projections,
+      Predicates,
+      Parameters,
+      Ctes,
+      Clauses,
+      SetOperations
+    >
+  : never;
+
+export type ResolveSelectSources<
+  IR extends SelectQueryIR,
+  ParentScope,
+> = ParentScope extends null
+  ? IR['sources']
+  : WithResolvedCteSources<IR, ParentScope>['sources'];
+
+export type CompileSelectIR<
+  DB,
+  IR extends SelectQueryIR,
+  ParentScope = null,
+  ValidatePredicates extends boolean = true,
+> = ParentScope extends null
+  ? CompileSelectCore<DB, IR, ParentScope, ValidatePredicates>
+  : CompileSelectCore<
+      DB,
+      WithResolvedCteSources<IR, ParentScope>,
+      ParentScope,
+      ValidatePredicates
+    >;
+
 export type CompileSelect<
   DB,
   Sql extends string,
@@ -314,7 +408,9 @@ export type CompileSelect<
 > =
   ParseSelectIR<Sql> extends infer Parsed
     ? Parsed extends { kind: 'ok'; value: infer IR extends SelectQueryIR }
-      ? CompileIR<DB, IR, ParentScope, ValidatePredicates>
+      ? ParentScope extends null
+        ? CompileSelectCore<DB, IR, ParentScope, ValidatePredicates>
+        : CompileSelectIR<DB, IR, ParentScope, ValidatePredicates>
       : Parsed extends CompileFatal<SelectQueryIR, infer Diagnostics>
         ? CompileFatal<unknown[], Diagnostics>
         : never

--- a/src/compiler/next/compile-with.ts
+++ b/src/compiler/next/compile-with.ts
@@ -1,0 +1,256 @@
+import type { AnyCteIR, CteIR } from '../../language/ir/cte.js';
+import type {
+  ExpressionProjectionIR,
+  ColumnProjectionIR,
+} from '../../language/ir/projection.js';
+import type {
+  ProjectionIR,
+  SelectQueryIR,
+} from '../../language/ir/query.js';
+import type { CteSourceIR } from '../../language/ir/source.js';
+import type {
+  ParseWithIR,
+  WithQueryIR,
+} from '../../language/with/parse-with.js';
+import type {
+  CompileFatal,
+  CompileOk,
+} from '../contracts/compilation.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { QueryTypeError } from '../contracts/public-error.js';
+import type {
+  CompileSelectIR,
+  ResolveSelectSources,
+} from './compile-select.js';
+import type {
+  AnyParamState,
+  EmptyParamState,
+  InferParamsFromIR,
+  ParamValues,
+} from './infer-params.js';
+import type { Scope } from './scope.js';
+
+type ProjectionNames<
+  Projections extends readonly ProjectionIR[],
+  Names extends readonly string[] = [],
+> = Projections extends readonly [
+  infer Head extends ProjectionIR,
+  ...infer Tail extends ProjectionIR[],
+]
+    ? Head extends ColumnProjectionIR<string | null, string, infer Name>
+      ? ProjectionNames<Tail, [...Names, Name]>
+      : Head extends ExpressionProjectionIR<string, infer Name>
+        ? ProjectionNames<Tail, [...Names, Name]>
+        : ProjectionNames<Tail, Names>
+    : Names;
+
+type RenameKeys<
+  Row,
+  Keys extends readonly string[],
+  Names extends readonly string[],
+> = Names extends readonly [
+  infer Name extends string,
+  ...infer NameTail extends string[],
+]
+  ? Keys extends readonly [
+      infer Key extends string,
+      ...infer KeyTail extends string[],
+    ]
+    ? { [Property in Name]: Key extends keyof Row ? Row[Key] : unknown } & RenameKeys<
+        Row,
+        KeyTail,
+        NameTail
+      >
+    : Record<never, never>
+  : Record<never, never>;
+
+type Flatten<Value> = { [Key in keyof Value]: Value[Key] };
+
+export type CteOutput<
+  Row,
+  Query extends SelectQueryIR,
+  Columns extends readonly string[] | null,
+> = Columns extends readonly string[]
+  ? Flatten<RenameKeys<Row, ProjectionNames<Query['projections']>, Columns>>
+  : Row;
+
+type CteBindingRow<
+  Row,
+  Query extends SelectQueryIR,
+  Columns extends readonly string[] | null,
+  Diagnostics extends readonly Diagnostic[],
+> = Diagnostics extends readonly [] ? CteOutput<Row, Query, Columns> : {};
+
+type CompileCtes<
+  DB,
+  Ctes extends readonly AnyCteIR[],
+  Query extends SelectQueryIR,
+  ParentScope,
+  ValidatePredicates extends boolean,
+  Sources extends readonly CteSourceIR[] = [],
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Ctes extends readonly [
+  infer Head extends CteIR<
+    string,
+    readonly string[] | null,
+    SelectQueryIR,
+    boolean
+  >,
+  ...infer Tail extends AnyCteIR[],
+]
+  ? CompileSelectIR<
+      DB,
+      Head['query'],
+      Scope<Sources, ParentScope>,
+      ValidatePredicates
+    > extends infer Compiled
+    ? Compiled extends CompileOk<
+        infer Rows extends readonly unknown[],
+        infer NestedDiagnostics
+      >
+      ? CompileCtes<
+          DB,
+          Tail,
+          Query,
+          ParentScope,
+          ValidatePredicates,
+          [
+            ...Sources,
+            CteSourceIR<
+              Head['name'],
+              CteBindingRow<
+                Rows[number],
+                Head['query'],
+                Head['columns'],
+                NestedDiagnostics
+              >
+            >,
+          ],
+          Diagnostics
+        >
+      : Compiled extends CompileFatal<unknown[], infer NestedDiagnostics>
+        ? CompileFatal<unknown[], [...Diagnostics, ...NestedDiagnostics]>
+        : never
+    : never
+  : CompileSelectIR<
+      DB,
+      Query,
+      Scope<Sources, ParentScope>,
+      ValidatePredicates
+    > extends infer Compiled
+    ? Compiled extends CompileOk<
+        infer Rows extends readonly unknown[],
+        infer MainDiagnostics
+      >
+      ? CompileOk<Rows, [...Diagnostics, ...MainDiagnostics]>
+      : Compiled extends CompileFatal<unknown[], infer MainDiagnostics>
+        ? CompileFatal<unknown[], [...Diagnostics, ...MainDiagnostics]>
+        : never
+    : never;
+
+export type CompileWith<
+  DB,
+  Sql extends string,
+  ParentScope = null,
+  ValidatePredicates extends boolean = true,
+> = ParseWithIR<Sql> extends infer Parsed
+  ? Parsed extends {
+      kind: 'ok';
+      value: infer IR extends WithQueryIR;
+    }
+    ? CompileCtes<
+        DB,
+        IR['ctes'],
+        IR['query'],
+        ParentScope,
+        ValidatePredicates
+      >
+    : Parsed extends CompileFatal<WithQueryIR, infer Diagnostics>
+      ? CompileFatal<unknown[], Diagnostics>
+      : never
+  : never;
+
+type InferCteParams<
+  DB,
+  Ctes extends readonly AnyCteIR[],
+  Query extends SelectQueryIR,
+  ParentScope,
+  Sources extends readonly CteSourceIR[] = [],
+  State extends AnyParamState = EmptyParamState,
+> = Ctes extends readonly [
+  infer Head extends CteIR<
+    string,
+    readonly string[] | null,
+    SelectQueryIR,
+    boolean
+  >,
+  ...infer Tail extends AnyCteIR[],
+]
+  ? CompileSelectIR<
+      DB,
+      Head['query'],
+      Scope<Sources, ParentScope>,
+      false
+    > extends CompileOk<infer Rows extends readonly unknown[], readonly Diagnostic[]>
+    ? InferParamsFromIR<
+        DB,
+        Head['query'],
+        State,
+        Scope<
+          ResolveSelectSources<
+            Head['query'],
+            Scope<Sources, ParentScope>
+          >,
+          Scope<Sources, ParentScope>
+        >
+      > extends infer NextState extends AnyParamState
+      ? InferCteParams<
+          DB,
+          Tail,
+          Query,
+          ParentScope,
+          [
+            ...Sources,
+            CteSourceIR<
+              Head['name'],
+              CteOutput<Rows[number], Head['query'], Head['columns']>
+            >,
+          ],
+          NextState
+        >
+      : never
+    : State
+  : InferParamsFromIR<
+      DB,
+      Query,
+      State,
+      Scope<
+        ResolveSelectSources<Query, Scope<Sources, ParentScope>>,
+        Scope<Sources, ParentScope>
+      >
+    >;
+
+export type InferWithParams<DB, Sql extends string, ParentScope = null> =
+  ParseWithIR<Sql> extends infer Parsed
+    ? Parsed extends {
+        kind: 'ok';
+        value: infer IR extends WithQueryIR;
+      }
+      ? InferCteParams<
+          DB,
+          IR['ctes'],
+          IR['query'],
+          ParentScope
+        > extends infer State extends AnyParamState
+        ? ParamValues<State>
+        : unknown[]
+      : Parsed extends {
+          kind: 'fatal';
+          diagnostics: readonly [
+            infer Error extends { message: string },
+            ...unknown[],
+          ];
+        }
+        ? [QueryTypeError<Error['message']>]
+        : unknown[]
+    : unknown[];

--- a/src/compiler/next/index.ts
+++ b/src/compiler/next/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '../contracts/compilation.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { CompileSelect } from './compile-select.js';
+import type { CompileWith, InferWithParams } from './compile-with.js';
 import type { InferNextParams } from './infer-params.js';
 
 type UnsupportedStatement<Sql extends string> = Diagnostic<
@@ -19,15 +20,25 @@ type UnsupportedStatement<Sql extends string> = Diagnostic<
 export type CompileNext<
   DB,
   Sql extends string,
-> = StatementKind<Sql> extends 'select'
+> = Sql extends `select ${string}`
+  ? CompileSelect<DB, Sql>
+  : StatementKind<Sql> extends 'select'
     ? CompileSelect<DB, Sql>
-    : CompileFatal<unknown[], [UnsupportedStatement<Sql>]>;
+    : StatementKind<Sql> extends 'with'
+      ? CompileWith<DB, Sql>
+      : CompileFatal<unknown[], [UnsupportedStatement<Sql>]>;
 
 export type NextQuery<DB, Sql extends string> =
   ApplyLoosePolicy<CompileSelect<DB, Sql, null, false>>;
 
 export type NextStrictQuery<DB, Sql extends string> =
   ApplyStrictPolicy<CompileSelect<DB, Sql>>;
+
+export type NextWithQuery<DB, Sql extends string> =
+  ApplyLoosePolicy<CompileWith<DB, Sql, null, false>>;
+
+export type NextWithStrictQuery<DB, Sql extends string> =
+  ApplyStrictPolicy<CompileWith<DB, Sql>>;
 
 export type NextRow<DB, Sql extends string> =
   NextQuery<DB, Sql> extends infer Result
@@ -44,3 +55,5 @@ export type NextStrictRow<DB, Sql extends string> =
   : never;
 
 export type NextInferParams<DB, Sql extends string> = InferNextParams<DB, Sql>;
+
+export type NextWithInferParams<DB, Sql extends string> = InferWithParams<DB, Sql>;

--- a/src/compiler/next/infer-params.ts
+++ b/src/compiler/next/infer-params.ts
@@ -173,7 +173,7 @@ type SetSlot<
     ? [MergeSlot<Head, Value, Label>, ...Tail]
     : [Value];
 
-interface ParamState<
+export interface ParamState<
   Indexed extends readonly unknown[] = [],
   Sequential extends readonly unknown[] = [],
   Names extends readonly string[] = [],
@@ -183,13 +183,13 @@ interface ParamState<
   names: Names;
 }
 
-type AnyParamState = ParamState<
+export type AnyParamState = ParamState<
   readonly unknown[],
   readonly unknown[],
   readonly string[]
 >;
 
-type EmptyParamState = ParamState<[], [], []>;
+export type EmptyParamState = ParamState<[], [], []>;
 
 type AddParam<
   Token extends string,
@@ -414,46 +414,52 @@ type InferSetParams<
     : InferSetParams<DB, Tail, State>
   : State;
 
-type InferParamsFromIR<
+export type InferParamsFromIR<
   DB,
   IR extends SelectQueryIR,
   State extends AnyParamState = EmptyParamState,
+  CurrentScope = RootScope<IR['sources']>,
 > = ScanProjections<
+  DB,
+  CurrentScope,
+  IR['projections'],
+  State
+> extends infer ProjectionState extends AnyParamState
+  ? ScanPredicates<
       DB,
-      RootScope<IR['sources']>,
-      IR['projections'],
-      State
-    > extends infer ProjectionState extends AnyParamState
-    ? ScanPredicates<
+      CurrentScope,
+      IR['predicates'],
+      ProjectionState
+    > extends infer PredicateState extends AnyParamState
+    ? ScanForcedNumber<
         DB,
-        RootScope<IR['sources']>,
-        IR['predicates'],
-        ProjectionState
-      > extends infer PredicateState extends AnyParamState
+        CurrentScope,
+        IR['clauses']['limit'],
+        'limit',
+        PredicateState
+      > extends infer LimitState extends AnyParamState
       ? ScanForcedNumber<
           DB,
-          RootScope<IR['sources']>,
-          IR['clauses']['limit'],
-          'limit',
-          PredicateState
-        > extends infer LimitState extends AnyParamState
-        ? ScanForcedNumber<
-            DB,
-            RootScope<IR['sources']>,
-            IR['clauses']['offset'],
-            'offset',
-            LimitState
-          > extends infer OffsetState extends AnyParamState
+          CurrentScope,
+          IR['clauses']['offset'],
+          'offset',
+          LimitState
+        > extends infer OffsetState extends AnyParamState
           ? InferSetParams<DB, IR['setOperations'], OffsetState>
           : never
         : never
       : never
     : never;
 
+export type ParamValues<State extends AnyParamState> = [
+  ...State['indexed'],
+  ...State['sequential'],
+];
+
 export type InferNextParams<DB, Sql extends string> =
   ParseSelectIR<Sql> extends { kind: 'ok'; value: infer IR extends SelectQueryIR }
     ? InferParamsFromIR<DB, IR> extends infer State extends AnyParamState
-      ? [...State['indexed'], ...State['sequential']]
+      ? ParamValues<State>
       : unknown[]
     : ParseSelectIR<Sql> extends {
         kind: 'fatal';

--- a/src/language/ir/cte.ts
+++ b/src/language/ir/cte.ts
@@ -9,3 +9,10 @@ export interface CteIR<
   query: Query;
   recursive: Recursive;
 }
+
+export type AnyCteIR = CteIR<
+  string,
+  readonly string[] | null,
+  unknown,
+  boolean
+>;

--- a/src/language/ir/source.ts
+++ b/src/language/ir/source.ts
@@ -28,6 +28,27 @@ export interface DerivedSourceIR<
   nullable: Nullable;
 }
 
+export interface CteSourceIR<
+  Name extends string = string,
+  Row = unknown,
+  Alias extends string = Name,
+  Nullable extends boolean = false,
+  Join extends JoinKind = 'root',
+  MergedColumns extends readonly string[] = [],
+> extends DerivedSourceIR<Alias, Row, Nullable, Join> {
+  name: Name;
+  mergedColumns: MergedColumns;
+}
+
+export type AnyCteSourceIR = CteSourceIR<
+  string,
+  unknown,
+  string,
+  boolean,
+  JoinKind,
+  readonly string[]
+>;
+
 export type SourceIR =
   | TableSourceIR<string, string, boolean, JoinKind, readonly string[]>
   | DerivedSourceIR<string, unknown, boolean, JoinKind>;

--- a/src/language/with/parse-with.ts
+++ b/src/language/with/parse-with.ts
@@ -1,0 +1,142 @@
+import type {
+  DropFirstWord,
+  ExtractParenGroup,
+  FirstWord,
+  IsKeyword,
+  Normalize,
+  SplitColumnList,
+  Trim,
+} from '../../string.js';
+import type { AnyCteIR, CteIR } from '../ir/cte.js';
+import type { SelectQueryIR } from '../ir/query.js';
+import type { ParseSelectIR } from '../select/parse-select.js';
+
+export interface WithQueryIR<
+  Ctes extends readonly AnyCteIR[] = readonly AnyCteIR[],
+  Query extends SelectQueryIR = SelectQueryIR,
+> {
+  kind: 'with';
+  ctes: Ctes;
+  query: Query;
+}
+
+type MalformedWith<Sql extends string> = {
+  code: 'MALFORMED_QUERY';
+  message: 'malformed WITH query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type ParseFatal<Sql extends string> = {
+  kind: 'fatal';
+  readonly __value?: WithQueryIR;
+  diagnostics: [MalformedWith<Sql>];
+};
+
+type CteNameAndRest<Sql extends string> = Sql extends `${infer NamePart}(${infer AfterOpen}`
+  ? NamePart extends `${string} ${string}`
+    ? {
+        name: FirstWord<Sql>;
+        columns: null;
+        rest: Trim<DropFirstWord<Sql>>;
+      }
+    : ExtractParenGroup<AfterOpen> extends {
+          inner: infer Columns extends string;
+          rest: infer Rest extends string;
+        }
+      ? {
+          name: Trim<NamePart>;
+          columns: SplitColumnList<Columns>;
+          rest: Trim<Rest>;
+        }
+      : never
+  : {
+      name: FirstWord<Sql>;
+      columns: null;
+      rest: Trim<DropFirstWord<Sql>>;
+    };
+
+type SkipMaterialization<Sql extends string> = IsKeyword<
+  FirstWord<Sql>,
+  'materialized'
+> extends true
+  ? Trim<DropFirstWord<Sql>>
+  : IsKeyword<FirstWord<Sql>, 'not'> extends true
+    ? IsKeyword<FirstWord<Trim<DropFirstWord<Sql>>>, 'materialized'> extends true
+      ? Trim<DropFirstWord<Trim<DropFirstWord<Sql>>>>
+      : Sql
+    : Sql;
+
+type ParseCteEntry<
+  Sql extends string,
+  Recursive extends boolean,
+  Whole extends string,
+> = CteNameAndRest<Trim<Sql>> extends {
+  name: infer Name extends string;
+  columns: infer Columns extends readonly string[] | null;
+  rest: infer Rest extends string;
+}
+  ? IsKeyword<FirstWord<Rest>, 'as'> extends true
+    ? SkipMaterialization<Trim<DropFirstWord<Rest>>> extends `(${infer AfterOpen}`
+      ? ExtractParenGroup<AfterOpen> extends {
+          inner: infer Body extends string;
+          rest: infer AfterBody extends string;
+        }
+        ? ParseSelectIR<Trim<Body>> extends infer Parsed
+          ? Parsed extends {
+              kind: 'ok';
+              value: infer Query extends SelectQueryIR;
+            }
+            ? {
+                kind: 'ok';
+                cte: CteIR<Name, Columns, Query, Recursive>;
+                rest: Trim<AfterBody>;
+              }
+            : Parsed
+          : never
+        : ParseFatal<Whole>
+      : ParseFatal<Whole>
+    : ParseFatal<Whole>
+  : ParseFatal<Whole>;
+
+type ParseCteList<
+  Sql extends string,
+  Recursive extends boolean,
+  Whole extends string,
+  Ctes extends readonly AnyCteIR[] = [],
+> = ParseCteEntry<Sql, Recursive, Whole> extends infer Entry
+  ? Entry extends {
+      kind: 'ok';
+      cte: infer Cte extends AnyCteIR;
+      rest: infer Rest extends string;
+    }
+    ? Rest extends `,${infer Tail}`
+      ? ParseCteList<Trim<Tail>, Recursive, Whole, [...Ctes, Cte]>
+      : ParseSelectIR<Rest> extends infer Main
+        ? Main extends {
+            kind: 'ok';
+            value: infer Query extends SelectQueryIR;
+          }
+          ? {
+              kind: 'ok';
+              value: WithQueryIR<[...Ctes, Cte], Query>;
+              diagnostics: [];
+            }
+          : Main
+        : never
+    : Entry
+  : never;
+
+type ParseWithBody<Sql extends string, Whole extends string> = IsKeyword<
+  FirstWord<Sql>,
+  'recursive'
+> extends true
+  ? ParseCteList<Trim<DropFirstWord<Sql>>, true, Whole>
+  : ParseCteList<Sql, false, Whole>;
+
+export type ParseWithIR<Sql extends string> = Normalize<Sql> extends `${infer With} ${infer Body}`
+  ? IsKeyword<With, 'with'> extends true
+    ? ParseWithBody<Body, Sql>
+    : ParseFatal<Sql>
+  : ParseFatal<Sql>;

--- a/tests/next/cte-parity.test-d.ts
+++ b/tests/next/cte-parity.test-d.ts
@@ -1,0 +1,112 @@
+import type {
+  LegacyInferParams,
+  LegacyInferResult,
+  LegacyInferResultStrict,
+} from '../../src/compiler/legacy.js';
+import type {
+  InferParamsViaGateway,
+  InferViaGateway,
+} from '../../src/compiler/gateway.js';
+import type {
+  NextWithInferParams,
+  NextWithQuery,
+  NextWithStrictQuery,
+} from '../../src/compiler/next/index.js';
+import type { ParseWithIR } from '../../src/language/with/parse-with.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<Value extends true> = Value;
+
+type DB = {
+  users: { id: number; name: string; active: boolean };
+  posts: { id: number; user_id: number; title: string; views: number };
+};
+
+type _structural = Expect<
+  ParseWithIR<'with recursive popular(post_id) as materialized (select id from posts) select post_id from popular'> extends {
+    kind: 'ok';
+    value: {
+      ctes: readonly [{
+        name: 'popular';
+        columns: readonly ['post_id'];
+        query: { kind: 'select' };
+        recursive: true;
+      }];
+      query: { kind: 'select' };
+    };
+  }
+    ? true
+    : false
+>;
+
+type _single = Expect<Equal<
+  LegacyInferResult<DB, 'with popular as (select id, title from posts where views > 100) select id, title from popular'>,
+  NextWithQuery<DB, 'with popular as (select id, title from posts where views > 100) select id, title from popular'>
+>>;
+
+type _chained = Expect<Equal<
+  LegacyInferResult<DB, 'with popular as (select id, title from posts), titles as (select title from popular) select title from titles'>,
+  NextWithQuery<DB, 'with popular as (select id, title from posts), titles as (select title from popular) select title from titles'>
+>>;
+
+
+type _aliases = Expect<Equal<
+  LegacyInferResult<DB, 'with popular(post_id, label) as (select id, title from posts) select post_id, label from popular'>,
+  NextWithQuery<DB, 'with popular(post_id, label) as (select id, title from posts) select post_id, label from popular'>
+>>;
+
+type _shadowing = Expect<Equal<
+  LegacyInferResultStrict<DB, 'with users as (select id from posts) select name from users'>,
+  NextWithStrictQuery<DB, 'with users as (select id from posts) select name from users'>
+>>;
+
+type _params = Expect<Equal<
+  LegacyInferParams<DB, 'with popular as (select id from posts where views > @minimum) select id from popular where id = @id'>,
+  NextWithInferParams<DB, 'with popular as (select id from posts where views > @minimum) select id from popular where id = @id'>
+>>;
+
+type _nestedCase = Expect<Equal<
+  LegacyInferResult<DB, "with states as (select case when active then case when name = 'x' then 'named' else 'active' end else 'inactive' end as state from users) select state from states">,
+  NextWithQuery<DB, "with states as (select case when active then case when name = 'x' then 'named' else 'active' end else 'inactive' end as state from users) select state from states">
+>>;
+
+type _materialized = Expect<Equal<
+  LegacyInferResult<DB, 'with popular as materialized (select id from posts) select id from popular'>,
+  NextWithQuery<DB, 'with popular as materialized (select id from posts) select id from popular'>
+>>;
+
+type _notMaterialized = Expect<Equal<
+  LegacyInferResult<DB, 'with popular as not materialized (select id from posts) select id from popular'>,
+  NextWithQuery<DB, 'with popular as not materialized (select id from posts) select id from popular'>
+>>;
+
+type _recursiveKeyword = Expect<Equal<
+  LegacyInferResult<DB, 'with recursive popular as (select id from posts) select id from popular'>,
+  NextWithQuery<DB, 'with recursive popular as (select id from posts) select id from popular'>
+>>;
+
+type _diagnosticPropagation = Expect<Equal<
+  LegacyInferResultStrict<DB, 'with broken as (select missing from posts) select missing from broken'>,
+  NextWithStrictQuery<DB, 'with broken as (select missing from posts) select missing from broken'>
+>>;
+
+type _scalarSubqueryScope = Expect<Equal<
+  LegacyInferResult<DB, 'with popular as (select id from posts) select (select id from popular) as post_id'>,
+  NextWithQuery<DB, 'with popular as (select id from posts) select (select id from popular) as post_id'>
+>>;
+
+type WithLedUpdate = `with targets as (select id from users)
+update users set name = @name where id in (select id from targets)`;
+
+type _withLedDmlResultStaysLegacy = Expect<Equal<
+  InferViaGateway<DB, WithLedUpdate>,
+  LegacyInferResult<DB, WithLedUpdate>
+>>;
+
+type _withLedDmlParamsStayLegacy = Expect<Equal<
+  InferParamsViaGateway<DB, WithLedUpdate>,
+  LegacyInferParams<DB, WithLedUpdate>
+>>;

--- a/tests/perf/baseline.json
+++ b/tests/perf/baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 212616
+  "instantiations": 225590
 }

--- a/tests/perf/select-next-baseline.json
+++ b/tests/perf/select-next-baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 21435
+  "instantiations": 37521
 }


### PR DESCRIPTION
## Summary

- route WITH and CTE inference through the Next compiler
- preserve public row and parameter inference across supported CTE behavior
- freeze the post-cutover performance baseline

## Verification

- `npm test`: 217 passed, 36 skipped
- architecture fitness checks passed
- `npm run test:perf`: 225,590 instantiations, matching baseline and below the 230,000 budget
- `npm run test:package` passed

## Stack

Depends on #360.
