### PR TITLE
refactor: migrate DML inference to Next in M5

### DIFF
--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -41,7 +41,11 @@ const SHAPE_REPEATS = 4;
 // ordered scope sources moved the public fixture from 223,663 to 225,590
 // instantiations (+0.86%); 230,000 keeps a reviewed 2% margin without hiding
 // the measured baseline.
-const MAX_INSTANTIATIONS = 230_000;
+// Raised from 230,000 for the M5 INSERT cutover. Routing INSERT result and
+// parameter inference through structured Next IR moved the public fixture from
+// 225,590 to 231,605 instantiations (+2.67%); 235,000 keeps a reviewed 1.5%
+// margin while the remaining DML statements migrate independently.
+const MAX_INSTANTIATIONS = 235_000;
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PERF_DIR = join(ROOT, 'tests', 'perf');

--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -48,7 +48,10 @@ const SHAPE_REPEATS = 4;
 // Raised from 235,000 for the M5 UPDATE cutover. Structured assignments,
 // predicates and output inference moved the fixture from 231,605 to 236,778
 // instantiations (+2.23%); 240,000 keeps a reviewed 1.36% margin.
-const MAX_INSTANTIATIONS = 240_000;
+// Raised from 240,000 for the M5 MERGE cutover. Structured sources, actions,
+// `$action` output and parameter fragments moved the fixture from 239,943 to
+// 244,919 instantiations (+2.07%); 250,000 keeps a reviewed 2.07% margin.
+const MAX_INSTANTIATIONS = 250_000;
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PERF_DIR = join(ROOT, 'tests', 'perf');

--- a/scripts/type-budget.mjs
+++ b/scripts/type-budget.mjs
@@ -45,7 +45,10 @@ const SHAPE_REPEATS = 4;
 // parameter inference through structured Next IR moved the public fixture from
 // 225,590 to 231,605 instantiations (+2.67%); 235,000 keeps a reviewed 1.5%
 // margin while the remaining DML statements migrate independently.
-const MAX_INSTANTIATIONS = 235_000;
+// Raised from 235,000 for the M5 UPDATE cutover. Structured assignments,
+// predicates and output inference moved the fixture from 231,605 to 236,778
+// instantiations (+2.23%); 240,000 keeps a reviewed 1.36% margin.
+const MAX_INSTANTIATIONS = 240_000;
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PERF_DIR = join(ROOT, 'tests', 'perf');

--- a/src/compiler/gateway.ts
+++ b/src/compiler/gateway.ts
@@ -11,6 +11,7 @@ import type {
 } from './legacy.js';
 import type { CompileInsert, InferInsertParams } from './next/compile-insert.js';
 import type { CompileDelete, InferDeleteParams } from './next/compile-delete.js';
+import type { CompileMerge, InferMergeParams } from './next/compile-merge.js';
 import type { CompileSelect } from './next/compile-select.js';
 import type { CompileUpdate, InferUpdateParams } from './next/compile-update.js';
 import type { CompileWith, InferWithParams } from './next/compile-with.js';
@@ -30,7 +31,9 @@ type NextCompilation<
         ? CompileInsert<DB, Q, null, ValidatePredicates>
         : GatewayKind<Q> extends 'update'
           ? CompileUpdate<DB, Q, null, ValidatePredicates>
-          : CompileDelete<DB, Q, null, ValidatePredicates>;
+          : GatewayKind<Q> extends 'delete'
+            ? CompileDelete<DB, Q, null, ValidatePredicates>
+            : CompileMerge<DB, Q, null, ValidatePredicates>;
 
 type NextQuery<DB, Q extends string> =
   ApplyLoosePolicy<NextCompilation<DB, Q, false>>;
@@ -67,7 +70,9 @@ type UsesNext<Q extends string> = GatewayKind<Q> extends 'select'
         ? true
         : GatewayKind<Q> extends 'delete'
           ? true
-          : false;
+          : GatewayKind<Q> extends 'merge'
+            ? true
+            : false;
 
 export type InferViaGateway<DB extends SchemaLike, Q extends string> =
   UsesNext<Q> extends true
@@ -102,4 +107,6 @@ export type InferParamsViaGateway<DB extends SchemaLike, Q extends string> =
           ? InferUpdateParams<DB, Q>
           : GatewayKind<Q> extends 'delete'
             ? InferDeleteParams<DB, Q>
-            : LegacyInferParams<DB, Q>;
+            : GatewayKind<Q> extends 'merge'
+              ? InferMergeParams<DB, Q>
+              : LegacyInferParams<DB, Q>;

--- a/src/compiler/gateway.ts
+++ b/src/compiler/gateway.ts
@@ -10,6 +10,7 @@ import type {
   LegacyInferRowStrict,
 } from './legacy.js';
 import type { CompileInsert, InferInsertParams } from './next/compile-insert.js';
+import type { CompileDelete, InferDeleteParams } from './next/compile-delete.js';
 import type { CompileSelect } from './next/compile-select.js';
 import type { CompileUpdate, InferUpdateParams } from './next/compile-update.js';
 import type { CompileWith, InferWithParams } from './next/compile-with.js';
@@ -27,7 +28,9 @@ type NextCompilation<
       ? CompileWith<DB, Q, null, ValidatePredicates>
       : GatewayKind<Q> extends 'insert'
         ? CompileInsert<DB, Q, null, ValidatePredicates>
-        : CompileUpdate<DB, Q, null, ValidatePredicates>;
+        : GatewayKind<Q> extends 'update'
+          ? CompileUpdate<DB, Q, null, ValidatePredicates>
+          : CompileDelete<DB, Q, null, ValidatePredicates>;
 
 type NextQuery<DB, Q extends string> =
   ApplyLoosePolicy<NextCompilation<DB, Q, false>>;
@@ -62,7 +65,9 @@ type UsesNext<Q extends string> = GatewayKind<Q> extends 'select'
       ? true
       : GatewayKind<Q> extends 'update'
         ? true
-        : false;
+        : GatewayKind<Q> extends 'delete'
+          ? true
+          : false;
 
 export type InferViaGateway<DB extends SchemaLike, Q extends string> =
   UsesNext<Q> extends true
@@ -95,4 +100,6 @@ export type InferParamsViaGateway<DB extends SchemaLike, Q extends string> =
         ? InferInsertParams<DB, Q>
         : GatewayKind<Q> extends 'update'
           ? InferUpdateParams<DB, Q>
-          : LegacyInferParams<DB, Q>;
+          : GatewayKind<Q> extends 'delete'
+            ? InferDeleteParams<DB, Q>
+            : LegacyInferParams<DB, Q>;

--- a/src/compiler/gateway.ts
+++ b/src/compiler/gateway.ts
@@ -9,6 +9,7 @@ import type {
   LegacyInferRow,
   LegacyInferRowStrict,
 } from './legacy.js';
+import type { CompileInsert, InferInsertParams } from './next/compile-insert.js';
 import type { CompileSelect } from './next/compile-select.js';
 import type { CompileWith, InferWithParams } from './next/compile-with.js';
 import type { InferNextParams } from './next/infer-params.js';
@@ -21,7 +22,9 @@ type NextCompilation<
   ? CompileSelect<DB, Q, null, ValidatePredicates>
   : GatewayKind<Q> extends 'select'
     ? CompileSelect<DB, Q, null, ValidatePredicates>
-    : CompileWith<DB, Q, null, ValidatePredicates>;
+    : GatewayKind<Q> extends 'with'
+      ? CompileWith<DB, Q, null, ValidatePredicates>
+      : CompileInsert<DB, Q, null, ValidatePredicates>;
 
 type NextQuery<DB, Q extends string> =
   ApplyLoosePolicy<NextCompilation<DB, Q, false>>;
@@ -52,7 +55,9 @@ type UsesNext<Q extends string> = GatewayKind<Q> extends 'select'
     ? ParseWithIR<Q> extends { kind: 'ok' }
       ? true
       : false
-    : false;
+    : GatewayKind<Q> extends 'insert'
+      ? true
+      : false;
 
 export type InferViaGateway<DB extends SchemaLike, Q extends string> =
   UsesNext<Q> extends true
@@ -81,4 +86,6 @@ export type InferParamsViaGateway<DB extends SchemaLike, Q extends string> =
       ? UsesNext<Q> extends true
         ? InferWithParams<DB, Q>
         : LegacyInferParams<DB, Q>
-      : LegacyInferParams<DB, Q>;
+      : GatewayKind<Q> extends 'insert'
+        ? InferInsertParams<DB, Q>
+        : LegacyInferParams<DB, Q>;

--- a/src/compiler/gateway.ts
+++ b/src/compiler/gateway.ts
@@ -11,6 +11,7 @@ import type {
 } from './legacy.js';
 import type { CompileInsert, InferInsertParams } from './next/compile-insert.js';
 import type { CompileSelect } from './next/compile-select.js';
+import type { CompileUpdate, InferUpdateParams } from './next/compile-update.js';
 import type { CompileWith, InferWithParams } from './next/compile-with.js';
 import type { InferNextParams } from './next/infer-params.js';
 
@@ -24,7 +25,9 @@ type NextCompilation<
     ? CompileSelect<DB, Q, null, ValidatePredicates>
     : GatewayKind<Q> extends 'with'
       ? CompileWith<DB, Q, null, ValidatePredicates>
-      : CompileInsert<DB, Q, null, ValidatePredicates>;
+      : GatewayKind<Q> extends 'insert'
+        ? CompileInsert<DB, Q, null, ValidatePredicates>
+        : CompileUpdate<DB, Q, null, ValidatePredicates>;
 
 type NextQuery<DB, Q extends string> =
   ApplyLoosePolicy<NextCompilation<DB, Q, false>>;
@@ -57,7 +60,9 @@ type UsesNext<Q extends string> = GatewayKind<Q> extends 'select'
       : false
     : GatewayKind<Q> extends 'insert'
       ? true
-      : false;
+      : GatewayKind<Q> extends 'update'
+        ? true
+        : false;
 
 export type InferViaGateway<DB extends SchemaLike, Q extends string> =
   UsesNext<Q> extends true
@@ -88,4 +93,6 @@ export type InferParamsViaGateway<DB extends SchemaLike, Q extends string> =
         : LegacyInferParams<DB, Q>
       : GatewayKind<Q> extends 'insert'
         ? InferInsertParams<DB, Q>
-        : LegacyInferParams<DB, Q>;
+        : GatewayKind<Q> extends 'update'
+          ? InferUpdateParams<DB, Q>
+          : LegacyInferParams<DB, Q>;

--- a/src/compiler/next/compile-delete.ts
+++ b/src/compiler/next/compile-delete.ts
@@ -1,0 +1,113 @@
+import type { ParseDeleteIR } from '../../language/dml/parse-delete.js';
+import type { DeleteQueryIR } from '../../language/ir/query.js';
+import type { SourceIR, TableSourceIR } from '../../language/ir/source.js';
+import type { CompileFatal, CompileOk } from '../contracts/compilation.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type {
+  AnalyzePredicates,
+  CompileSourceList,
+  CompiledSources,
+} from './compile-select.js';
+import type { InferOutput } from './infer-output.js';
+import type {
+  AnyParamState,
+  EmptyParamState,
+  ParamValues,
+  ScanPredicateParams,
+} from './infer-params.js';
+import type { Scope } from './scope.js';
+
+type TargetSource<IR extends DeleteQueryIR> = TableSourceIR<
+  IR['target']['name'],
+  IR['target']['alias'],
+  false,
+  'root',
+  []
+>;
+
+type CompileResolvedDelete<
+  DB,
+  IR extends DeleteQueryIR,
+  Sources extends readonly SourceIR[],
+  SourceDiagnostics extends readonly Diagnostic[],
+  ParentScope,
+  Validate extends boolean,
+> = InferOutput<
+  DB,
+  Scope<Sources, ParentScope>,
+  IR['output']
+> extends CompileOk<infer Rows, infer OutputDiagnostics>
+  ? CompileOk<
+      Rows,
+      [
+        ...SourceDiagnostics,
+        ...(Validate extends true
+          ? AnalyzePredicates<
+              DB,
+              Scope<Sources, ParentScope>,
+              IR['predicates']
+            >
+          : []),
+        ...OutputDiagnostics,
+      ]
+    >
+  : never;
+
+export type CompileDeleteIR<
+  DB,
+  IR extends DeleteQueryIR,
+  ParentScope = null,
+  Validate extends boolean = true,
+> = CompileSourceList<
+  DB,
+  [TargetSource<IR>, ...IR['sources']],
+  ParentScope,
+  Validate
+> extends infer Compiled
+  ? Compiled extends CompiledSources<
+      infer Sources,
+      infer SourceDiagnostics
+    >
+    ? CompileResolvedDelete<
+        DB,
+        IR,
+        Sources,
+        SourceDiagnostics,
+        ParentScope,
+        Validate
+      >
+    : Compiled extends CompileFatal<unknown[], infer Diagnostics>
+      ? CompileFatal<unknown[], Diagnostics>
+      : never
+  : never;
+
+export type CompileDelete<
+  DB,
+  Sql extends string,
+  ParentScope = null,
+  Validate extends boolean = true,
+> = ParseDeleteIR<Sql> extends infer Parsed
+  ? Parsed extends { kind: 'ok'; value: infer IR extends DeleteQueryIR }
+    ? CompileDeleteIR<DB, IR, ParentScope, Validate>
+    : Parsed extends CompileFatal<DeleteQueryIR, infer Diagnostics>
+      ? CompileFatal<unknown[], Diagnostics>
+      : never
+  : never;
+
+export type InferDeleteParamsFromIR<DB, IR extends DeleteQueryIR> =
+  ScanPredicateParams<
+    DB,
+    Scope<[TargetSource<IR>, ...IR['sources']]>,
+    IR['predicates'],
+    EmptyParamState
+  > extends infer State extends AnyParamState
+    ? ParamValues<State>
+    : unknown[];
+
+export type InferDeleteParams<DB, Sql extends string> =
+  ParseDeleteIR<Sql> extends {
+    kind: 'ok';
+    value: infer IR extends DeleteQueryIR;
+  }
+    ? InferDeleteParamsFromIR<DB, IR>
+    : unknown[];

--- a/src/compiler/next/compile-insert.ts
+++ b/src/compiler/next/compile-insert.ts
@@ -1,0 +1,192 @@
+import type {
+  InsertQueryIR,
+  InsertSelectIR,
+  InsertValuesIR,
+} from '../../language/ir/query.js';
+import type { TableSourceIR } from '../../language/ir/source.js';
+import type { WriteTargetIR } from '../../language/ir/write.js';
+import type { ParseInsertIR } from '../../language/dml/parse-insert.js';
+import type { CompileFatal, CompileOk } from '../contracts/compilation.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { CompileSelectIR } from './compile-select.js';
+import type { InferOutput } from './infer-output.js';
+import type {
+  AnyParamState,
+  EmptyParamState,
+  ParamValues,
+  ScanParamFragment,
+  ScanTypedFragment,
+} from './infer-params.js';
+import type {
+  ResolveWriteColumn,
+  ResolveWriteTarget,
+} from './resolve-write-target.js';
+import type { Scope } from './scope.js';
+
+type TargetSource<Target extends WriteTargetIR> = TableSourceIR<
+  Target['name'],
+  Target['alias'],
+  false,
+  'root',
+  []
+>;
+
+type TargetDiagnostics<
+  DB,
+  Target extends WriteTargetIR,
+  Validate extends boolean,
+> = Validate extends true
+  ? ResolveWriteTarget<DB, Target> extends {
+      kind: 'error';
+      diagnostic: infer Error extends Diagnostic;
+    }
+    ? [Error]
+    : []
+  : [];
+
+type ColumnDiagnostics<
+  DB,
+  Target extends WriteTargetIR,
+  Columns extends readonly string[],
+  Validate extends boolean,
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Validate extends false
+  ? Diagnostics
+  : Columns extends readonly [
+        infer Head extends string,
+        ...infer Tail extends string[],
+      ]
+    ? ResolveWriteColumn<DB, Target, Head> extends {
+        kind: 'error';
+        diagnostic: infer Error extends Diagnostic;
+      }
+      ? ColumnDiagnostics<DB, Target, Tail, Validate, [...Diagnostics, Error]>
+      : ColumnDiagnostics<DB, Target, Tail, Validate, Diagnostics>
+    : Diagnostics;
+
+type SourceDiagnostics<
+  DB,
+  Source,
+  ParentScope,
+  Validate extends boolean,
+> = Source extends InsertSelectIR<infer Query>
+  ? CompileSelectIR<DB, Query, ParentScope, Validate> extends infer Compiled
+    ? Compiled extends CompileOk<readonly unknown[], infer Diagnostics>
+      ? Diagnostics
+      : Compiled extends CompileFatal<unknown[], infer Diagnostics>
+        ? Diagnostics
+        : []
+    : []
+  : [];
+
+export type CompileInsertIR<
+  DB,
+  IR extends InsertQueryIR,
+  ParentScope = null,
+  Validate extends boolean = true,
+> = InferOutput<
+  DB,
+  Scope<[TargetSource<IR['target']>], ParentScope>,
+  IR['output']
+> extends CompileOk<infer Rows, infer OutputDiagnostics>
+  ? CompileOk<
+      Rows,
+      [
+        ...TargetDiagnostics<DB, IR['target'], Validate>,
+        ...ColumnDiagnostics<DB, IR['target'], IR['columns'], Validate>,
+        ...SourceDiagnostics<DB, IR['source'], ParentScope, Validate>,
+        ...OutputDiagnostics,
+      ]
+    >
+  : never;
+
+export type CompileInsert<
+  DB,
+  Sql extends string,
+  ParentScope = null,
+  Validate extends boolean = true,
+> = ParseInsertIR<Sql> extends infer Parsed
+  ? Parsed extends { kind: 'ok'; value: infer IR extends InsertQueryIR }
+    ? CompileInsertIR<DB, IR, ParentScope, Validate>
+    : Parsed extends CompileFatal<InsertQueryIR, infer Diagnostics>
+      ? CompileFatal<unknown[], Diagnostics>
+      : never
+  : never;
+
+type ColumnValue<
+  DB,
+  Target extends WriteTargetIR,
+  Column extends string,
+> = ResolveWriteColumn<DB, Target, Column> extends {
+  kind: 'ok';
+  value: infer Value;
+}
+  ? Value
+  : unknown;
+
+type ScanValues<
+  DB,
+  Target extends WriteTargetIR,
+  Columns extends readonly string[],
+  Values extends readonly string[],
+  State extends AnyParamState,
+> = Columns extends readonly [
+  infer Column extends string,
+  ...infer ColumnTail extends string[],
+]
+  ? Values extends readonly [
+      infer Value extends string,
+      ...infer ValueTail extends string[],
+    ]
+    ? ScanTypedFragment<
+        Value,
+        ColumnValue<DB, Target, Column>,
+        State
+      > extends infer Next extends AnyParamState
+      ? ScanValues<DB, Target, ColumnTail, ValueTail, Next>
+      : never
+    : State
+  : State;
+
+type ScanRows<
+  DB,
+  Target extends WriteTargetIR,
+  Columns extends readonly string[],
+  Rows extends readonly (readonly string[])[],
+  State extends AnyParamState = EmptyParamState,
+> = Rows extends readonly [
+  infer Head extends readonly string[],
+  ...infer Tail extends readonly (readonly string[])[],
+]
+  ? ScanValues<DB, Target, Columns, Head, State> extends infer Next extends AnyParamState
+    ? ScanRows<DB, Target, Columns, Tail, Next>
+    : never
+  : State;
+
+export type InferInsertParamsFromIR<
+  DB,
+  IR extends InsertQueryIR,
+> = IR['columns'] extends readonly []
+  ? unknown[]
+  : IR['source'] extends InsertValuesIR<infer Rows, infer Tail>
+    ? ScanRows<DB, IR['target'], IR['columns'], Rows> extends infer ValuesState extends AnyParamState
+      ? ScanParamFragment<
+          DB,
+          Scope<[TargetSource<IR['target']>]>,
+          Tail,
+          ValuesState
+        > extends infer FinalState extends AnyParamState
+        ? ParamValues<FinalState>
+        : unknown[]
+      : unknown[]
+    : IR['source'] extends InsertSelectIR
+      ? unknown[]
+      : [];
+
+export type InferInsertParams<DB, Sql extends string> =
+  ParseInsertIR<Sql> extends {
+    kind: 'ok';
+    value: infer IR extends InsertQueryIR;
+  }
+    ? InferInsertParamsFromIR<DB, IR>
+    : unknown[];

--- a/src/compiler/next/compile-insert.ts
+++ b/src/compiler/next/compile-insert.ts
@@ -124,7 +124,7 @@ type ColumnValue<
   ? Value
   : unknown;
 
-type ScanValues<
+export type ScanWriteValues<
   DB,
   Target extends WriteTargetIR,
   Columns extends readonly string[],
@@ -143,7 +143,7 @@ type ScanValues<
         ColumnValue<DB, Target, Column>,
         State
       > extends infer Next extends AnyParamState
-      ? ScanValues<DB, Target, ColumnTail, ValueTail, Next>
+      ? ScanWriteValues<DB, Target, ColumnTail, ValueTail, Next>
       : never
     : State
   : State;
@@ -158,7 +158,7 @@ type ScanRows<
   infer Head extends readonly string[],
   ...infer Tail extends readonly (readonly string[])[],
 ]
-  ? ScanValues<DB, Target, Columns, Head, State> extends infer Next extends AnyParamState
+  ? ScanWriteValues<DB, Target, Columns, Head, State> extends infer Next extends AnyParamState
     ? ScanRows<DB, Target, Columns, Tail, Next>
     : never
   : State;

--- a/src/compiler/next/compile-merge.ts
+++ b/src/compiler/next/compile-merge.ts
@@ -1,0 +1,209 @@
+import type { ParseMergeIR } from '../../language/dml/parse-merge.js';
+import type { MergeQueryIR } from '../../language/ir/query.js';
+import type {
+  DerivedSourceIR,
+  SourceIR,
+  TableSourceIR,
+} from '../../language/ir/source.js';
+import type {
+  AssignmentIR,
+  MergeActionIR,
+  WriteTargetIR,
+} from '../../language/ir/write.js';
+import type { CompileFatal, CompileOk } from '../contracts/compilation.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { ResolveKey } from '../schema/model.js';
+import type { AnalyzePredicates } from './compile-select.js';
+import type { ScanWriteValues } from './compile-insert.js';
+import type { InferOutput } from './infer-output.js';
+import type {
+  AnyParamState,
+  EmptyParamState,
+  ParamValues,
+  ScanPredicateParams,
+  ScanTypedFragment,
+} from './infer-params.js';
+import type { ResolveWriteTarget } from './resolve-write-target.js';
+import type { Scope } from './scope.js';
+
+type MergeActionValue = 'INSERT' | 'UPDATE' | 'DELETE';
+
+type TargetSource<IR extends MergeQueryIR> = TableSourceIR<
+  IR['target']['name'],
+  IR['target']['alias'],
+  false,
+  'root',
+  []
+>;
+
+type UnknownTable<Name extends string> = Diagnostic<
+  'UNKNOWN_TABLE',
+  `unknown table: ${Name}`,
+  'error',
+  'from',
+  Name
+>;
+
+type TargetDiagnostics<
+  DB,
+  Target extends WriteTargetIR,
+  Validate extends boolean,
+> = Validate extends true
+  ? ResolveWriteTarget<DB, Target> extends {
+      kind: 'error';
+      diagnostic: infer Error extends Diagnostic;
+    }
+    ? [Error]
+    : []
+  : [];
+
+type SourceDiagnostics<
+  DB,
+  Sources extends readonly SourceIR[],
+  Validate extends boolean,
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Validate extends false
+  ? Diagnostics
+  : Sources extends readonly [
+        infer Head extends SourceIR,
+        ...infer Tail extends SourceIR[],
+      ]
+    ? Head extends TableSourceIR<infer Name, string, boolean, import('../../language/ir/source.js').JoinKind, readonly string[]>
+      ? ResolveKey<DB, Name> extends never
+        ? SourceDiagnostics<DB, Tail, Validate, [...Diagnostics, UnknownTable<Name>]>
+        : SourceDiagnostics<DB, Tail, Validate, Diagnostics>
+      : SourceDiagnostics<DB, Tail, Validate, Diagnostics>
+    : Diagnostics;
+
+type AssignmentValues<
+  Assignments extends readonly AssignmentIR[],
+  Result extends string[] = [],
+> = Assignments extends readonly [
+  infer Head extends AssignmentIR,
+  ...infer Tail extends AssignmentIR[],
+]
+  ? AssignmentValues<Tail, [...Result, Head['value']]>
+  : Result;
+
+type AssignmentColumns<
+  Assignments extends readonly AssignmentIR[],
+  Result extends string[] = [],
+> = Assignments extends readonly [
+  infer Head extends AssignmentIR,
+  ...infer Tail extends AssignmentIR[],
+]
+  ? AssignmentColumns<Tail, [...Result, Head['target']]>
+  : Result;
+
+type MergeScope<IR extends MergeQueryIR> = Scope<
+  [TargetSource<IR>, ...IR['sources']]
+>;
+
+type MergeOutputScope<IR extends MergeQueryIR> = Scope<
+  [
+    TargetSource<IR>,
+    DerivedSourceIR<'$merge', { $action: MergeActionValue }>,
+  ]
+>;
+
+export type CompileMergeIR<
+  DB,
+  IR extends MergeQueryIR,
+  ParentScope = null,
+  Validate extends boolean = true,
+> = InferOutput<DB, MergeOutputScope<IR>, IR['output']> extends CompileOk<
+  infer Rows,
+  infer OutputDiagnostics
+>
+  ? CompileOk<
+      Rows,
+      [
+        ...TargetDiagnostics<DB, IR['target'], Validate>,
+        ...SourceDiagnostics<DB, IR['sources'], Validate>,
+        ...(Validate extends true
+          ? AnalyzePredicates<DB, MergeScope<IR>, IR['predicates']>
+          : []),
+        ...OutputDiagnostics,
+      ]
+    >
+  : never;
+
+export type CompileMerge<
+  DB,
+  Sql extends string,
+  ParentScope = null,
+  Validate extends boolean = true,
+> = ParseMergeIR<Sql> extends infer Parsed
+  ? Parsed extends { kind: 'ok'; value: infer IR extends MergeQueryIR }
+    ? CompileMergeIR<DB, IR, ParentScope, Validate>
+    : Parsed extends CompileFatal<MergeQueryIR, infer Diagnostics>
+      ? CompileFatal<unknown[], Diagnostics>
+      : never
+  : never;
+
+type ScanFragments<
+  Fragments extends readonly string[],
+  State extends AnyParamState,
+> = Fragments extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? ScanTypedFragment<Head, unknown, State> extends infer Next extends AnyParamState
+    ? ScanFragments<Tail, Next>
+    : never
+  : State;
+
+type ScanActions<
+  DB,
+  IR extends MergeQueryIR,
+  Actions extends readonly MergeActionIR[],
+  State extends AnyParamState,
+> = Actions extends readonly [
+  infer Head extends MergeActionIR,
+  ...infer Tail extends MergeActionIR[],
+]
+  ? Head extends { kind: 'update'; assignments: infer Assignments extends readonly AssignmentIR[] }
+    ? ScanWriteValues<
+        DB,
+        IR['target'],
+        AssignmentColumns<Assignments>,
+        AssignmentValues<Assignments>,
+        State
+      > extends infer Next extends AnyParamState
+      ? ScanActions<DB, IR, Tail, Next>
+      : never
+    : Head extends {
+          kind: 'insert';
+          columns: infer Columns extends readonly string[];
+          values: infer Values extends readonly string[];
+        }
+      ? ScanFragments<
+          Values,
+          State
+        > extends infer Next extends AnyParamState
+        ? ScanActions<DB, IR, Tail, Next>
+        : never
+      : ScanActions<DB, IR, Tail, State>
+  : State;
+
+export type InferMergeParamsFromIR<DB, IR extends MergeQueryIR> =
+  ScanFragments<IR['sourceValues'], EmptyParamState> extends infer SourceState extends AnyParamState
+    ? ScanPredicateParams<
+        DB,
+        MergeScope<IR>,
+        IR['predicates'],
+        SourceState
+      > extends infer PredicateState extends AnyParamState
+      ? ScanActions<DB, IR, IR['actions'], PredicateState> extends infer FinalState extends AnyParamState
+        ? ParamValues<FinalState>
+        : unknown[]
+      : unknown[]
+    : unknown[];
+
+export type InferMergeParams<DB, Sql extends string> =
+  ParseMergeIR<Sql> extends {
+    kind: 'ok';
+    value: infer IR extends MergeQueryIR;
+  }
+    ? InferMergeParamsFromIR<DB, IR>
+    : unknown[];

--- a/src/compiler/next/compile-select.ts
+++ b/src/compiler/next/compile-select.ts
@@ -155,7 +155,7 @@ export type AnalyzePredicate<
   Predicate extends PredicateIR,
 > = AnalyzePredicateTokens<DB, CurrentScope, PredicateText<Predicate['fragment']>>;
 
-type AnalyzePredicates<
+export type AnalyzePredicates<
   DB,
   CurrentScope,
   Predicates extends readonly PredicateIR[],

--- a/src/compiler/next/compile-update.ts
+++ b/src/compiler/next/compile-update.ts
@@ -1,5 +1,4 @@
 import type { AssignmentIR } from '../../language/ir/write.js';
-import type { PredicateIR } from '../../language/ir/predicate.js';
 import type { UpdateQueryIR } from '../../language/ir/query.js';
 import type { SourceIR, TableSourceIR } from '../../language/ir/source.js';
 import type { ParseUpdateIR } from '../../language/dml/parse-update.js';
@@ -15,7 +14,7 @@ import type {
   AnyParamState,
   EmptyParamState,
   ParamValues,
-  ScanParamFragment,
+  ScanPredicateParams,
   ScanTypedFragment,
 } from './infer-params.js';
 import type { ResolveWriteColumn } from './resolve-write-target.js';
@@ -156,28 +155,9 @@ type ScanAssignments<
     : never
   : State;
 
-type ScanPredicates<
-  DB,
-  CurrentScope,
-  Predicates extends readonly PredicateIR[],
-  State extends AnyParamState,
-> = Predicates extends readonly [
-  infer Head extends PredicateIR,
-  ...infer Tail extends PredicateIR[],
-]
-  ? ScanParamFragment<
-      DB,
-      CurrentScope,
-      Head['fragment'],
-      State
-    > extends infer Next extends AnyParamState
-    ? ScanPredicates<DB, CurrentScope, Tail, Next>
-    : never
-  : State;
-
 export type InferUpdateParamsFromIR<DB, IR extends UpdateQueryIR> =
   ScanAssignments<DB, IR, IR['assignments']> extends infer AssignmentState extends AnyParamState
-    ? ScanPredicates<
+    ? ScanPredicateParams<
         DB,
         Scope<[TargetSource<IR>, ...IR['sources']]>,
         IR['predicates'],

--- a/src/compiler/next/compile-update.ts
+++ b/src/compiler/next/compile-update.ts
@@ -1,0 +1,196 @@
+import type { AssignmentIR } from '../../language/ir/write.js';
+import type { PredicateIR } from '../../language/ir/predicate.js';
+import type { UpdateQueryIR } from '../../language/ir/query.js';
+import type { SourceIR, TableSourceIR } from '../../language/ir/source.js';
+import type { ParseUpdateIR } from '../../language/dml/parse-update.js';
+import type { CompileFatal, CompileOk } from '../contracts/compilation.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type {
+  AnalyzePredicates,
+  CompileSourceList,
+  CompiledSources,
+} from './compile-select.js';
+import type { InferOutput } from './infer-output.js';
+import type {
+  AnyParamState,
+  EmptyParamState,
+  ParamValues,
+  ScanParamFragment,
+  ScanTypedFragment,
+} from './infer-params.js';
+import type { ResolveWriteColumn } from './resolve-write-target.js';
+import type { Scope } from './scope.js';
+
+type TargetSource<IR extends UpdateQueryIR> = TableSourceIR<
+  IR['target']['name'],
+  IR['target']['alias'],
+  false,
+  'root',
+  []
+>;
+
+type AssignmentDiagnostics<
+  DB,
+  CurrentScope,
+  IR extends UpdateQueryIR,
+  Assignments extends readonly AssignmentIR[] = IR['assignments'],
+  Diagnostics extends readonly Diagnostic[] = [],
+> = Assignments extends readonly [
+  infer Head extends AssignmentIR,
+  ...infer Tail extends AssignmentIR[],
+]
+  ? ResolveWriteColumn<DB, IR['target'], Head['target']> extends infer Resolved
+    ? Resolved extends {
+        kind: 'error';
+        diagnostic: infer Error extends Diagnostic;
+      }
+      ? AssignmentDiagnostics<
+          DB,
+          CurrentScope,
+          IR,
+          Tail,
+          [...Diagnostics, Error]
+        >
+      : AssignmentDiagnostics<DB, CurrentScope, IR, Tail, Diagnostics>
+    : never
+  : Diagnostics;
+
+type CompileResolvedUpdate<
+  DB,
+  IR extends UpdateQueryIR,
+  Sources extends readonly SourceIR[],
+  SourceDiagnostics extends readonly Diagnostic[],
+  ParentScope,
+  Validate extends boolean,
+> = InferOutput<
+  DB,
+  Scope<Sources, ParentScope>,
+  IR['output']
+> extends CompileOk<infer Rows, infer OutputDiagnostics>
+  ? CompileOk<
+      Rows,
+      [
+        ...SourceDiagnostics,
+        ...(Validate extends true
+          ? AssignmentDiagnostics<DB, Scope<Sources, ParentScope>, IR>
+          : []),
+        ...(Validate extends true
+          ? AnalyzePredicates<
+              DB,
+              Scope<Sources, ParentScope>,
+              IR['predicates']
+            >
+          : []),
+        ...OutputDiagnostics,
+      ]
+    >
+  : never;
+
+export type CompileUpdateIR<
+  DB,
+  IR extends UpdateQueryIR,
+  ParentScope = null,
+  Validate extends boolean = true,
+> = CompileSourceList<
+  DB,
+  [TargetSource<IR>, ...IR['sources']],
+  ParentScope,
+  Validate
+> extends infer Compiled
+  ? Compiled extends CompiledSources<
+      infer Sources,
+      infer SourceDiagnostics
+    >
+    ? CompileResolvedUpdate<
+        DB,
+        IR,
+        Sources,
+        SourceDiagnostics,
+        ParentScope,
+        Validate
+      >
+    : Compiled extends CompileFatal<unknown[], infer Diagnostics>
+      ? CompileFatal<unknown[], Diagnostics>
+      : never
+  : never;
+
+export type CompileUpdate<
+  DB,
+  Sql extends string,
+  ParentScope = null,
+  Validate extends boolean = true,
+> = ParseUpdateIR<Sql> extends infer Parsed
+  ? Parsed extends { kind: 'ok'; value: infer IR extends UpdateQueryIR }
+    ? CompileUpdateIR<DB, IR, ParentScope, Validate>
+    : Parsed extends CompileFatal<UpdateQueryIR, infer Diagnostics>
+      ? CompileFatal<unknown[], Diagnostics>
+      : never
+  : never;
+
+type AssignmentValue<
+  DB,
+  IR extends UpdateQueryIR,
+  Target extends string,
+> = ResolveWriteColumn<DB, IR['target'], Target> extends {
+  kind: 'ok';
+  value: infer Value;
+}
+  ? Value
+  : unknown;
+
+type ScanAssignments<
+  DB,
+  IR extends UpdateQueryIR,
+  Assignments extends readonly AssignmentIR[],
+  State extends AnyParamState = EmptyParamState,
+> = Assignments extends readonly [
+  infer Head extends AssignmentIR,
+  ...infer Tail extends AssignmentIR[],
+]
+  ? ScanTypedFragment<
+      Head['value'],
+      AssignmentValue<DB, IR, Head['target']>,
+      State
+    > extends infer Next extends AnyParamState
+    ? ScanAssignments<DB, IR, Tail, Next>
+    : never
+  : State;
+
+type ScanPredicates<
+  DB,
+  CurrentScope,
+  Predicates extends readonly PredicateIR[],
+  State extends AnyParamState,
+> = Predicates extends readonly [
+  infer Head extends PredicateIR,
+  ...infer Tail extends PredicateIR[],
+]
+  ? ScanParamFragment<
+      DB,
+      CurrentScope,
+      Head['fragment'],
+      State
+    > extends infer Next extends AnyParamState
+    ? ScanPredicates<DB, CurrentScope, Tail, Next>
+    : never
+  : State;
+
+export type InferUpdateParamsFromIR<DB, IR extends UpdateQueryIR> =
+  ScanAssignments<DB, IR, IR['assignments']> extends infer AssignmentState extends AnyParamState
+    ? ScanPredicates<
+        DB,
+        Scope<[TargetSource<IR>, ...IR['sources']]>,
+        IR['predicates'],
+        AssignmentState
+      > extends infer FinalState extends AnyParamState
+      ? ParamValues<FinalState>
+      : unknown[]
+    : unknown[];
+
+export type InferUpdateParams<DB, Sql extends string> =
+  ParseUpdateIR<Sql> extends {
+    kind: 'ok';
+    value: infer IR extends UpdateQueryIR;
+  }
+    ? InferUpdateParamsFromIR<DB, IR>
+    : unknown[];

--- a/src/compiler/next/index.ts
+++ b/src/compiler/next/index.ts
@@ -6,6 +6,7 @@ import type {
 } from '../contracts/compilation.js';
 import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { CompileSelect } from './compile-select.js';
+import type { CompileInsert, InferInsertParams } from './compile-insert.js';
 import type { CompileWith, InferWithParams } from './compile-with.js';
 import type { InferNextParams } from './infer-params.js';
 
@@ -24,6 +25,8 @@ export type CompileNext<
   ? CompileSelect<DB, Sql>
   : StatementKind<Sql> extends 'select'
     ? CompileSelect<DB, Sql>
+    : StatementKind<Sql> extends 'insert'
+      ? CompileInsert<DB, Sql>
     : StatementKind<Sql> extends 'with'
       ? CompileWith<DB, Sql>
       : CompileFatal<unknown[], [UnsupportedStatement<Sql>]>;
@@ -39,6 +42,29 @@ export type NextWithQuery<DB, Sql extends string> =
 
 export type NextWithStrictQuery<DB, Sql extends string> =
   ApplyStrictPolicy<CompileWith<DB, Sql>>;
+
+export type NextInsertQuery<DB, Sql extends string> =
+  ApplyLoosePolicy<CompileInsert<DB, Sql, null, false>>;
+
+export type NextInsertStrictQuery<DB, Sql extends string> =
+  ApplyStrictPolicy<CompileInsert<DB, Sql>>;
+
+export type NextInsertRow<DB, Sql extends string> =
+  NextInsertQuery<DB, Sql> extends infer Result
+    ? Result extends readonly (infer Row)[]
+      ? Row
+      : Result
+    : never;
+
+export type NextInsertStrictRow<DB, Sql extends string> =
+  NextInsertStrictQuery<DB, Sql> extends infer Result
+    ? Result extends readonly (infer Row)[]
+      ? Row
+      : Result
+    : never;
+
+export type NextInsertInferParams<DB, Sql extends string> =
+  InferInsertParams<DB, Sql>;
 
 export type NextRow<DB, Sql extends string> =
   NextQuery<DB, Sql> extends infer Result

--- a/src/compiler/next/index.ts
+++ b/src/compiler/next/index.ts
@@ -9,6 +9,7 @@ import type { CompileSelect } from './compile-select.js';
 import type { CompileInsert, InferInsertParams } from './compile-insert.js';
 import type { CompileUpdate, InferUpdateParams } from './compile-update.js';
 import type { CompileDelete, InferDeleteParams } from './compile-delete.js';
+import type { CompileMerge, InferMergeParams } from './compile-merge.js';
 import type { CompileWith, InferWithParams } from './compile-with.js';
 import type { InferNextParams } from './infer-params.js';
 
@@ -33,6 +34,8 @@ export type CompileNext<
       ? CompileUpdate<DB, Sql>
     : StatementKind<Sql> extends 'delete'
       ? CompileDelete<DB, Sql>
+    : StatementKind<Sql> extends 'merge'
+      ? CompileMerge<DB, Sql>
     : StatementKind<Sql> extends 'with'
       ? CompileWith<DB, Sql>
       : CompileFatal<unknown[], [UnsupportedStatement<Sql>]>;
@@ -117,6 +120,29 @@ export type NextDeleteStrictRow<DB, Sql extends string> =
 
 export type NextDeleteInferParams<DB, Sql extends string> =
   InferDeleteParams<DB, Sql>;
+
+export type NextMergeQuery<DB, Sql extends string> =
+  ApplyLoosePolicy<CompileMerge<DB, Sql, null, false>>;
+
+export type NextMergeStrictQuery<DB, Sql extends string> =
+  ApplyStrictPolicy<CompileMerge<DB, Sql>>;
+
+export type NextMergeRow<DB, Sql extends string> =
+  NextMergeQuery<DB, Sql> extends infer Result
+    ? Result extends readonly (infer Row)[]
+      ? Row
+      : Result
+    : never;
+
+export type NextMergeStrictRow<DB, Sql extends string> =
+  NextMergeStrictQuery<DB, Sql> extends infer Result
+    ? Result extends readonly (infer Row)[]
+      ? Row
+      : Result
+    : never;
+
+export type NextMergeInferParams<DB, Sql extends string> =
+  InferMergeParams<DB, Sql>;
 
 export type NextRow<DB, Sql extends string> =
   NextQuery<DB, Sql> extends infer Result

--- a/src/compiler/next/index.ts
+++ b/src/compiler/next/index.ts
@@ -7,6 +7,7 @@ import type {
 import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { CompileSelect } from './compile-select.js';
 import type { CompileInsert, InferInsertParams } from './compile-insert.js';
+import type { CompileUpdate, InferUpdateParams } from './compile-update.js';
 import type { CompileWith, InferWithParams } from './compile-with.js';
 import type { InferNextParams } from './infer-params.js';
 
@@ -27,6 +28,8 @@ export type CompileNext<
     ? CompileSelect<DB, Sql>
     : StatementKind<Sql> extends 'insert'
       ? CompileInsert<DB, Sql>
+    : StatementKind<Sql> extends 'update'
+      ? CompileUpdate<DB, Sql>
     : StatementKind<Sql> extends 'with'
       ? CompileWith<DB, Sql>
       : CompileFatal<unknown[], [UnsupportedStatement<Sql>]>;
@@ -65,6 +68,29 @@ export type NextInsertStrictRow<DB, Sql extends string> =
 
 export type NextInsertInferParams<DB, Sql extends string> =
   InferInsertParams<DB, Sql>;
+
+export type NextUpdateQuery<DB, Sql extends string> =
+  ApplyLoosePolicy<CompileUpdate<DB, Sql, null, false>>;
+
+export type NextUpdateStrictQuery<DB, Sql extends string> =
+  ApplyStrictPolicy<CompileUpdate<DB, Sql>>;
+
+export type NextUpdateRow<DB, Sql extends string> =
+  NextUpdateQuery<DB, Sql> extends infer Result
+    ? Result extends readonly (infer Row)[]
+      ? Row
+      : Result
+    : never;
+
+export type NextUpdateStrictRow<DB, Sql extends string> =
+  NextUpdateStrictQuery<DB, Sql> extends infer Result
+    ? Result extends readonly (infer Row)[]
+      ? Row
+      : Result
+    : never;
+
+export type NextUpdateInferParams<DB, Sql extends string> =
+  InferUpdateParams<DB, Sql>;
 
 export type NextRow<DB, Sql extends string> =
   NextQuery<DB, Sql> extends infer Result

--- a/src/compiler/next/index.ts
+++ b/src/compiler/next/index.ts
@@ -8,6 +8,7 @@ import type { Diagnostic } from '../contracts/diagnostic.js';
 import type { CompileSelect } from './compile-select.js';
 import type { CompileInsert, InferInsertParams } from './compile-insert.js';
 import type { CompileUpdate, InferUpdateParams } from './compile-update.js';
+import type { CompileDelete, InferDeleteParams } from './compile-delete.js';
 import type { CompileWith, InferWithParams } from './compile-with.js';
 import type { InferNextParams } from './infer-params.js';
 
@@ -30,6 +31,8 @@ export type CompileNext<
       ? CompileInsert<DB, Sql>
     : StatementKind<Sql> extends 'update'
       ? CompileUpdate<DB, Sql>
+    : StatementKind<Sql> extends 'delete'
+      ? CompileDelete<DB, Sql>
     : StatementKind<Sql> extends 'with'
       ? CompileWith<DB, Sql>
       : CompileFatal<unknown[], [UnsupportedStatement<Sql>]>;
@@ -91,6 +94,29 @@ export type NextUpdateStrictRow<DB, Sql extends string> =
 
 export type NextUpdateInferParams<DB, Sql extends string> =
   InferUpdateParams<DB, Sql>;
+
+export type NextDeleteQuery<DB, Sql extends string> =
+  ApplyLoosePolicy<CompileDelete<DB, Sql, null, false>>;
+
+export type NextDeleteStrictQuery<DB, Sql extends string> =
+  ApplyStrictPolicy<CompileDelete<DB, Sql>>;
+
+export type NextDeleteRow<DB, Sql extends string> =
+  NextDeleteQuery<DB, Sql> extends infer Result
+    ? Result extends readonly (infer Row)[]
+      ? Row
+      : Result
+    : never;
+
+export type NextDeleteStrictRow<DB, Sql extends string> =
+  NextDeleteStrictQuery<DB, Sql> extends infer Result
+    ? Result extends readonly (infer Row)[]
+      ? Row
+      : Result
+    : never;
+
+export type NextDeleteInferParams<DB, Sql extends string> =
+  InferDeleteParams<DB, Sql>;
 
 export type NextRow<DB, Sql extends string> =
   NextQuery<DB, Sql> extends infer Result

--- a/src/compiler/next/infer-output.ts
+++ b/src/compiler/next/infer-output.ts
@@ -1,0 +1,28 @@
+import type { OutputIR } from '../../language/ir/write.js';
+import type { ProjectionIR } from '../../language/ir/projection.js';
+import type { CompileOk } from '../contracts/compilation.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { InferProjections } from './infer-projection.js';
+
+type EmptyWriteRow = Record<string, never>;
+
+export type InferOutput<
+  DB,
+  CurrentScope,
+  Output extends OutputIR<
+    'none' | 'returning' | 'output',
+    readonly ProjectionIR[]
+  >,
+> =
+  Output['mode'] extends 'none'
+    ? CompileOk<EmptyWriteRow[], []>
+    : InferProjections<
+          DB,
+          CurrentScope,
+          Output['projections']
+        > extends {
+          row: infer Row;
+          diagnostics: infer Diagnostics extends readonly Diagnostic[];
+        }
+      ? CompileOk<Row[], Diagnostics>
+      : never;

--- a/src/compiler/next/infer-params.ts
+++ b/src/compiler/next/infer-params.ts
@@ -1,6 +1,8 @@
 import type {
   Digit,
+  ExtractParenGroup,
   Qualifier,
+  SplitColumnList,
   StartsWithIdentifierChar,
   StripQualifier,
   Trim,
@@ -348,6 +350,41 @@ type ScanFragment<
           State
         >
       : State;
+
+export type ScanParamFragment<
+  DB,
+  CurrentScope,
+  Sql extends string,
+  State extends AnyParamState = EmptyParamState,
+> = ScanFragment<DB, CurrentScope, Sql, State>;
+
+type TypedCallArguments<Fragment extends string> =
+  Fragment extends `${string}(${infer AfterOpen}`
+    ? ExtractParenGroup<AfterOpen> extends { inner: infer Inner extends string }
+      ? SplitColumnList<Inner>
+      : []
+    : [];
+
+type ScanTypedParts<
+  Parts extends readonly string[],
+  Value,
+  State extends AnyParamState,
+> = Parts extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? ScanTypedFragment<Head, Value, State> extends infer Next extends AnyParamState
+    ? ScanTypedParts<Tail, Value, Next>
+    : never
+  : State;
+
+export type ScanTypedFragment<
+  Fragment extends string,
+  Value,
+  State extends AnyParamState = EmptyParamState,
+> = IsPlaceholder<Trim<Fragment>> extends true
+  ? AddParam<Trim<Fragment>, Value, State>
+  : ScanTypedParts<TypedCallArguments<Trim<Fragment>>, Value, State>;
 
 type ScanPredicates<
   DB,

--- a/src/compiler/next/infer-params.ts
+++ b/src/compiler/next/infer-params.ts
@@ -386,7 +386,7 @@ export type ScanTypedFragment<
   ? AddParam<Trim<Fragment>, Value, State>
   : ScanTypedParts<TypedCallArguments<Trim<Fragment>>, Value, State>;
 
-type ScanPredicates<
+export type ScanPredicateParams<
   DB,
   CurrentScope,
   Predicates extends readonly PredicateIR[],
@@ -401,7 +401,7 @@ type ScanPredicates<
       Head['fragment'],
       State
     > extends infer Next extends AnyParamState
-    ? ScanPredicates<DB, CurrentScope, Tail, Next>
+    ? ScanPredicateParams<DB, CurrentScope, Tail, Next>
     : never
   : State;
 
@@ -462,7 +462,7 @@ export type InferParamsFromIR<
   IR['projections'],
   State
 > extends infer ProjectionState extends AnyParamState
-  ? ScanPredicates<
+    ? ScanPredicateParams<
       DB,
       CurrentScope,
       IR['predicates'],

--- a/src/compiler/next/resolve-write-target.ts
+++ b/src/compiler/next/resolve-write-target.ts
@@ -1,0 +1,48 @@
+import type { WriteTargetIR } from '../../language/ir/write.js';
+import type { TableSourceIR } from '../../language/ir/source.js';
+import type { Diagnostic } from '../contracts/diagnostic.js';
+import type { ResolveKey } from '../schema/model.js';
+import type { ResolveError, ResolveOk } from './resolve-source.js';
+
+type UnknownTable<Name extends string> = Diagnostic<
+  'UNKNOWN_TABLE',
+  `unknown table: ${Name}`,
+  'error',
+  'from',
+  Name
+>;
+
+type UnknownColumn<Name extends string> = Diagnostic<
+  'UNKNOWN_COLUMN',
+  `unknown column: ${Name}`,
+  'error',
+  'statement',
+  Name
+>;
+
+export type ResolveWriteTarget<
+  DB,
+  Target extends WriteTargetIR,
+> = ResolveKey<DB, Target['name']> extends never
+  ? ResolveError<UnknownTable<Target['name']>>
+  : ResolveOk<
+      TableSourceIR<Target['name'], Target['alias'], false, 'root', []>
+    >;
+
+export type ResolveWriteColumn<
+  DB,
+  Target extends WriteTargetIR,
+  Column extends string,
+> = ResolveKey<DB, Target['name']> extends infer Table
+  ? [Table] extends [never]
+    ? ResolveError<UnknownTable<Target['name']>>
+    : Table extends keyof DB
+      ? ResolveKey<DB[Table], Column> extends infer Key
+        ? [Key] extends [never]
+          ? ResolveError<UnknownColumn<Column>>
+          : Key extends keyof DB[Table]
+            ? ResolveOk<DB[Table][Key]>
+            : never
+        : never
+      : never
+  : never;

--- a/src/language/dml/parse-delete.ts
+++ b/src/language/dml/parse-delete.ts
@@ -1,0 +1,116 @@
+import type {
+  DropFirstWord,
+  FirstWord,
+  HasNonTrailingSemicolon,
+  IsKeyword,
+  Normalize,
+  SplitAtTopLevelKeyword,
+  TakeUntilTopLevelKeyword,
+  Trim,
+} from '../../string.js';
+import type { PredicateIR } from '../ir/predicate.js';
+import type { DeleteQueryIR } from '../ir/query.js';
+import type { SourceIR } from '../ir/source.js';
+import type { WriteTargetIR } from '../ir/write.js';
+import type { ParseNormalizedFromSources } from '../select/parse-from.js';
+import type {
+  ParseWriteOutput,
+  ParseWriteTarget,
+} from './parse-insert.js';
+
+type TargetText<Sql extends string> = TakeUntilTopLevelKeyword<
+  Sql,
+  'output' | 'using' | 'where' | 'returning'
+>;
+
+type UsingSources<Body extends string> = [
+  SplitAtTopLevelKeyword<Body, 'using'>,
+] extends [never]
+  ? { sources: []; predicates: [] }
+  : SplitAtTopLevelKeyword<Body, 'using'> extends {
+      after: infer After extends string;
+    }
+    ? ParseNormalizedFromSources<
+        TakeUntilTopLevelKeyword<After, 'returning' | 'output'>
+      > extends {
+        sources: infer Sources;
+        predicates: infer Predicates;
+      }
+      ? { sources: Sources; predicates: Predicates }
+      : { sources: []; predicates: [] }
+    : { sources: []; predicates: [] };
+
+type WherePredicate<Body extends string> = [
+  SplitAtTopLevelKeyword<Body, 'where'>,
+] extends [never]
+  ? []
+  : SplitAtTopLevelKeyword<Body, 'where'> extends {
+      after: infer After extends string;
+    }
+    ? [
+        PredicateIR<
+          'where',
+          TakeUntilTopLevelKeyword<After, 'returning' | 'output'>
+        >,
+      ]
+    : [];
+
+type MalformedDelete<Sql extends string> = {
+  code: 'MALFORMED_QUERY';
+  message: 'malformed DELETE query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type MultipleStatements<Sql extends string> = {
+  code: 'MULTIPLE_STATEMENTS';
+  message: 'multiple statements are not supported: found a semicolon before the end of the query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type ParseFatal<Sql extends string, Error = MalformedDelete<Sql>> = {
+  kind: 'fatal';
+  readonly __value?: DeleteQueryIR;
+  diagnostics: [Error];
+};
+
+type BuildDelete<Sql extends string, Body extends string> =
+  ParseWriteTarget<
+    TargetText<Body>,
+    'output' | 'using' | 'where' | 'returning'
+  > extends { target: infer Target extends WriteTargetIR }
+    ? UsingSources<Body> extends {
+        sources: infer Sources extends readonly SourceIR[];
+        predicates: infer JoinPredicates extends readonly PredicateIR[];
+      }
+      ? {
+          kind: 'ok';
+          value: DeleteQueryIR<
+            Target,
+            Sources,
+            [...JoinPredicates, ...WherePredicate<Body>],
+            ParseWriteOutput<Sql, 'where' | 'from'>
+          >;
+          diagnostics: [];
+        }
+      : ParseFatal<Sql>
+    : ParseFatal<Sql>;
+
+type ParseNormalized<Sql extends string> = FirstWord<Sql> extends infer Delete extends string
+  ? IsKeyword<Delete, 'delete'> extends true
+    ? DropFirstWord<Sql> extends infer Rest extends string
+      ? FirstWord<Rest> extends infer From extends string
+        ? IsKeyword<From, 'from'> extends true
+          ? BuildDelete<Sql, Trim<DropFirstWord<Rest>>>
+          : ParseFatal<Sql>
+        : ParseFatal<Sql>
+      : ParseFatal<Sql>
+    : ParseFatal<Sql>
+  : ParseFatal<Sql>;
+
+export type ParseDeleteIR<Sql extends string> = HasNonTrailingSemicolon<Sql> extends true
+  ? ParseFatal<Sql, MultipleStatements<Sql>>
+  : ParseNormalized<Normalize<Sql>>;

--- a/src/language/dml/parse-insert.ts
+++ b/src/language/dml/parse-insert.ts
@@ -1,0 +1,257 @@
+import type {
+  BeforeParen,
+  DropFirstWord,
+  ExtractParenGroup,
+  FirstWord,
+  HasNonTrailingSemicolon,
+  IsKeyword,
+  Normalize,
+  SplitAtTopLevelKeyword,
+  SplitColumnList,
+  StripQualifier,
+  Trim,
+  Unquote,
+} from '../../string.js';
+import type {
+  InsertDefaultValuesIR,
+  InsertQueryIR,
+  InsertSelectIR,
+  InsertValuesIR,
+  SelectQueryIR,
+} from '../ir/query.js';
+import type { OutputIR, WriteTargetIR } from '../ir/write.js';
+import type { ParseProjectionList } from '../select/parse-projection.js';
+import type { ParseSelectIR } from '../select/parse-select.js';
+
+type InsertBoundary =
+  | 'values'
+  | 'value'
+  | 'select'
+  | 'default'
+  | 'output'
+  | 'returning';
+
+type IsInsertBoundary<Token extends string> = Lowercase<Token> extends InsertBoundary
+  ? true
+  : false;
+
+type CleanTarget<Token extends string> = Unquote<StripQualifier<BeforeParen<Token>>>;
+
+type RestAfterTarget<Sql extends string> = FirstWord<Trim<Sql>> extends `${string}(${string}`
+  ? Trim<Sql> extends `${string}(${infer AfterOpen}`
+    ? `(${AfterOpen}`
+    : ''
+  : Trim<DropFirstWord<Trim<Sql>>>;
+
+type TargetParts<AfterInto extends string> = CleanTarget<
+  FirstWord<Trim<AfterInto>>
+> extends infer Name extends string
+  ? RestAfterTarget<AfterInto> extends infer Rest extends string
+    ? Trim<Rest> extends `(${string}` | ''
+      ? { target: WriteTargetIR<Name>; rest: Rest }
+      : FirstWord<Rest> extends infer Head extends string
+        ? IsKeyword<Head, 'as'> extends true
+          ? FirstWord<DropFirstWord<Rest>> extends infer Alias extends string
+            ? {
+                target: WriteTargetIR<Name, CleanTarget<Alias>>;
+                rest: Trim<DropFirstWord<DropFirstWord<Rest>>>;
+              }
+            : never
+          : IsInsertBoundary<Head> extends true
+            ? { target: WriteTargetIR<Name>; rest: Rest }
+            : {
+                target: WriteTargetIR<Name, CleanTarget<Head>>;
+                rest: Trim<DropFirstWord<Rest>>;
+              }
+        : never
+    : never
+  : never;
+
+type ColumnParts<Rest extends string> = Trim<Rest> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends {
+      inner: infer Columns extends string;
+      rest: infer Tail extends string;
+    }
+    ? { columns: SplitColumnList<Columns>; rest: Trim<Tail> }
+    : { columns: []; rest: Rest }
+  : { columns: []; rest: Rest };
+
+type ParseValueRows<
+  Sql extends string,
+  Rows extends readonly (readonly string[])[] = [],
+> = Trim<Sql> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends {
+      inner: infer Values extends string;
+      rest: infer Rest extends string;
+    }
+    ? Trim<Rest> extends `,${infer Tail}`
+      ? ParseValueRows<Tail, [...Rows, SplitColumnList<Values>]>
+      : { rows: [...Rows, SplitColumnList<Values>]; rest: Trim<Rest> }
+    : { rows: Rows; rest: Trim<Sql> }
+  : { rows: Rows; rest: Trim<Sql> };
+
+type BeforeClause<Sql extends string, Keyword extends string> = [
+  SplitAtTopLevelKeyword<Sql, Keyword>,
+] extends [never]
+  ? Sql
+  : SplitAtTopLevelKeyword<Sql, Keyword> extends {
+      before: infer Before extends string;
+    }
+    ? Before
+    : Sql;
+
+type BeforeOutputClauses<Sql extends string> = BeforeClause<
+  BeforeClause<Sql, 'returning'>,
+  'output'
+>;
+
+type StripPseudoQualifier<Entry extends string> = Lowercase<
+  Entry extends `${infer Qualifier}.${string}` ? Trim<Qualifier> : ''
+> extends 'inserted' | 'deleted'
+  ? Entry extends `${string}.${infer Column}`
+    ? Trim<Column>
+    : Entry
+  : Entry;
+
+type StripPseudoQualifiers<
+  Entries extends readonly string[],
+  Result extends string[] = [],
+> = Entries extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? StripPseudoQualifiers<Tail, [...Result, StripPseudoQualifier<Head>]>
+  : Result;
+
+type JoinEntries<Entries extends readonly string[]> = Entries extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? Tail extends []
+    ? Head
+    : `${Head},${JoinEntries<Tail>}`
+  : '';
+
+type OutputText<Sql extends string> = [
+  SplitAtTopLevelKeyword<Sql, 'returning'>,
+] extends [never]
+  ? [SplitAtTopLevelKeyword<Sql, 'output'>] extends [never]
+    ? { mode: 'none'; text: '' }
+    : SplitAtTopLevelKeyword<Sql, 'output'> extends {
+        after: infer After extends string;
+      }
+      ? { mode: 'output'; text: BeforeClause<After, 'values'> }
+      : { mode: 'none'; text: '' }
+  : SplitAtTopLevelKeyword<Sql, 'returning'> extends {
+      after: infer After extends string;
+    }
+    ? { mode: 'returning'; text: After }
+    : { mode: 'none'; text: '' };
+
+type ParseOutput<Sql extends string> = OutputText<Sql> extends {
+  mode: infer Mode extends 'none' | 'returning' | 'output';
+  text: infer Text extends string;
+}
+  ? Mode extends 'none'
+    ? OutputIR<'none', []>
+    : OutputIR<
+        Mode,
+        ParseProjectionList<
+          JoinEntries<StripPseudoQualifiers<SplitColumnList<Text>>>
+        >
+      >
+  : never;
+
+type ParseSource<Rest extends string> = [
+  SplitAtTopLevelKeyword<Rest, 'values'>,
+] extends [never]
+  ? [SplitAtTopLevelKeyword<Rest, 'select'>] extends [never]
+    ? Lowercase<Trim<Rest>> extends `${string}default values${string}`
+      ? InsertDefaultValuesIR
+      : never
+    : SplitAtTopLevelKeyword<Rest, 'select'> extends {
+        after: infer SelectBody extends string;
+      }
+      ? ParseSelectIR<`select ${BeforeOutputClauses<SelectBody>}`> extends {
+          kind: 'ok';
+          value: infer Query extends SelectQueryIR;
+        }
+        ? InsertSelectIR<Query>
+        : ParseSelectIR<`select ${BeforeOutputClauses<SelectBody>}`>
+      : never
+  : SplitAtTopLevelKeyword<Rest, 'values'> extends {
+      after: infer Values extends string;
+    }
+    ? ParseValueRows<Values> extends {
+        rows: infer Rows extends readonly (readonly string[])[];
+        rest: infer Tail extends string;
+      }
+      ? InsertValuesIR<Rows, BeforeOutputClauses<Tail>>
+      : never
+    : never;
+
+type MalformedInsert<Sql extends string> = {
+  code: 'MALFORMED_QUERY';
+  message: 'malformed INSERT query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type MultipleStatements<Sql extends string> = {
+  code: 'MULTIPLE_STATEMENTS';
+  message: 'multiple statements are not supported: found a semicolon before the end of the query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type ParseFatal<Sql extends string, Error = MalformedInsert<Sql>> = {
+  kind: 'fatal';
+  readonly __value?: InsertQueryIR;
+  diagnostics: [Error];
+};
+
+type BuildInsert<Sql extends string, AfterInto extends string> =
+  TargetParts<AfterInto> extends {
+    target: infer Target extends WriteTargetIR;
+    rest: infer Rest extends string;
+  }
+    ? ColumnParts<Rest> extends {
+        columns: infer Columns extends readonly string[];
+        rest: infer Body extends string;
+      }
+      ? ParseSource<Body> extends infer Source
+        ? Source extends InsertValuesIR | InsertSelectIR | InsertDefaultValuesIR
+          ? {
+              kind: 'ok';
+              value: InsertQueryIR<Target, Columns, Source, ParseOutput<Sql>>;
+              diagnostics: [];
+            }
+          : Source extends {
+                kind: 'fatal';
+                diagnostics: infer Diagnostics;
+              }
+            ? {
+                kind: 'fatal';
+                readonly __value?: InsertQueryIR;
+                diagnostics: Diagnostics;
+              }
+            : ParseFatal<Sql>
+        : never
+      : ParseFatal<Sql>
+    : ParseFatal<Sql>;
+
+type ParseNormalized<Sql extends string> = Sql extends `${infer Insert} ${infer Rest}`
+  ? IsKeyword<Insert, 'insert'> extends true
+    ? Rest extends `${infer Into} ${infer AfterInto}`
+      ? IsKeyword<Into, 'into'> extends true
+        ? BuildInsert<Sql, AfterInto>
+        : ParseFatal<Sql>
+      : ParseFatal<Sql>
+    : ParseFatal<Sql>
+  : ParseFatal<Sql>;
+
+export type ParseInsertIR<Sql extends string> = HasNonTrailingSemicolon<Sql> extends true
+  ? ParseFatal<Sql, MultipleStatements<Sql>>
+  : ParseNormalized<Normalize<Sql>>;

--- a/src/language/dml/parse-insert.ts
+++ b/src/language/dml/parse-insert.ts
@@ -9,6 +9,7 @@ import type {
   SplitAtTopLevelKeyword,
   SplitColumnList,
   StripQualifier,
+  TakeUntilTopLevelKeyword,
   Trim,
   Unquote,
 } from '../../string.js';
@@ -31,7 +32,10 @@ type InsertBoundary =
   | 'output'
   | 'returning';
 
-type IsInsertBoundary<Token extends string> = Lowercase<Token> extends InsertBoundary
+type IsWriteBoundary<
+  Token extends string,
+  Boundary extends string,
+> = Lowercase<Token> extends Lowercase<Boundary>
   ? true
   : false;
 
@@ -43,7 +47,10 @@ type RestAfterTarget<Sql extends string> = FirstWord<Trim<Sql>> extends `${strin
     : ''
   : Trim<DropFirstWord<Trim<Sql>>>;
 
-type TargetParts<AfterInto extends string> = CleanTarget<
+export type ParseWriteTarget<
+  AfterInto extends string,
+  Boundary extends string,
+> = CleanTarget<
   FirstWord<Trim<AfterInto>>
 > extends infer Name extends string
   ? RestAfterTarget<AfterInto> extends infer Rest extends string
@@ -57,7 +64,7 @@ type TargetParts<AfterInto extends string> = CleanTarget<
                 rest: Trim<DropFirstWord<DropFirstWord<Rest>>>;
               }
             : never
-          : IsInsertBoundary<Head> extends true
+          : IsWriteBoundary<Head, Boundary> extends true
             ? { target: WriteTargetIR<Name>; rest: Rest }
             : {
                 target: WriteTargetIR<Name, CleanTarget<Head>>;
@@ -148,18 +155,32 @@ type OutputText<Sql extends string> = [
     ? { mode: 'returning'; text: After }
     : { mode: 'none'; text: '' };
 
-type ParseOutput<Sql extends string> = OutputText<Sql> extends {
+export type ParseWriteOutput<
+  Sql extends string,
+  StopKeyword extends string = never,
+> = OutputText<Sql> extends {
   mode: infer Mode extends 'none' | 'returning' | 'output';
   text: infer Text extends string;
 }
   ? Mode extends 'none'
     ? OutputIR<'none', []>
-    : OutputIR<
-        Mode,
-        ParseProjectionList<
-          JoinEntries<StripPseudoQualifiers<SplitColumnList<Text>>>
+    : [StopKeyword] extends [never]
+      ? OutputIR<
+          Mode,
+          ParseProjectionList<
+            JoinEntries<StripPseudoQualifiers<SplitColumnList<Text>>>
+          >
         >
-      >
+      : OutputIR<
+          Mode,
+          ParseProjectionList<
+            JoinEntries<
+              StripPseudoQualifiers<
+                SplitColumnList<TakeUntilTopLevelKeyword<Text, StopKeyword>>
+              >
+            >
+          >
+        >
   : never;
 
 type ParseSource<Rest extends string> = [
@@ -213,7 +234,7 @@ type ParseFatal<Sql extends string, Error = MalformedInsert<Sql>> = {
 };
 
 type BuildInsert<Sql extends string, AfterInto extends string> =
-  TargetParts<AfterInto> extends {
+  ParseWriteTarget<AfterInto, InsertBoundary> extends {
     target: infer Target extends WriteTargetIR;
     rest: infer Rest extends string;
   }
@@ -225,7 +246,7 @@ type BuildInsert<Sql extends string, AfterInto extends string> =
         ? Source extends InsertValuesIR | InsertSelectIR | InsertDefaultValuesIR
           ? {
               kind: 'ok';
-              value: InsertQueryIR<Target, Columns, Source, ParseOutput<Sql>>;
+              value: InsertQueryIR<Target, Columns, Source, ParseWriteOutput<Sql, 'values'>>;
               diagnostics: [];
             }
           : Source extends {

--- a/src/language/dml/parse-merge.ts
+++ b/src/language/dml/parse-merge.ts
@@ -1,0 +1,226 @@
+import type {
+  DropFirstWord,
+  ExtractParenGroup,
+  FirstWord,
+  HasNonTrailingSemicolon,
+  IsKeyword,
+  Normalize,
+  SplitAtTopLevelKeyword,
+  SplitColumnList,
+  TakeUntilTopLevelKeyword,
+  Trim,
+  Unquote,
+} from '../../string.js';
+import type { PredicateIR } from '../ir/predicate.js';
+import type { MergeQueryIR } from '../ir/query.js';
+import type { DerivedSourceIR, SourceIR } from '../ir/source.js';
+import type { MergeActionIR, WriteTargetIR } from '../ir/write.js';
+import type { ParseNormalizedFromSources } from '../select/parse-from.js';
+import type {
+  ParseWriteOutput,
+  ParseWriteTarget,
+} from './parse-insert.js';
+import type { ParseAssignmentList } from './parse-update.js';
+
+type ColumnRow<Columns extends readonly string[]> = {
+  [Column in Columns[number]]: unknown;
+};
+
+type SourceAliasAndColumns<Rest extends string> =
+  FirstWord<Trim<Rest>> extends infer Head extends string
+    ? IsKeyword<Head, 'as'> extends true
+      ? FirstWord<DropFirstWord<Trim<Rest>>> extends infer Alias extends string
+        ? Trim<DropFirstWord<DropFirstWord<Trim<Rest>>>> extends `(${infer AfterOpen}`
+          ? ExtractParenGroup<AfterOpen> extends { inner: infer Columns extends string }
+            ? { alias: Unquote<Alias>; columns: SplitColumnList<Columns> }
+            : never
+          : { alias: Unquote<Alias>; columns: [] }
+        : never
+      : Trim<Rest> extends `${infer Alias} (${infer AfterOpen}`
+        ? ExtractParenGroup<AfterOpen> extends { inner: infer Columns extends string }
+          ? { alias: Unquote<Trim<Alias>>; columns: SplitColumnList<Columns> }
+          : never
+        : { alias: Unquote<Head>; columns: [] }
+    : never;
+
+type ValuesInside<Sql extends string> = [
+  SplitAtTopLevelKeyword<Sql, 'values'>,
+] extends [never]
+  ? []
+  : SplitAtTopLevelKeyword<Sql, 'values'> extends {
+      after: infer After extends string;
+    }
+    ? Trim<After> extends `(${infer AfterOpen}`
+      ? ExtractParenGroup<AfterOpen> extends { inner: infer Values extends string }
+        ? SplitColumnList<Values>
+        : []
+      : []
+    : [];
+
+type ParseMergeSource<Sql extends string> = Trim<Sql> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends {
+      inner: infer Inner extends string;
+      rest: infer Rest extends string;
+    }
+    ? SourceAliasAndColumns<Rest> extends {
+        alias: infer Alias extends string;
+        columns: infer Columns extends readonly string[];
+      }
+      ? {
+          sources: [DerivedSourceIR<Alias, ColumnRow<Columns>>];
+          values: ValuesInside<Inner>;
+        }
+      : { sources: []; values: [] }
+    : { sources: []; values: [] }
+  : ParseNormalizedFromSources<Sql> extends {
+      sources: infer Sources extends readonly SourceIR[];
+    }
+    ? { sources: Sources; values: [] }
+    : { sources: []; values: [] };
+
+type ParseInsertAction<Sql extends string> = Trim<
+  DropFirstWord<Trim<Sql>>
+> extends `(${infer AfterOpen}`
+  ? ExtractParenGroup<AfterOpen> extends {
+      inner: infer Columns extends string;
+      rest: infer Rest extends string;
+    }
+    ? SplitAtTopLevelKeyword<Rest, 'values'> extends {
+        after: infer AfterValues extends string;
+      }
+      ? Trim<AfterValues> extends `(${infer ValuesOpen}`
+        ? ExtractParenGroup<ValuesOpen> extends { inner: infer Values extends string }
+          ? {
+              kind: 'insert';
+              columns: SplitColumnList<Columns>;
+              values: SplitColumnList<Values>;
+            }
+          : { kind: 'insert'; columns: SplitColumnList<Columns>; values: [] }
+        : { kind: 'insert'; columns: SplitColumnList<Columns>; values: [] }
+      : { kind: 'insert'; columns: SplitColumnList<Columns>; values: [] }
+    : { kind: 'insert'; columns: []; values: [] }
+  : { kind: 'insert'; columns: []; values: [] };
+
+type ParseAction<Clause extends string> = [
+  SplitAtTopLevelKeyword<Clause, 'then'>,
+] extends [never]
+  ? never
+  : SplitAtTopLevelKeyword<Clause, 'then'> extends {
+      after: infer Action extends string;
+    }
+    ? FirstWord<Trim<Action>> extends infer Kind extends string
+      ? IsKeyword<Kind, 'update'> extends true
+        ? SplitAtTopLevelKeyword<Action, 'set'> extends {
+            after: infer Assignments extends string;
+          }
+          ? {
+              kind: 'update';
+              assignments: ParseAssignmentList<Assignments>;
+            }
+          : { kind: 'update'; assignments: [] }
+        : IsKeyword<Kind, 'insert'> extends true
+          ? ParseInsertAction<Action>
+          : IsKeyword<Kind, 'delete'> extends true
+            ? { kind: 'delete' }
+            : never
+      : never
+    : never;
+
+type ParseActions<
+  Sql extends string,
+  Result extends readonly MergeActionIR[] = [],
+> = SplitAtTopLevelKeyword<Sql, 'when'> extends infer Next
+  ? [Next] extends [never]
+    ? ParseAction<TakeUntilTopLevelKeyword<Sql, 'output'>> extends infer Action
+      ? Action extends MergeActionIR
+        ? [...Result, Action]
+        : Result
+      : Result
+    : Next extends {
+        before: infer Current extends string;
+        after: infer Rest extends string;
+      }
+      ? ParseAction<Current> extends infer Action
+        ? Action extends MergeActionIR
+          ? ParseActions<Rest, [...Result, Action]>
+          : ParseActions<Rest, Result>
+        : Result
+      : Result
+  : Result;
+
+type MalformedMerge<Sql extends string> = {
+  code: 'MALFORMED_QUERY';
+  message: 'malformed MERGE query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type MultipleStatements<Sql extends string> = {
+  code: 'MULTIPLE_STATEMENTS';
+  message: 'multiple statements are not supported: found a semicolon before the end of the query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type ParseFatal<Sql extends string, Error = MalformedMerge<Sql>> = {
+  kind: 'fatal';
+  readonly __value?: MergeQueryIR;
+  diagnostics: [Error];
+};
+
+type BuildMerge<
+  Sql extends string,
+  TargetText extends string,
+  AfterUsing extends string,
+> = ParseWriteTarget<TargetText, 'using'> extends {
+  target: infer Target extends WriteTargetIR;
+}
+  ? SplitAtTopLevelKeyword<AfterUsing, 'on'> extends {
+      before: infer SourceText extends string;
+      after: infer AfterOn extends string;
+    }
+    ? SplitAtTopLevelKeyword<AfterOn, 'when'> extends {
+        before: infer On extends string;
+        after: infer Actions extends string;
+      }
+      ? ParseMergeSource<SourceText> extends {
+          sources: infer Sources extends readonly SourceIR[];
+          values: infer Values extends readonly string[];
+        }
+        ? {
+            kind: 'ok';
+            value: MergeQueryIR<
+              Target,
+              Sources,
+              [PredicateIR<'join-on', On>],
+              ParseActions<Actions>,
+              ParseWriteOutput<Sql>,
+              Values
+            >;
+            diagnostics: [];
+          }
+        : ParseFatal<Sql>
+      : ParseFatal<Sql>
+    : ParseFatal<Sql>
+  : ParseFatal<Sql>;
+
+type ParseNormalized<Sql extends string> = Sql extends `${infer Merge} ${infer Rest}`
+  ? IsKeyword<Merge, 'merge'> extends true
+    ? Rest extends `${infer Into} ${infer AfterInto}`
+      ? IsKeyword<Into, 'into'> extends true
+        ? SplitAtTopLevelKeyword<AfterInto, 'using'> extends {
+            before: infer Target extends string;
+            after: infer AfterUsing extends string;
+          }
+          ? BuildMerge<Sql, Target, AfterUsing>
+          : ParseFatal<Sql>
+        : ParseFatal<Sql>
+      : ParseFatal<Sql>
+    : ParseFatal<Sql>
+  : ParseFatal<Sql>;
+
+export type ParseMergeIR<Sql extends string> = HasNonTrailingSemicolon<Sql> extends true
+  ? ParseFatal<Sql, MultipleStatements<Sql>>
+  : ParseNormalized<Normalize<Sql>>;

--- a/src/language/dml/parse-update.ts
+++ b/src/language/dml/parse-update.ts
@@ -32,6 +32,10 @@ type ParseAssignments<
   ? ParseAssignments<Tail, [...Result, Assignment<Head>]>
   : Result;
 
+export type ParseAssignmentList<Sql extends string> = ParseAssignments<
+  SplitColumnList<Sql>
+>;
+
 type AssignmentText<Body extends string> = TakeUntilTopLevelKeyword<
   Body,
   'output' | 'from' | 'where' | 'returning'
@@ -106,7 +110,7 @@ type BuildUpdate<
         kind: 'ok';
         value: UpdateQueryIR<
           Target,
-          ParseAssignments<SplitColumnList<AssignmentText<Body>>>,
+          ParseAssignmentList<AssignmentText<Body>>,
           Sources,
           [...JoinPredicates, ...WherePredicate<Body>],
           ParseWriteOutput<Sql, 'where' | 'from'>

--- a/src/language/dml/parse-update.ts
+++ b/src/language/dml/parse-update.ts
@@ -1,0 +1,132 @@
+import type {
+  HasNonTrailingSemicolon,
+  IsKeyword,
+  Normalize,
+  SplitAtTopLevelKeyword,
+  SplitColumnList,
+  StripQualifier,
+  TakeUntilTopLevelKeyword,
+  Trim,
+  Unquote,
+} from '../../string.js';
+import type { PredicateIR } from '../ir/predicate.js';
+import type { UpdateQueryIR } from '../ir/query.js';
+import type { AssignmentIR, WriteTargetIR } from '../ir/write.js';
+import type { ParseNormalizedFromSources } from '../select/parse-from.js';
+import type {
+  ParseWriteOutput,
+  ParseWriteTarget,
+} from './parse-insert.js';
+
+type Assignment<Entry extends string> = Trim<Entry> extends `${infer Target}=${infer Value}`
+  ? AssignmentIR<Unquote<StripQualifier<Trim<Target>>>, Trim<Value>>
+  : AssignmentIR<Trim<Entry>, ''>;
+
+type ParseAssignments<
+  Entries extends readonly string[],
+  Result extends AssignmentIR[] = [],
+> = Entries extends readonly [
+  infer Head extends string,
+  ...infer Tail extends string[],
+]
+  ? ParseAssignments<Tail, [...Result, Assignment<Head>]>
+  : Result;
+
+type AssignmentText<Body extends string> = TakeUntilTopLevelKeyword<
+  Body,
+  'output' | 'from' | 'where' | 'returning'
+>;
+
+type ExtraSources<Body extends string> = [
+  SplitAtTopLevelKeyword<Body, 'from'>,
+] extends [never]
+  ? { sources: []; predicates: [] }
+  : SplitAtTopLevelKeyword<Body, 'from'> extends {
+      after: infer After extends string;
+    }
+    ? ParseNormalizedFromSources<
+        TakeUntilTopLevelKeyword<After, 'returning' | 'output'>
+      > extends {
+        sources: infer Sources;
+        predicates: infer Predicates;
+      }
+      ? { sources: Sources; predicates: Predicates }
+      : { sources: []; predicates: [] }
+    : { sources: []; predicates: [] };
+
+type WherePredicate<Body extends string> = [
+  SplitAtTopLevelKeyword<Body, 'where'>,
+] extends [never]
+  ? []
+  : SplitAtTopLevelKeyword<Body, 'where'> extends {
+      after: infer After extends string;
+    }
+    ? [
+        PredicateIR<
+          'where',
+          TakeUntilTopLevelKeyword<After, 'returning' | 'output'>
+        >,
+      ]
+    : [];
+
+type MalformedUpdate<Sql extends string> = {
+  code: 'MALFORMED_QUERY';
+  message: 'malformed UPDATE query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type MultipleStatements<Sql extends string> = {
+  code: 'MULTIPLE_STATEMENTS';
+  message: 'multiple statements are not supported: found a semicolon before the end of the query';
+  severity: 'fatal';
+  location: 'statement';
+  reference: Sql;
+};
+
+type ParseFatal<Sql extends string, Error = MalformedUpdate<Sql>> = {
+  kind: 'fatal';
+  readonly __value?: UpdateQueryIR;
+  diagnostics: [Error];
+};
+
+type BuildUpdate<
+  Sql extends string,
+  TargetText extends string,
+  Body extends string,
+> = ParseWriteTarget<TargetText, 'set'> extends {
+  target: infer Target extends WriteTargetIR;
+}
+  ? ExtraSources<Body> extends {
+      sources: infer Sources extends readonly [] | readonly import('../ir/source.js').SourceIR[];
+      predicates: infer JoinPredicates extends readonly PredicateIR[];
+    }
+    ? {
+        kind: 'ok';
+        value: UpdateQueryIR<
+          Target,
+          ParseAssignments<SplitColumnList<AssignmentText<Body>>>,
+          Sources,
+          [...JoinPredicates, ...WherePredicate<Body>],
+          ParseWriteOutput<Sql, 'where' | 'from'>
+        >;
+        diagnostics: [];
+      }
+    : ParseFatal<Sql>
+  : ParseFatal<Sql>;
+
+type ParseNormalized<Sql extends string> = Sql extends `${infer Update} ${infer Rest}`
+  ? IsKeyword<Update, 'update'> extends true
+    ? SplitAtTopLevelKeyword<Rest, 'set'> extends {
+        before: infer Target extends string;
+        after: infer Body extends string;
+      }
+      ? BuildUpdate<Sql, Target, Body>
+      : ParseFatal<Sql>
+    : ParseFatal<Sql>
+  : ParseFatal<Sql>;
+
+export type ParseUpdateIR<Sql extends string> = HasNonTrailingSemicolon<Sql> extends true
+  ? ParseFatal<Sql, MultipleStatements<Sql>>
+  : ParseNormalized<Normalize<Sql>>;

--- a/src/language/ir/projection.ts
+++ b/src/language/ir/projection.ts
@@ -24,3 +24,8 @@ export interface ExpressionProjectionIR<
   fragment: Fragment;
   outputName: OutputName;
 }
+
+export type ProjectionIR =
+  | ColumnProjectionIR
+  | ExpressionProjectionIR
+  | StarProjectionIR<string | null>;

--- a/src/language/ir/query.ts
+++ b/src/language/ir/query.ts
@@ -2,16 +2,11 @@ import type { CteIR } from './cte.js';
 import type { ParameterIR } from './parameter.js';
 import type { PredicateIR } from './predicate.js';
 import type {
-  ColumnProjectionIR,
-  ExpressionProjectionIR,
-  StarProjectionIR,
+  ProjectionIR,
 } from './projection.js';
 import type { SourceIR } from './source.js';
 
-export type ProjectionIR =
-  | ColumnProjectionIR
-  | ExpressionProjectionIR
-  | StarProjectionIR<string | null>;
+export type { ProjectionIR } from './projection.js';
 
 export interface SelectClausesIR<
   GroupBy extends string = '',

--- a/src/language/ir/query.ts
+++ b/src/language/ir/query.ts
@@ -5,7 +5,12 @@ import type {
   ProjectionIR,
 } from './projection.js';
 import type { SourceIR } from './source.js';
-import type { AssignmentIR, OutputIR, WriteTargetIR } from './write.js';
+import type {
+  AssignmentIR,
+  MergeActionIR,
+  OutputIR,
+  WriteTargetIR,
+} from './write.js';
 
 export type { ProjectionIR } from './projection.js';
 
@@ -142,4 +147,27 @@ export interface DeleteQueryIR<
   sources: Sources;
   predicates: Predicates;
   output: Output;
+}
+
+export interface MergeQueryIR<
+  Target extends WriteTargetIR = WriteTargetIR,
+  Sources extends readonly SourceIR[] = readonly SourceIR[],
+  Predicates extends readonly PredicateIR[] = readonly PredicateIR[],
+  Actions extends readonly MergeActionIR[] = readonly MergeActionIR[],
+  Output extends OutputIR<
+    'none' | 'returning' | 'output',
+    readonly ProjectionIR[]
+  > = OutputIR<
+    'none' | 'returning' | 'output',
+    readonly ProjectionIR[]
+  >,
+  SourceValues extends readonly string[] = readonly string[],
+> {
+  kind: 'merge';
+  target: Target;
+  sources: Sources;
+  predicates: Predicates;
+  actions: Actions;
+  output: Output;
+  sourceValues: SourceValues;
 }

--- a/src/language/ir/query.ts
+++ b/src/language/ir/query.ts
@@ -124,3 +124,22 @@ export interface UpdateQueryIR<
   predicates: Predicates;
   output: Output;
 }
+
+export interface DeleteQueryIR<
+  Target extends WriteTargetIR = WriteTargetIR,
+  Sources extends readonly SourceIR[] = readonly SourceIR[],
+  Predicates extends readonly PredicateIR[] = readonly PredicateIR[],
+  Output extends OutputIR<
+    'none' | 'returning' | 'output',
+    readonly ProjectionIR[]
+  > = OutputIR<
+    'none' | 'returning' | 'output',
+    readonly ProjectionIR[]
+  >,
+> {
+  kind: 'delete';
+  target: Target;
+  sources: Sources;
+  predicates: Predicates;
+  output: Output;
+}

--- a/src/language/ir/query.ts
+++ b/src/language/ir/query.ts
@@ -5,7 +5,7 @@ import type {
   ProjectionIR,
 } from './projection.js';
 import type { SourceIR } from './source.js';
-import type { OutputIR, WriteTargetIR } from './write.js';
+import type { AssignmentIR, OutputIR, WriteTargetIR } from './write.js';
 
 export type { ProjectionIR } from './projection.js';
 
@@ -101,5 +101,26 @@ export interface InsertQueryIR<
   target: Target;
   columns: Columns;
   source: Source;
+  output: Output;
+}
+
+export interface UpdateQueryIR<
+  Target extends WriteTargetIR = WriteTargetIR,
+  Assignments extends readonly AssignmentIR[] = readonly AssignmentIR[],
+  Sources extends readonly SourceIR[] = readonly SourceIR[],
+  Predicates extends readonly PredicateIR[] = readonly PredicateIR[],
+  Output extends OutputIR<
+    'none' | 'returning' | 'output',
+    readonly ProjectionIR[]
+  > = OutputIR<
+    'none' | 'returning' | 'output',
+    readonly ProjectionIR[]
+  >,
+> {
+  kind: 'update';
+  target: Target;
+  assignments: Assignments;
+  sources: Sources;
+  predicates: Predicates;
   output: Output;
 }

--- a/src/language/ir/query.ts
+++ b/src/language/ir/query.ts
@@ -5,6 +5,7 @@ import type {
   ProjectionIR,
 } from './projection.js';
 import type { SourceIR } from './source.js';
+import type { OutputIR, WriteTargetIR } from './write.js';
 
 export type { ProjectionIR } from './projection.js';
 
@@ -57,4 +58,48 @@ export interface SelectQueryIR<
   ctes: Ctes;
   clauses: Clauses;
   setOperations: SetOperations;
+}
+
+export interface InsertValuesIR<
+  Rows extends readonly (readonly string[])[] = readonly (readonly string[])[],
+  Tail extends string = string,
+> {
+  mode: 'values';
+  rows: Rows;
+  tail: Tail;
+}
+
+export interface InsertSelectIR<
+  Query extends SelectQueryIR = SelectQueryIR,
+> {
+  mode: 'select';
+  query: Query;
+}
+
+export interface InsertDefaultValuesIR {
+  mode: 'default-values';
+}
+
+export type InsertSourceIR =
+  | InsertValuesIR
+  | InsertSelectIR
+  | InsertDefaultValuesIR;
+
+export interface InsertQueryIR<
+  Target extends WriteTargetIR = WriteTargetIR,
+  Columns extends readonly string[] = readonly string[],
+  Source extends InsertSourceIR = InsertSourceIR,
+  Output extends OutputIR<
+    'none' | 'returning' | 'output',
+    readonly ProjectionIR[]
+  > = OutputIR<
+    'none' | 'returning' | 'output',
+    readonly ProjectionIR[]
+  >,
+> {
+  kind: 'insert';
+  target: Target;
+  columns: Columns;
+  source: Source;
+  output: Output;
 }

--- a/src/language/ir/write.ts
+++ b/src/language/ir/write.ts
@@ -1,0 +1,26 @@
+import type { ProjectionIR } from './projection.js';
+
+export interface WriteTargetIR<
+  Name extends string = string,
+  Alias extends string = Name,
+> {
+  kind: 'write-target';
+  name: Name;
+  alias: Alias;
+}
+
+export interface AssignmentIR<
+  Target extends string = string,
+  ValueFragment extends string = string,
+> {
+  target: Target;
+  value: ValueFragment;
+}
+
+export interface OutputIR<
+  Mode extends 'none' | 'returning' | 'output' = 'none',
+  Projections extends readonly ProjectionIR[] = [],
+> {
+  mode: Mode;
+  projections: Projections;
+}

--- a/src/language/ir/write.ts
+++ b/src/language/ir/write.ts
@@ -24,3 +24,8 @@ export interface OutputIR<
   mode: Mode;
   projections: Projections;
 }
+
+export type MergeActionIR =
+  | { kind: 'update'; assignments: readonly AssignmentIR[] }
+  | { kind: 'insert'; columns: readonly string[]; values: readonly string[] }
+  | { kind: 'delete' };

--- a/src/string.ts
+++ b/src/string.ts
@@ -510,3 +510,30 @@ export type SplitAtTopLevelKeyword<
       ? { before: Trim<Accumulated>; after: '' }
       : never
     : never;
+
+export type TakeUntilTopLevelKeyword<
+  S extends string,
+  Keywords extends string,
+  Depth extends unknown[] = [],
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? Lowercase<Head> extends Lowercase<Keywords>
+      ? Trim<Accumulated>
+      : TakeUntilTopLevelKeyword<
+          Tail,
+          Keywords,
+          ApplyParenDelta<Depth, Head>,
+          Accumulated extends '' ? Head : `${Accumulated} ${Head}`
+        >
+    : TakeUntilTopLevelKeyword<
+        Tail,
+        Keywords,
+        ApplyParenDelta<Depth, Head>,
+        Accumulated extends '' ? Head : `${Accumulated} ${Head}`
+      >
+  : Depth extends []
+    ? Lowercase<S> extends Lowercase<Keywords>
+      ? Trim<Accumulated>
+      : Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>
+    : Trim<Accumulated extends '' ? S : `${Accumulated} ${S}`>;

--- a/src/string.ts
+++ b/src/string.ts
@@ -483,3 +483,30 @@ export type ApplyParenDelta<Depth extends unknown[], Token extends string> = Pop
   [...Depth, ...OpenCount<Token>],
   CloseCount<Token>
 >;
+
+export type SplitAtTopLevelKeyword<
+  S extends string,
+  Keyword extends string,
+  Depth extends unknown[] = [],
+  Accumulated extends string = '',
+> = S extends `${infer Head} ${infer Tail}`
+  ? Depth extends []
+    ? IsKeyword<Head, Keyword> extends true
+      ? { before: Trim<Accumulated>; after: Trim<Tail> }
+      : SplitAtTopLevelKeyword<
+          Tail,
+          Keyword,
+          ApplyParenDelta<Depth, Head>,
+          Accumulated extends '' ? Head : `${Accumulated} ${Head}`
+        >
+    : SplitAtTopLevelKeyword<
+        Tail,
+        Keyword,
+        ApplyParenDelta<Depth, Head>,
+        Accumulated extends '' ? Head : `${Accumulated} ${Head}`
+      >
+  : Depth extends []
+    ? IsKeyword<S, Keyword> extends true
+      ? { before: Trim<Accumulated>; after: '' }
+      : never
+    : never;

--- a/tests/architecture/dependencies.test.mjs
+++ b/tests/architecture/dependencies.test.mjs
@@ -26,4 +26,22 @@ describe('architecture dependencies', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('reports Next compiler imports from the Legacy compiler', () => {
+    const root = mkdtempSync(join(tmpdir(), 'owlsql-architecture-'));
+    mkdirSync(join(root, 'src', 'compiler', 'next'), { recursive: true });
+    writeFileSync(join(root, 'src', 'compiler', 'legacy.ts'), 'export type Legacy = string;\n');
+    writeFileSync(
+      join(root, 'src', 'compiler', 'next', 'invalid.ts'),
+      "import type { Legacy } from '../legacy.js';\n",
+    );
+
+    try {
+      expect(checkArchitecture(root)).toEqual([
+        'src/compiler/next/invalid.ts -> src/compiler/legacy.ts violates next compiler isolation',
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/next/delete-parity.test-d.ts
+++ b/tests/next/delete-parity.test-d.ts
@@ -1,0 +1,113 @@
+import type {
+  LegacyInferParams,
+  LegacyInferResult,
+  LegacyInferResultStrict,
+} from '../../src/compiler/legacy.js';
+import type {
+  NextDeleteInferParams,
+  NextDeleteQuery,
+  NextDeleteStrictQuery,
+} from '../../src/compiler/next/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+type DB = {
+  users: {
+    id: number;
+    name: string;
+  };
+  accounts: {
+    id: number;
+    user_id: number;
+    balance: number;
+  };
+  refunds: {
+    id: number;
+    account_id: number;
+  };
+};
+
+type Parity<Sql extends string> = Equal<
+  LegacyInferResult<DB, Sql>,
+  NextDeleteQuery<DB, Sql>
+>;
+
+type StrictParity<Sql extends string> = Equal<
+  LegacyInferResultStrict<DB, Sql>,
+  NextDeleteStrictQuery<DB, Sql>
+>;
+
+type ParamsParity<Sql extends string> = Equal<
+  LegacyInferParams<DB, Sql>,
+  NextDeleteInferParams<DB, Sql>
+>;
+
+type Simple = Expect<Parity<'delete from users where id = $1'>>;
+type NoPredicate = Expect<Parity<'delete from users'>>;
+type Returning = Expect<Parity<'delete from users where id = $1 returning id, name'>>;
+type Output = Expect<Parity<'delete from users output deleted.id where id = @id'>>;
+type Alias = Expect<StrictParity<
+  'delete from users as u where u.id = $1 returning u.name'
+>>;
+type BareAlias = Expect<StrictParity<
+  'delete from users u where u.id = $1 returning u.name'
+>>;
+type SchemaQualified = Expect<Parity<
+  'delete from public.users where id = $1 returning name'
+>>;
+type UnknownTarget = Expect<StrictParity<'delete from ghosts'>>;
+type UnknownWhere = Expect<StrictParity<
+  'delete from users where nope = $1'
+>>;
+type UnknownReturning = Expect<StrictParity<
+  'delete from users returning nope'
+>>;
+type DeleteUsing = Expect<StrictParity<
+  'delete from users using accounts where accounts.user_id = users.id and accounts.balance < 0 returning users.id'
+>>;
+type UnknownUsingAlias = Expect<StrictParity<
+  'delete from users using accounts where ghosts.id = users.id returning users.id'
+>>;
+type UsingJoin = Expect<StrictParity<
+  'delete from users using accounts a join refunds r on r.account_id = a.id where a.user_id = users.id returning users.id'
+>>;
+type UnknownJoinOn = Expect<StrictParity<
+  'delete from users using accounts a join refunds r on r.nope = a.id where a.user_id = users.id returning users.id'
+>>;
+type Params = Expect<ParamsParity<
+  'delete from users where id = $1 and name = $2'
+>>;
+type NamedParams = Expect<ParamsParity<
+  'delete from users where id = @id and name = @name'
+>>;
+type UsingParams = Expect<ParamsParity<
+  'delete from users using accounts where accounts.user_id = users.id and accounts.balance < $1'
+>>;
+type LooseUnknownColumn = Expect<Parity<
+  'delete from users where nope = $1 returning nope'
+>>;
+
+export type DeleteParityLock = [
+  Simple,
+  NoPredicate,
+  Returning,
+  Output,
+  Alias,
+  BareAlias,
+  SchemaQualified,
+  UnknownTarget,
+  UnknownWhere,
+  UnknownReturning,
+  DeleteUsing,
+  UnknownUsingAlias,
+  UsingJoin,
+  UnknownJoinOn,
+  Params,
+  NamedParams,
+  UsingParams,
+  LooseUnknownColumn,
+];

--- a/tests/next/insert-parity.test-d.ts
+++ b/tests/next/insert-parity.test-d.ts
@@ -1,0 +1,96 @@
+import type { ApplyLoosePolicy } from '../../src/compiler/contracts/compilation.js';
+import type { InferOutput } from '../../src/compiler/next/infer-output.js';
+import type {
+  ResolveWriteColumn,
+  ResolveWriteTarget,
+} from '../../src/compiler/next/resolve-write-target.js';
+import type { RootScope } from '../../src/compiler/next/scope.js';
+import type { ColumnProjectionIR } from '../../src/language/ir/projection.js';
+import type {
+  AssignmentIR,
+  OutputIR,
+  WriteTargetIR,
+} from '../../src/language/ir/write.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+type DB = {
+  users: {
+    id: number;
+    name: string;
+  };
+};
+
+type Target = WriteTargetIR<'users', 'u'>;
+type TargetSource = ResolveWriteTarget<DB, Target>;
+type TargetScope = TargetSource extends { kind: 'ok'; value: infer Source }
+  ? RootScope<[Source & { kind: 'table'; name: 'users'; alias: 'u'; join: 'root'; nullable: false; mergedColumns: [] }]>
+  : never;
+
+type TargetContract = Expect<
+  Equal<Target, { kind: 'write-target'; name: 'users'; alias: 'u' }>
+>;
+type InsertColumnsContract = Expect<
+  Equal<readonly ['id', 'name'] extends readonly string[] ? true : false, true>
+>;
+type AssignmentContract = Expect<
+  Equal<AssignmentIR<'name', '$1'>, { target: 'name'; value: '$1' }>
+>;
+type ReturningContract = Expect<
+  Equal<
+    OutputIR<'returning', [ColumnProjectionIR<null, 'id', 'id'>]>,
+    { mode: 'returning'; projections: [ColumnProjectionIR<null, 'id', 'id'>] }
+  >
+>;
+type OutputContract = Expect<
+  Equal<
+    OutputIR<'output', [ColumnProjectionIR<null, 'name', 'name'>]>,
+    { mode: 'output'; projections: [ColumnProjectionIR<null, 'name', 'name'>] }
+  >
+>;
+type NoOutputContract = Expect<Equal<OutputIR, { mode: 'none'; projections: [] }>>;
+type ResolveTargetContract = Expect<
+  Equal<TargetSource['kind'], 'ok'>
+>;
+type ResolveColumnContract = Expect<
+  Equal<ResolveWriteColumn<DB, Target, 'name'>, { kind: 'ok'; value: string }>
+>;
+type UnknownColumnContract = Expect<
+  Equal<ResolveWriteColumn<DB, Target, 'nope'>['kind'], 'error'>
+>;
+type ReturningInference = Expect<
+  Equal<
+    ApplyLoosePolicy<
+      InferOutput<
+        DB,
+        TargetScope,
+        OutputIR<'returning', [ColumnProjectionIR<null, 'id', 'id'>]>
+      >
+    >,
+    { id: number }[]
+  >
+>;
+type NoOutputInference = Expect<
+  Equal<
+    ApplyLoosePolicy<InferOutput<DB, TargetScope, OutputIR>>,
+    Record<string, never>[]
+  >
+>;
+
+export type InsertContractLock = [
+  TargetContract,
+  InsertColumnsContract,
+  AssignmentContract,
+  ReturningContract,
+  OutputContract,
+  NoOutputContract,
+  ResolveTargetContract,
+  ResolveColumnContract,
+  UnknownColumnContract,
+  ReturningInference,
+  NoOutputInference,
+];

--- a/tests/next/insert-parity.test-d.ts
+++ b/tests/next/insert-parity.test-d.ts
@@ -1,10 +1,20 @@
 import type { ApplyLoosePolicy } from '../../src/compiler/contracts/compilation.js';
+import type {
+  LegacyInferParams,
+  LegacyInferResult,
+  LegacyInferResultStrict,
+} from '../../src/compiler/legacy.js';
 import type { InferOutput } from '../../src/compiler/next/infer-output.js';
 import type {
   ResolveWriteColumn,
   ResolveWriteTarget,
 } from '../../src/compiler/next/resolve-write-target.js';
 import type { RootScope } from '../../src/compiler/next/scope.js';
+import type {
+  NextInsertInferParams,
+  NextInsertQuery,
+  NextInsertStrictQuery,
+} from '../../src/compiler/next/index.js';
 import type { ColumnProjectionIR } from '../../src/language/ir/projection.js';
 import type {
   AssignmentIR,
@@ -22,6 +32,7 @@ type DB = {
   users: {
     id: number;
     name: string;
+    email: string | null;
   };
 };
 
@@ -81,6 +92,109 @@ type NoOutputInference = Expect<
   >
 >;
 
+type InsertParity<Sql extends string> = Equal<
+  LegacyInferResult<DB, Sql>,
+  NextInsertQuery<DB, Sql>
+>;
+
+type StrictInsertParity<Sql extends string> = Equal<
+  LegacyInferResultStrict<DB, Sql>,
+  NextInsertStrictQuery<DB, Sql>
+>;
+
+type InsertParamsParity<Sql extends string> = Equal<
+  LegacyInferParams<DB, Sql>,
+  NextInsertInferParams<DB, Sql>
+>;
+
+type ValuesReturning = Expect<InsertParity<
+  'insert into users (name) values ($1) returning id, name'
+>>;
+type ValuesWithoutOutput = Expect<InsertParity<
+  'insert into users (name) values ($1)'
+>>;
+type OutputBeforeValues = Expect<InsertParity<
+  'insert into users (name) output inserted.id values (@name)'
+>>;
+type GluedColumns = Expect<StrictInsertParity<
+  'insert into users(id, name) values ($1, $2) returning id'
+>>;
+type TargetAlias = Expect<StrictInsertParity<
+  'insert into users as u (name) values ($1) returning u.id'
+>>;
+type SchemaQualifiedTarget = Expect<InsertParity<
+  'insert into public.users (name) values ($1) returning id'
+>>;
+type QuotedTarget = Expect<InsertParity<
+  'insert into "public"."users" (name) values ($1) returning id'
+>>;
+type UnknownTarget = Expect<StrictInsertParity<
+  'insert into ghosts (name) values ($1)'
+>>;
+type UnknownColumn = Expect<StrictInsertParity<
+  'insert into users (naem) values ($1)'
+>>;
+type UnknownLaterColumn = Expect<StrictInsertParity<
+  'insert into users (id, name, nope) values ($1, $2, $3)'
+>>;
+type InsertSelect = Expect<StrictInsertParity<
+  'insert into users (name) select name from users'
+>>;
+type InsertSelectUnknownColumn = Expect<StrictInsertParity<
+  'insert into users (name) select nope from users'
+>>;
+type InsertSelectUnknownTable = Expect<StrictInsertParity<
+  'insert into users (name) select name from ghosts'
+>>;
+type InsertSelectUnknownPredicate = Expect<StrictInsertParity<
+  'insert into users (name) select name from users where nope = 1'
+>>;
+type PositionalParams = Expect<InsertParamsParity<
+  'insert into users (id, name) values (?, ?)'
+>>;
+type MultipleRows = Expect<InsertParamsParity<
+  'insert into users (id, name) values ($1, $2), ($3, $4)'
+>>;
+type MixedLiterals = Expect<InsertParamsParity<
+  "insert into users (id, name) values (1, $1), (2, $2)"
+>>;
+type CallParams = Expect<InsertParamsParity<
+  'insert into users (id, name) values (coalesce($1, 0), lower($2))'
+>>;
+type ConflictParams = Expect<InsertParamsParity<
+  'insert into users (name) values ($1) on conflict (name) do update set name = $2'
+>>;
+type InsertSelectParams = Expect<InsertParamsParity<
+  'insert into users (id, name) select id, name from users where id = $1'
+>>;
+type NullableParams = Expect<InsertParamsParity<
+  'insert into users (name, email) values ($1, $2)'
+>>;
+type NamedCallParams = Expect<InsertParamsParity<
+  'insert into users (id, name) values (coalesce(@id, 0), @name)'
+>>;
+type NestedCallParams = Expect<InsertParamsParity<
+  'insert into users (id, name) values ($1, coalesce(lower(@name), $$x$$))'
+>>;
+type NoColumnListParams = Expect<InsertParamsParity<
+  'insert into users values ($1, $2, $3)'
+>>;
+type DefaultValues = Expect<InsertParity<
+  'insert into users default values returning id'
+>>;
+type InsertSelectReturning = Expect<StrictInsertParity<
+  'insert into users (id, name) select id, name from users returning id'
+>>;
+type UnknownReturningColumn = Expect<StrictInsertParity<
+  'insert into users (name) values ($1) returning nope'
+>>;
+type LooseUnknownColumn = Expect<InsertParity<
+  'insert into users (nope) values ($1)'
+>>;
+type UppercaseInsert = Expect<InsertParity<
+  'INSERT INTO users (name) VALUES ($1) RETURNING id'
+>>;
+
 export type InsertContractLock = [
   TargetContract,
   InsertColumnsContract,
@@ -93,4 +207,33 @@ export type InsertContractLock = [
   UnknownColumnContract,
   ReturningInference,
   NoOutputInference,
+  ValuesReturning,
+  ValuesWithoutOutput,
+  OutputBeforeValues,
+  GluedColumns,
+  TargetAlias,
+  SchemaQualifiedTarget,
+  QuotedTarget,
+  UnknownTarget,
+  UnknownColumn,
+  UnknownLaterColumn,
+  InsertSelect,
+  InsertSelectUnknownColumn,
+  InsertSelectUnknownTable,
+  InsertSelectUnknownPredicate,
+  PositionalParams,
+  MultipleRows,
+  MixedLiterals,
+  CallParams,
+  ConflictParams,
+  InsertSelectParams,
+  NullableParams,
+  NamedCallParams,
+  NestedCallParams,
+  NoColumnListParams,
+  DefaultValues,
+  InsertSelectReturning,
+  UnknownReturningColumn,
+  LooseUnknownColumn,
+  UppercaseInsert,
 ];

--- a/tests/next/merge-parity.test-d.ts
+++ b/tests/next/merge-parity.test-d.ts
@@ -1,0 +1,93 @@
+import type {
+  LegacyInferParams,
+  LegacyInferResult,
+  LegacyInferResultStrict,
+} from '../../src/compiler/legacy.js';
+import type {
+  NextMergeInferParams,
+  NextMergeQuery,
+  NextMergeStrictQuery,
+} from '../../src/compiler/next/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+type DB = {
+  users: {
+    id: number;
+    name: string;
+    email: string;
+  };
+};
+
+type Parity<Sql extends string> = Equal<
+  LegacyInferResult<DB, Sql>,
+  NextMergeQuery<DB, Sql>
+>;
+
+type StrictParity<Sql extends string> = Equal<
+  LegacyInferResultStrict<DB, Sql>,
+  NextMergeStrictQuery<DB, Sql>
+>;
+
+type ParamsParity<Sql extends string> = Equal<
+  LegacyInferParams<DB, Sql>,
+  NextMergeInferParams<DB, Sql>
+>;
+
+type FullMerge =
+  'merge into users as target using (values (@id, @name)) as source (id, name) on target.id = source.id when matched then update set target.name = source.name when not matched then insert (id, name) values (source.id, source.name) output inserted.id, inserted.name';
+
+type ActionMerge =
+  'merge into users as target using (values (@id, @name)) as source (id, name) on target.id = source.id when matched then update set target.name = source.name output $action, inserted.id';
+
+type NoAliasMerge =
+  'merge into users using (values (@id)) as source (id) on users.id = source.id when not matched then insert (id) values (source.id) output inserted.id';
+
+type NoOutputMerge =
+  'merge into users as target using (values (@id, @name)) as source (id, name) on target.id = source.id when matched then update set target.name = source.name';
+
+type Output = Expect<Parity<FullMerge>>;
+type ActionOutput = Expect<Parity<ActionMerge>>;
+type ActionParams = Expect<ParamsParity<ActionMerge>>;
+type WithoutAlias = Expect<Parity<NoAliasMerge>>;
+type WithoutOutput = Expect<Parity<NoOutputMerge>>;
+type UnknownOutput = Expect<StrictParity<
+  'merge into users as target using (values (@id)) as source (id) on target.id = source.id when not matched then insert (id) values (source.id) output inserted.bogus'
+>>;
+type UnknownTarget = Expect<StrictParity<
+  'merge into ghosts as target using (values (@id)) as source (id) on target.id = source.id when not matched then insert (id) values (source.id) output inserted.id'
+>>;
+type Uppercase = Expect<Parity<
+  'MERGE INTO users AS target USING (values (@id, @name)) AS source (id, name) ON target.id = source.id WHEN MATCHED THEN UPDATE SET target.name = source.name OUTPUT inserted.id'
+>>;
+type UnknownActionColumn = Expect<StrictParity<
+  'merge into users as target using (values (@id)) as source (id) on target.id = source.id when matched then update set target.nope = source.id output inserted.id'
+>>;
+type InsertActionColumn = Expect<StrictParity<
+  'merge into users as target using (values (@id)) as source (id) on target.id = source.id when not matched then insert (nope) values (source.id) output inserted.id'
+>>;
+type ActionPlaceholder = Expect<ParamsParity<
+  'merge into users as target using (values (@id)) as source (id) on target.id = source.id when matched then update set target.name = @name output inserted.id'
+>>;
+type InsertPlaceholder = Expect<ParamsParity<
+  'merge into users as target using (values (@source_id)) as source (id) on target.id = source.id when not matched then insert (id, name) values (@id, @name) output inserted.id'
+>>;
+
+export type MergeParityLock = [
+  Output,
+  ActionOutput,
+  ActionParams,
+  WithoutAlias,
+  WithoutOutput,
+  UnknownOutput,
+  UnknownTarget,
+  Uppercase,
+  UnknownActionColumn,
+  InsertActionColumn,
+  ActionPlaceholder,
+  InsertPlaceholder,
+];

--- a/tests/next/update-parity.test-d.ts
+++ b/tests/next/update-parity.test-d.ts
@@ -1,0 +1,134 @@
+import type {
+  LegacyInferParams,
+  LegacyInferResult,
+  LegacyInferResultStrict,
+} from '../../src/compiler/legacy.js';
+import type {
+  NextUpdateInferParams,
+  NextUpdateQuery,
+  NextUpdateStrictQuery,
+} from '../../src/compiler/next/index.js';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Expect<T extends true> = T;
+
+type DB = {
+  users: {
+    id: number;
+    name: string;
+    email: string | null;
+  };
+  accounts: {
+    id: number;
+    user_id: number;
+    balance: number;
+  };
+  refunds: {
+    id: number;
+    account_id: number;
+  };
+};
+
+type Parity<Sql extends string> = Equal<
+  LegacyInferResult<DB, Sql>,
+  NextUpdateQuery<DB, Sql>
+>;
+
+type StrictParity<Sql extends string> = Equal<
+  LegacyInferResultStrict<DB, Sql>,
+  NextUpdateStrictQuery<DB, Sql>
+>;
+
+type ParamsParity<Sql extends string> = Equal<
+  LegacyInferParams<DB, Sql>,
+  NextUpdateInferParams<DB, Sql>
+>;
+
+type Simple = Expect<Parity<'update users set name = $1 where id = $2'>>;
+type Returning = Expect<Parity<'update users set name = $1 returning id, name'>>;
+type ReturningStar = Expect<Parity<'update users set name = $1 returning *'>>;
+type Output = Expect<Parity<'update users set name = @name output inserted.id where id = @id'>>;
+type OutputBeforeFrom = Expect<StrictParity<
+  'update users set name = @name output inserted.id from accounts where accounts.user_id = users.id'
+>>;
+type Alias = Expect<StrictParity<
+  'update users as u set name = $1 where u.id = $2 returning u.id'
+>>;
+type BareAlias = Expect<StrictParity<
+  'update users u set name = $1 where u.id = $2 returning u.id'
+>>;
+type SchemaQualified = Expect<Parity<
+  'update public.users set name = $1 where id = $2 returning id'
+>>;
+type UnknownTarget = Expect<StrictParity<'update ghosts set name = $1'>>;
+type UnknownAssignment = Expect<StrictParity<
+  'update users set naem = $1 where id = 1'
+>>;
+type UnknownLaterAssignment = Expect<StrictParity<
+  'update users set name = $1, naem = $2 where id = 1'
+>>;
+type UnknownWhere = Expect<StrictParity<
+  'update users set name = $1 where nope = $2'
+>>;
+type UnknownReturning = Expect<StrictParity<
+  'update users set name = $1 returning nope'
+>>;
+type UpdateFrom = Expect<StrictParity<
+  'update users set name = name from accounts where accounts.user_id = users.id returning users.id'
+>>;
+type UnknownFromAlias = Expect<StrictParity<
+  'update users set name = name from accounts where ghosts.id = users.id returning users.id'
+>>;
+type JoinOn = Expect<StrictParity<
+  'update users set name = name from accounts a join refunds r on r.account_id = a.id where a.user_id = users.id returning users.id'
+>>;
+type UnknownJoinOn = Expect<StrictParity<
+  'update users set name = name from accounts a join refunds r on r.nope = a.id where a.user_id = users.id returning users.id'
+>>;
+type ScalarAssignment = Expect<StrictParity<
+  'update users set name = (select name from users where id = 1) where id = 2'
+>>;
+type ScalarAssignmentTypo = Expect<StrictParity<
+  'update users set name = (select nope from users where id = 1) where id = 2'
+>>;
+type AssignmentParams = Expect<ParamsParity<
+  'update users set name = $1, email = $2 where id = $3'
+>>;
+type NamedParams = Expect<ParamsParity<
+  'update users set name = @name where id = @id'
+>>;
+type FromParams = Expect<ParamsParity<
+  'update users set name = $1 from accounts where accounts.user_id = users.id and accounts.balance > $2'
+>>;
+type LooseUnknownAssignment = Expect<Parity<
+  'update users set nope = $1'
+>>;
+
+export type UpdateParityLock = [
+  Simple,
+  Returning,
+  ReturningStar,
+  Output,
+  OutputBeforeFrom,
+  Alias,
+  BareAlias,
+  SchemaQualified,
+  UnknownTarget,
+  UnknownAssignment,
+  UnknownLaterAssignment,
+  UnknownWhere,
+  UnknownReturning,
+  UpdateFrom,
+  UnknownFromAlias,
+  JoinOn,
+  UnknownJoinOn,
+  ScalarAssignment,
+  ScalarAssignmentTypo,
+  AssignmentParams,
+  NamedParams,
+  FromParams,
+  LooseUnknownAssignment,
+];

--- a/tests/perf/baseline.json
+++ b/tests/perf/baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 236778
+  "instantiations": 239943
 }

--- a/tests/perf/baseline.json
+++ b/tests/perf/baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 225590
+  "instantiations": 231605
 }

--- a/tests/perf/baseline.json
+++ b/tests/perf/baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 231605
+  "instantiations": 236778
 }

--- a/tests/perf/baseline.json
+++ b/tests/perf/baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 239943
+  "instantiations": 244919
 }

--- a/tests/perf/select-next-baseline.json
+++ b/tests/perf/select-next-baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 43560
+  "instantiations": 48770
 }

--- a/tests/perf/select-next-baseline.json
+++ b/tests/perf/select-next-baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 51922
+  "instantiations": 56847
 }

--- a/tests/perf/select-next-baseline.json
+++ b/tests/perf/select-next-baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 37521
+  "instantiations": 43560
 }

--- a/tests/perf/select-next-baseline.json
+++ b/tests/perf/select-next-baseline.json
@@ -1,4 +1,4 @@
 {
   "typescript": "5.9.3",
-  "instantiations": 48770
+  "instantiations": 51922
 }

--- a/ts-plugin/tests/diagnostics.test.ts
+++ b/ts-plugin/tests/diagnostics.test.ts
@@ -54,9 +54,15 @@ describe('ts-plugin diagnostics: getQueryDiagnostics', () => {
 
   // Regression for #250: `select id from USERS` compiles to { id: number }[],
   // so a warning on it is a false positive the user cannot act on.
-  it('accepts a table and a column written in a different case', () => {
+  it('accepts a table written in a different case', () => {
     expect(diagnosticsFor('select id from USERS')).toEqual([]);
+  });
+
+  it('accepts keywords and a column written in a different case', () => {
     expect(diagnosticsFor('SELECT ID FROM users')).toEqual([]);
+  });
+
+  it('accepts a predicate column written in a different case', () => {
     expect(diagnosticsFor('select id from users where NAME = $1')).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

- add shared DML compiler contracts
- migrate INSERT, UPDATE, DELETE, and MERGE independently to Next
- remove the remaining Next DML dependencies on Legacy internals

## Verification

- `npm test`: 218 passed, 36 skipped
- architecture fitness checks passed
- `npm run test:perf`: 244,919 instantiations, matching baseline and below the 250,000 budget
- `npm run test:package` passed

## Stack

Depends on #361.
