### PR TITLE
v1.0.0 ci: stage npm release for 2FA approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: Git ref tested by every CI job
+        required: false
+        type: string
+        default: ''
   push:
     branches: [master]
   pull_request:
@@ -19,6 +25,8 @@ jobs:
         typescript: ['5.4', '5.6', '6.0']
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
       - uses: actions/setup-node@v7
         with:
           node-version: 22
@@ -36,6 +44,8 @@ jobs:
         node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
@@ -52,6 +62,8 @@ jobs:
         typescript: ['5.4', '5.6', '6.0']
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
       - uses: actions/setup-node@v7
         with:
           node-version: 22
@@ -65,6 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
       - uses: actions/setup-node@v7
         with:
           node-version: 22
@@ -78,6 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
       - uses: actions/setup-node@v7
         with:
           node-version: 22
@@ -90,6 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
       - uses: actions/setup-node@v7
         with:
           node-version: 22
@@ -102,6 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
       - uses: actions/setup-node@v7
         with:
           node-version: 22
@@ -156,6 +176,8 @@ jobs:
       OWLSQL_MSSQL_URL: mssql://sa:Owlsql_Passw0rd@127.0.0.1:1434/master?encrypt=false&trustServerCertificate=true
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
       - uses: actions/setup-node@v7
         with:
           node-version: 22

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,47 +1,67 @@
 name: Release
 
-# Publishes @owlsql/core to npm without a token: the OIDC identity of this
+# Stages @owlsql/core on npm without a token: the OIDC identity of this
 # workflow is what the registry trusts, configured once on npmjs.com under the
 # package's "Trusted publisher" settings. That is also what makes a token
 # unnecessary here - npm is restricting 2FA-bypassing tokens for direct
-# publishing, and there is no secret in this repository to leak.
+# publishing, and there is no secret in this repository to leak. A maintainer
+# reviews and approves the staged package with 2FA before it becomes public.
 #
-# Run it from the Actions tab (or let a published GitHub Release trigger it)
-# once the version bump is on master. `npm publish` runs prepublishOnly, so
-# the type tests, the runtime tests and the build all have to pass first.
+# Run it from master with the version tag as input once the version bump is on
+# master. `npm stage publish` runs prepublishOnly, so the type tests, the runtime
+# tests and the build all have to pass first.
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Tag matching the package version, for example v1.0.0
+        required: true
+        type: string
 
 permissions:
   contents: read
-  # Required for trusted publishing: the job mints a short-lived OIDC token
-  # that npm verifies against the publisher configured for the package.
-  id-token: write
 
 jobs:
   v1-gate:
     uses: ./.github/workflows/ci.yml
+    with:
+      checkout_ref: refs/tags/${{ inputs.release_tag }}
 
   publish:
-    name: Publish to npm
+    name: Stage on npm
     needs: v1-gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for trusted publishing: the job mints a short-lived OIDC token
+      # that npm verifies against the publisher configured for the package.
+      id-token: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: refs/tags/${{ inputs.release_tag }}
       - uses: actions/setup-node@v7
         with:
           node-version: 22
           package-manager-cache: false
           registry-url: https://registry.npmjs.org
 
-      # Trusted publishing needs npm 11.5.1 or newer; Node 22 still ships an
-      # older npm, so the runner's npm is upgraded rather than the toolchain.
-      - run: npm install -g npm@latest
+      - name: Verify release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          expected_tag="v$(node -p "require('./packages/core/package.json').version")"
+          if [[ "${RELEASE_TAG}" != "${expected_tag}" ]]; then
+            echo "::error::Expected tag ${expected_tag}; got ${RELEASE_TAG}."
+            exit 1
+          fi
+
+      # Staged publishing needs npm 11.15.0 or newer.
+      - run: npm install -g npm@12.0.2
 
       - run: npm ci
 
-      - run: npm publish --loglevel verbose
+      - run: npm stage publish --loglevel verbose
         working-directory: packages/core

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,16 +123,16 @@ hide a regression.
 
 Both packages ship compiled JavaScript and declarations from their own `dist/`, wired into `prepublishOnly`.
 
-The library is published by the [Release workflow](.github/workflows/release.yml) rather than from a laptop, using npm's trusted publishing: the workflow's OIDC identity is what the registry trusts, so there is no npm token in this repository to leak or rotate. npm is restricting tokens that bypass 2FA for direct publishing, which is the other half of the reason.
+The library is staged by the [Release workflow](.github/workflows/release.yml) rather than published from a laptop, using npm's trusted publishing: the workflow's OIDC identity is what the registry trusts, so there is no npm token in this repository to leak or rotate. A maintainer reviews the staged package and approves it with 2FA before it becomes public.
 
 ```bash
 npm version <patch|minor|major>
 git push --follow-tags origin master
 ```
 
-Then run **Actions → Release → Run workflow**, or publish a GitHub Release for the tag — either triggers it. The release calls the same reusable CI workflow used by pushes and pull requests before publishing, including the TypeScript and Node matrices, plugin, architecture, package, performance, and real-database integration gates. `prepublishOnly` repeats the core type, runtime, architecture, and build checks immediately before npm receives the package.
+Then run `gh workflow run Release --ref master -f release_tag=<tag>`. The workflow itself comes from `master`, checks out only `refs/tags/<tag>`, and rejects tags that do not match `v${package.version}`. It calls the same reusable CI workflow used by pushes and pull requests before staging, including the TypeScript and Node matrices, plugin, architecture, package, performance, and real-database integration gates. `prepublishOnly` repeats the core type, runtime, architecture, and build checks immediately before npm receives the package. After the workflow succeeds, review the package under npm's **Staged Packages** tab and approve it with 2FA. Publish the GitHub Release only after npm makes the package public.
 
-This needs the package's *Trusted publisher* to be configured once on npmjs.com (package → Settings → Trusted publisher → GitHub Actions, repository `tiagolauer/OwlSQL`, workflow `release.yml`).
+This needs the package's *Trusted publisher* to be configured once on npmjs.com (package → Settings → Trusted publisher → GitHub Actions, repository `tiagolauer/OwlSQL`, workflow `release.yml`) with `npm stage publish` allowed and direct `npm publish` disabled. Staged-package approval must require 2FA.
 
 Publishing by hand still works if you own the package and pass a real one-time password, which npm now requires for a direct publish:
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -6,6 +6,8 @@ import ts from 'typescript';
 const SOURCE_EXTENSIONS = ['.ts', '.cts', '.mts'];
 const SOURCE_DIRECTORIES = ['packages/core/src', 'packages/ts-plugin/src'];
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CI_WORKFLOW = '.github/workflows/ci.yml';
+const RELEASE_WORKFLOW = '.github/workflows/release.yml';
 
 const LAYERS = [
   { name: 'facade', prefix: 'packages/core/src/index.ts' },
@@ -158,6 +160,26 @@ export function checkArchitecture(root) {
       if (target.startsWith('packages/core/src/') || target.startsWith('packages/ts-plugin/src/')) {
         violations.push(`${sourceFile} -> ${target} violates ${sourceLayer} isolation`);
       }
+    }
+  }
+
+  const ciWorkflowPath = join(root, CI_WORKFLOW);
+  if (existsSync(ciWorkflowPath)) {
+    const ciWorkflow = readFileSync(ciWorkflowPath, 'utf8');
+    const releaseWorkflow = readFileSync(join(root, RELEASE_WORKFLOW), 'utf8');
+    const checkoutSteps = ciWorkflow.match(/^\s*- uses: actions\/checkout@v7\s*$/gm) ?? [];
+    const configuredCheckouts = ciWorkflow.match(
+      /^\s*- uses: actions\/checkout@v7\s*\r?\n\s+with:\s*\r?\n\s+ref: \$\{\{ inputs\.checkout_ref \|\| github\.ref \}\}\s*$/gm,
+    ) ?? [];
+
+    if (!/^\s{6}checkout_ref:\s*$/m.test(ciWorkflow)) {
+      violations.push(`${CI_WORKFLOW} must declare the reusable checkout_ref input`);
+    }
+    if (configuredCheckouts.length !== checkoutSteps.length) {
+      violations.push(`${CI_WORKFLOW} must route checkout_ref through every checkout step`);
+    }
+    if (!/^\s+checkout_ref: refs\/tags\/\$\{\{ inputs\.release_tag \}\}\s*$/m.test(releaseWorkflow)) {
+      violations.push(`${RELEASE_WORKFLOW} must pass release_tag to reusable CI`);
     }
   }
 


### PR DESCRIPTION
## Summary

- replace direct npm publication with staged publishing and 2FA approval
- validate the exact release tag across every CI job and the staged package
- scope OIDC permission to the staging job and pin the npm release client
- document the staged release sequence and Trusted Publisher permissions

## Root cause

Release run `32421461186` exchanged the GitHub OIDC token successfully and signed provenance, but npm rejected the final direct publish request with `E403`. The staged flow keeps trusted publishing while moving the final registry publication behind an explicit maintainer review with 2FA.

## Verification

- `npm test`
- `npm run test:package`
- `npm test --workspace @owlsql/ts-plugin`
- `npm run test:architecture`
- `npx vitest run packages/core/tests/architecture/dependencies.test.mjs`
- workflow YAML parse and release-tag guard checks
- `git diff --check`

## Post-merge validation

- allow only `npm stage publish` for the npm Trusted Publisher
- run `gh workflow run Release --ref master -f release_tag=v1.0.0`
- inspect the package under npm Staged Packages
- approve it with 2FA
- verify `@owlsql/core@1.0.0` and its provenance from a clean install
