### PR TITLE
v1.0.0 chore: set core release version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2536,7 +2536,7 @@
     },
     "packages/core": {
       "name": "@owlsql/core",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "MIT",
       "bin": {
         "owlsql": "dist/cli/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@owlsql/core",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Parse SQL in TypeScript template literal types and infer the result shape from your schema — no codegen, no ORM.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- set `@owlsql/core` release version to `1.0.0`
- keep `@owlsql/ts-plugin` independently versioned at `0.1.0`
- synchronize the workspace lockfile
- leave changelog finalization and publication to their dedicated follow-up steps

## Verification

- `npm test`: 225 passed
- architecture fitness checks passed
- `npm run test:perf`: 134,857 instantiations against the 150,000 ceiling; Next delta +22 (+0.04%)
- `npm run test:package` passed
- `npm audit`: 0 vulnerabilities

## Scope

Release metadata only. No runtime, compiler, plugin, or public API behavior changed.

The Release workflow must not be dispatched until the remaining release-readiness steps are complete.
