### PR TITLE
v1.0.0 docs: finalize release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-20
+
 ### Architecture
 
 - Removed runtime statement parsing from the `node:sqlite` adapter. Driver column metadata now selects the row path, older `node:sqlite` versions fall back to `all()` without write metadata, and SQLite counters provide write metadata without interpreting user SQL.
@@ -13,6 +15,7 @@ Notable changes to this project, following [Keep a Changelog](https://keepachang
 
 ### Changed
 
+- Published `@owlsql/core` and `@owlsql/ts-plugin` packages now include their MIT `LICENSE` file.
 - **Breaking (pre-v1):** removed the accidental advanced exports `ParseSelect`, `ParseStatement`, `ParsedStatement`, `Source`, and `FunctionReturnTypes`. They exposed the retired parser and compiler internals and have no supported replacement. Use `Query`, `Row`, `StrictQuery`, `StrictRow`, and `Params` for the public type-inference contract.
 - The reviewed v1 type-instantiation baseline is 135,217, down from 244,919 after the Legacy compiler and accidental parser exports were removed. The public hard ceiling is reduced from 250,000 to 150,000; eight isolated stress cases add a 10% relative gate and a 200,000 absolute ceiling.
 


### PR DESCRIPTION
## Summary

- promote the existing `[Unreleased]` notes to `1.0.0`, dated 2026-08-20
- leave a new empty `[Unreleased]` section for subsequent work
- document that published core and plugin packages include their MIT license

## Verification

- `npm test`: 225 passed
- architecture fitness checks passed
- `npm run test:perf`: 134,857 instantiations against the 150,000 ceiling; Next delta +22 (+0.04%)
- `npm run test:package` passed
- package dry runs confirmed `LICENSE` in both workspace tarballs
- `npm audit`: 0 vulnerabilities
- no existing `v1.0.0` tag, GitHub Release, or npm version collision

## Review

- test coverage: 100% of 0 new executable paths; no tests needed
- plan completion: 1/1 item complete
- pre-landing and adversarial reviews: no remaining findings

## Scope

Documentation only. No runtime, compiler, package version, plugin version, or public API behavior changed.

Do not dispatch the Release workflow until the remaining release-readiness steps are complete.
